### PR TITLE
fix dropshadows in analog watchface

### DIFF
--- a/watchfaces/001-analog.qml
+++ b/watchfaces/001-analog.qml
@@ -41,10 +41,10 @@ Item {
 
     Canvas {
         anchors.fill: parent
-        rotation: wallClock.time.getHours() * 30 + wallClock.time.getMinutes() * 0.5
         smooth: true
         onPaint: {
             var ctx = getContext("2d")
+            var rot = (wallClock.time.getHours() - 3 + wallClock.time.getMinutes()/60) / 12
             ctx.lineWidth = 3
             ctx.strokeStyle = "white"
             ctx.shadowColor = "#80000000"
@@ -53,7 +53,8 @@ Item {
             ctx.shadowBlur = 3
             ctx.beginPath()
             ctx.moveTo(parent.width/2, parent.height/2)
-            ctx.lineTo(width/2, height*0.3)
+            ctx.lineTo(parent.width/2+Math.cos(rot * 2 * Math.PI)*width*0.2,
+                       parent.height/2+Math.sin(rot * 2 * Math.PI)*width*0.2)
             ctx.closePath()
             ctx.stroke()
         }
@@ -61,10 +62,10 @@ Item {
 
     Canvas {
         anchors.fill: parent
-        rotation: wallClock.time.getMinutes() * 6
         smooth: true
         onPaint: {
             var ctx = getContext("2d")
+            var rot = (wallClock.time.getMinutes() - 15)/60
             ctx.lineWidth = 3
             ctx.strokeStyle = "white"
             ctx.shadowColor = "#80000000"
@@ -73,7 +74,8 @@ Item {
             ctx.shadowBlur = 3
             ctx.beginPath()
             ctx.moveTo(parent.width/2, parent.height/2)
-            ctx.lineTo(width/2, height*0.1)
+            ctx.lineTo(parent.width/2+Math.cos(rot * 2 * Math.PI)*width*0.4,
+                       parent.height/2+Math.sin(rot * 2 * Math.PI)*width*0.4)
             ctx.closePath()
             ctx.stroke()
         }


### PR DESCRIPTION
Instead of rotating the hands and their dropshadow from 12 o'clock position, this patch causes the hands to be drawn directly with their right angle.