### PR TITLE
Add support for ambient mode.

### DIFF
--- a/qml/compositor/compositor.qml
+++ b/qml/compositor/compositor.qml
@@ -145,7 +145,10 @@ Item {
         id: delayTimer
         interval: 5000
         repeat: false
-        onTriggered: Lipstick.compositor.closeClientForWindowId(comp.topmostWindow.window.windowId)
+        onTriggered: {
+            Lipstick.compositor.closeClientForWindowId(comp.topmostWindow.window.windowId)
+            Lipstick.compositor.setAmbientUpdatesEnabled(true)
+        }
     }
 
     Compositor {

--- a/qml/notifications/NotificationIndicator.qml
+++ b/qml/notifications/NotificationIndicator.qml
@@ -128,7 +128,7 @@ Item {
         target: panelsGrid
 
         function makeVisible() {
-            if(panelsGrid.currentVerticalPos == 0 && panelsGrid.currentHorizontalPos < 0) {
+            if((panelsGrid.currentVerticalPos == 0 && panelsGrid.currentHorizontalPos < 0) && !Lipstick.compositor.displayAmbient) {
                 notifIndic.visible = true
                 moveTo(panelsGrid.currentHorizontalPos+1)
             } else

--- a/qml/quicksettings/QuickSettings.qml
+++ b/qml/quicksettings/QuickSettings.qml
@@ -74,7 +74,7 @@ Item {
         icon: "ios-unlock"
         togglable: false
         toggled: false
-        onUnchecked: mce_dbus.call("req_display_state_off", undefined)
+        onUnchecked: mce_dbus.call("req_display_state_lpm", undefined)
     }
 
     DisplaySettings {

--- a/watchfaces/000-default-digital.qml
+++ b/watchfaces/000-default-digital.qml
@@ -164,5 +164,8 @@ Item {
         dateCanvas.requestPaint()
         amPmCanvas.am = am
         amPmCanvas.requestPaint()
+
+        burnInProtectionManager.widthOffset = Qt.binding(function() { return width*0.32})
+        burnInProtectionManager.heightOffset = Qt.binding(function() { return height*0.7})
     }
 }

--- a/watchfaces/001-words-worte-palabras-mots.qml
+++ b/watchfaces/001-words-worte-palabras-mots.qml
@@ -184,4 +184,11 @@ Item {
             dateDisplay.text = Qt.binding(function() { return wallClock.time.toLocaleString(Qt.locale(), "<b>ddd</b> d MMM") })
         }
     }
+
+    Component.onCompleted: {
+        burnInProtectionManager.leftOffset = Qt.binding(function() { return width*0.05})
+        burnInProtectionManager.rightOffset = Qt.binding(function() { return width*0.05})
+        burnInProtectionManager.topOffset = Qt.binding(function() { return height*0.4})
+        burnInProtectionManager.bottomOffset = Qt.binding(function() { return height*0.05})
+    }
 }

--- a/watchfaces/002-analog-70s-classic.qml
+++ b/watchfaces/002-analog-70s-classic.qml
@@ -185,6 +185,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()

--- a/watchfaces/003-alternative-digital-2.qml
+++ b/watchfaces/003-alternative-digital-2.qml
@@ -160,7 +160,7 @@ Item {
         antialiasing: true
         smooth: true
         renderStrategy: Canvas.Threaded
-        visible: !use12H.value
+        visible: !use12H.value && !displayAmbient
 
         property var second: 0
 
@@ -233,6 +233,9 @@ Item {
         monthCanvas.requestPaint()
         amPmCanvas.am = am
         amPmCanvas.requestPaint()
+
+        burnInProtectionManager.widthOffset = Qt.binding(function() { return width*0.2})
+        burnInProtectionManager.heightOffset = Qt.binding(function() { return height*0.2})
     }
 
     Connections {

--- a/watchfaces/004-alternative-scifi.qml
+++ b/watchfaces/004-alternative-scifi.qml
@@ -238,6 +238,9 @@ Item {
         dowCanvas.requestPaint()
         amPmCanvas.am = am
         amPmCanvas.requestPaint()
+
+        burnInProtectionManager.widthOffset = Qt.binding(function() { return width*0.2})
+        burnInProtectionManager.heightOffset = Qt.binding(function() { return height*0.2})
     }
 
     Connections {

--- a/watchfaces/005-analog-nordic.qml
+++ b/watchfaces/005-analog-nordic.qml
@@ -163,6 +163,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()

--- a/watchfaces/006-analog-50s-americana.qml
+++ b/watchfaces/006-analog-50s-americana.qml
@@ -34,6 +34,7 @@ Item {
         antialiasing: true
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -61,7 +62,7 @@ Item {
             ctx.shadowBlur = 3
             ctx.beginPath()
             ctx.lineWidth = parent.height*0.0031
-            ctx.fillStyle = Qt.rgba(0, 0, 0, 1)
+            ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.7) : Qt.rgba(0, 0, 0, 1)
             ctx.strokeStyle = Qt.rgba(1, 1, 1, 0.4)
             ctx.moveTo(parent.width/2+Math.cos(((hour-3 + wallClock.time.getMinutes()/60) / 12) * 2 * Math.PI)*width*0.275,
                        parent.height/2+Math.sin(((hour-3 + wallClock.time.getMinutes()/60) / 12) * 2 * Math.PI)*width*0.275)
@@ -97,7 +98,7 @@ Item {
             ctx.shadowBlur = 2
             ctx.beginPath()
             ctx.lineWidth = parent.height*0.0031
-            ctx.fillStyle = Qt.rgba(0, 0, 0, 1)
+            ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.7) : Qt.rgba(0, 0, 0, 1)
             ctx.strokeStyle = Qt.rgba(1, 1, 1, 0.4)
             ctx.moveTo(parent.width/2+Math.cos(((minute - 15)/60) * 2 * Math.PI)*width*0.44,
                        parent.height/2+Math.sin(((minute - 15)/60) * 2 * Math.PI)*width*0.44)
@@ -124,6 +125,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -174,8 +176,8 @@ Item {
             var ctx = getContext("2d")
             ctx.reset()
             ctx.lineWidth = parent.height*0.0031
-            ctx.fillStyle = Qt.rgba(0.1, 0.1, 0.1, 1)
-            ctx.strokeStyle = Qt.rgba(1, 1, 1, 0.3)
+            ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.8) : Qt.rgba(0.1, 0.1, 0.1, 1)
+            ctx.strokeStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.9) : Qt.rgba(1, 1, 1, 0.3)
             ctx.textAlign = "center"
             ctx.textBaseline = 'middle';
             ctx.translate(parent.width/2, parent.height/2)
@@ -244,7 +246,7 @@ Item {
         z: 5
         renderType: Text.NativeRendering
         font.pixelSize: parent.height*0.08
-        color: "black"
+        color: displayAmbient ? Qt.rgba(1, 1, 1, 0.7) : "black"
         font.family: "Fyodor"
         horizontalAlignment: Text.AlignHCenter
         anchors {
@@ -254,6 +256,15 @@ Item {
             verticalCenterOffset: parent.height*0.195
         }
         text: Qt.formatDate(wallClock.time, "MMM dd")
+    }
+
+
+    Connections {
+        target: compositor
+        onDisplayAmbientChanged: {
+            minuteHand.requestPaint()
+            hourHand.requestPaint()
+        }
     }
 
     Connections {

--- a/watchfaces/007-bold-hour-bebas.qml
+++ b/watchfaces/007-bold-hour-bebas.qml
@@ -32,6 +32,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getMinutes() -15 )*6
@@ -128,5 +129,8 @@ Item {
         minuteCircle.minute = minute
         minuteCircle.requestPaint()
         minuteArc.requestPaint()
+
+        burnInProtectionManager.widthOffset = Qt.binding(function() { return width*0.3})
+        burnInProtectionManager.heightOffset = Qt.binding(function() { return height*0.3})
     }
 }

--- a/watchfaces/008-funky-town-words.qml
+++ b/watchfaces/008-funky-town-words.qml
@@ -83,4 +83,11 @@ Item {
         }
         text: wallClock.time.toLocaleString(Qt.locale(), "mm")
     }
+
+    Component.onCompleted: {
+        burnInProtectionManager.leftOffset = Qt.binding(function() { return width*0.4})
+        burnInProtectionManager.rightOffset = Qt.binding(function() { return width*0.05})
+        burnInProtectionManager.topOffset = Qt.binding(function() { return height*0.4})
+        burnInProtectionManager.bottomOffset = Qt.binding(function() { return height*0.05})
+    }
 }

--- a/watchfaces/009-contemporary-digital-rings.qml
+++ b/watchfaces/009-contemporary-digital-rings.qml
@@ -58,6 +58,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             var rot = (wallClock.time.getSeconds() - 15)*6
@@ -77,6 +78,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             var rot = (minute -15 )*6
@@ -95,6 +97,7 @@ Item {
         anchors.fill: parent
         smooth: true
         renderStrategy: Canvas.Threaded
+        visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
             var rot = 0.5 * (60 * (hour-3) + wallClock.time.getMinutes())
@@ -161,6 +164,7 @@ Item {
             left: hourDisplay.right;
         }
         text: wallClock.time.toLocaleString(Qt.locale(), "ss")
+        visible: !displayAmbient
     }
 
     Text {
@@ -201,6 +205,7 @@ Item {
     Connections {
         target: wallClock
         onTimeChanged: {
+            if (displayAmbient) return
             var hour = wallClock.time.getHours()
             var minute = wallClock.time.getMinutes()
             var second = wallClock.time.getSeconds()
@@ -227,5 +232,8 @@ Item {
         minuteCanvas.requestPaint()
         hourCanvas.hour = hour
         hourCanvas.requestPaint()
+
+        burnInProtectionManager.widthOffset = Qt.binding(function() { return width*0.3})
+        burnInProtectionManager.heightOffset = Qt.binding(function() { return height*0.3})
     }
 }

--- a/watchfaces/010-masked-spartan.qml
+++ b/watchfaces/010-masked-spartan.qml
@@ -33,7 +33,7 @@ Item {
     Rectangle {
         id: layer2mask
         width: parent.width; height: parent.height
-        color: Qt.rgba(0, 0, 0, 0.8)
+        color: displayAmbient ? Qt.rgba(1, 1, 1, 0.7) : Qt.rgba(0, 0, 0, 0.8)
         visible: true
         opacity: 0.0
         layer.enabled: true
@@ -79,6 +79,7 @@ Item {
             font.family: "League Spartan"
             font.styleName: "Bold"
             color: Qt.rgba(1, 1, 1, 1)
+            visible: !displayAmbient
             anchors {
                 bottom: parent.verticalCenter
                 bottomMargin: -parent.height*0.05
@@ -147,13 +148,19 @@ Item {
         layer.samplerName: "maskSource"
         layer.effect: ShaderEffect {
             property variant source: layer2mask
+            property bool keepInner: displayAmbient
             fragmentShader: "
                     varying highp vec2 qt_TexCoord0;
                     uniform highp float qt_Opacity;
                     uniform lowp sampler2D source;
                     uniform lowp sampler2D maskSource;
+                    uniform bool keepInner;
                     void main(void) {
-                        gl_FragColor = texture2D(source, qt_TexCoord0.st) * (1.0-texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+                        if (keepInner) {
+                            gl_FragColor = texture2D(source, qt_TexCoord0.st) * (texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+                        } else {
+                            gl_FragColor = texture2D(source, qt_TexCoord0.st) * (1.0-texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+                        }
                     }
                 "
         }


### PR DESCRIPTION
Add a burn-in protection manager that allows for a maximum offset in each direction of the watchface.
Uses the Lipstick ambient API to handle ambient mode changes.
Upon updating the screen a watchface is given 200ms to update its watchface.
The wallpaper is faded to black to increase visibility of the watchface.