### PR TITLE
Handle notification icons that come from syncing

### DIFF
--- a/qml/NotificationPreview.qml
+++ b/qml/NotificationPreview.qml
@@ -62,11 +62,21 @@ Item {
                 var notif = notificationPreviewPresenter.notification;
                 if(notif==null)
                     return "";
-                else if(notif.icon == "")
-                    return "ios-mail-outline";
-                else
-                    return notif.icon;
+
+                function noicon(str) {
+                    return str === "" || str === null || str === undefined;
                 }
+                // icon for asteroid internal, appIcon for notifications from android
+                if(noicon(notif.icon) && noicon(notif.appIcon))
+                    return "ios-mail-outline";
+                if(noicon(notif.icon) && !noicon(notif.appIcon))
+                    return notif.appIcon;
+                if(!noicon(notif.icon) && noicon(notif.appIcon))
+                    return notif.icon;
+
+                // prefer asteroid internal
+                return notif.icon;
+            }
         }
 
         Text {


### PR DESCRIPTION
On my setup the icons from e.g. usb cable connection events seem to come in `notification.icon`, but the ones from the Android sync clients come in `notification.appIcon`. This code handles both.