### PR TITLE
compositor: Close current active window when another window is opened.

### DIFF
--- a/qml/compositor/compositor.qml
+++ b/qml/compositor/compositor.qml
@@ -221,6 +221,9 @@ Item {
                 comp.homeWindow = w
                 setCurrentWindow(homeWindow)
             } else if (!isNotificationWindow && !isAgentWindow && !isDialogWindow) {
+                if (topmostApplicationWindow != null) {
+                    Lipstick.compositor.closeClientForWindowId(topmostApplicationWindow.window.windowId)
+                }
                 w.smoothBorders = true
                 w.x = width
                 w.moveInAnim.start()


### PR DESCRIPTION
Only one active app window is allowed.
Adding a new window forces the current window to vanish to the background.
Make sure that this window is stopped.

This fixes https://github.com/AsteroidOS/asteroid-launcher/issues/37