### PR TITLE
Zero-pad six-digit Bluetooth pairing code

### DIFF
--- a/qml/misc/BluetoothAgent.qml
+++ b/qml/misc/BluetoothAgent.qml
@@ -165,7 +165,7 @@ Item {
                 case BluetoothAgent.ReqConfirmation:
                     //% "Confirm:"
                     summary.text = qsTrId("id-btagent-confirm") + localeManager.changesObserver
-                    body.text = agent.passkey
+                    body.text = ("000000" + agent.passkey).substr(-6,6)  // padded to 6 digits
                     text.visible = true
                     inputField.text = ""
                     inputField.previewText = ""
@@ -177,7 +177,7 @@ Item {
                 case BluetoothAgent.DispPasskey:
                     //% "Pass Key:"
                     summary.text = qsTrId("id-btagent-passkey") + localeManager.changesObserver
-                    body.text = agent.passkey
+                    body.text = ("000000" + agent.passkey).substr(-6,6)  // padded to 6 digits
                     text.visible = true
                     inputField.text = ""
                     inputField.previewText = ""


### PR DESCRIPTION
This fixes asteroidos/asteroid-launcher#34.
Previously, the six-digit code didn't contain leading zeros, ex:
![screenshot](https://user-images.githubusercontent.com/8261698/89250558-a40b1d00-d5da-11ea-8996-91776ca116d6.png)

Now, it matches what's shown on the phone or other pairing device:
| ![IMG_20200803_224747](https://user-images.githubusercontent.com/8261698/89251098-cfdad280-d5db-11ea-91ee-e9bf29214d5b.jpg) | ![screenshot](https://user-images.githubusercontent.com/8261698/89250994-973af900-d5db-11ea-8df2-3063200c9766.png) |
|---|---|


