### PR TITLE
GestureFilterArea: Don't prioritize horizontal swipes.

### DIFF
--- a/gesturefilterarea.cpp
+++ b/gesturefilterarea.cpp
@@ -97,38 +97,42 @@ void GestureFilterArea::mouseMoveEvent(QMouseEvent *event) {
     m_velocityX = (m_velocityX*(m_counter-1) + (event->windowPos().x()-m_prevPos.x()))/m_counter;
     m_velocityY = (m_velocityY*(m_counter-1) + (event->windowPos().y()-m_prevPos.y()))/m_counter;
     if(m_tracing) {
-        if(m_velocityX > m_threshold) {
-            m_tracing = false;
-            if(m_toRightAllowed) {
-                m_horizontal = true;
-                grabMouse();
+        if (abs(m_velocityX) > abs(m_velocityY)) {
+            if(m_velocityX > m_threshold) {
+                m_tracing = false;
+                if(m_toRightAllowed) {
+                    m_horizontal = true;
+                    grabMouse();
+                }
+                else
+                    m_pressed = false;
+            } else if(m_velocityX < -m_threshold) {
+                m_tracing = false;
+                if(m_toLeftAllowed) {
+                    m_horizontal = true;
+                    grabMouse();
+                }
+                else
+                    m_pressed = false;
             }
-            else
-                m_pressed = false;
-        } else if(m_velocityX < -m_threshold) {
-            m_tracing = false;
-            if(m_toLeftAllowed) {
-                m_horizontal = true;
-                grabMouse();
+        } else {
+            if(m_velocityY > m_threshold) {
+                m_tracing = false;
+                if(m_toBottomAllowed) {
+                    m_horizontal = false;
+                    grabMouse();
+                }
+                else
+                    m_pressed = false;
+            } else if(m_velocityY < -m_threshold) {
+                m_tracing = false;
+                if(m_toTopAllowed) {
+                    m_horizontal = false;
+                    grabMouse();
+                }
+                else
+                    m_pressed = false;
             }
-            else
-                m_pressed = false;
-        } else if(m_velocityY > m_threshold) {
-            m_tracing = false;
-            if(m_toBottomAllowed) {
-                m_horizontal = false;
-                grabMouse();
-            }
-            else
-                m_pressed = false;
-        } else if(m_velocityY < -m_threshold) {
-            m_tracing = false;
-            if(m_toTopAllowed) {
-                m_horizontal = false;
-                grabMouse();
-            }
-            else
-                m_pressed = false;
         }
     } else if(m_pressed) {
         qreal delta;


### PR DESCRIPTION
For some reason this issue is more noticeable depending on the watch used. For example, swiping in any direction works great on both `sturgeon` and `tetra`, but on others a horizontal swipe occurs to be preferred even though a vertical swipe is intended, this is something that I notices on `smelt` and to a lesser degree on `swift`. There are also reports that this happens on the wip port for `sawfish` (https://github.com/AsteroidOS/asteroid/issues/101#issuecomment-778785938 and https://github.com/AsteroidOS/asteroid/issues/101#issuecomment-778827054).

Tested on `smelt` as it was really bad there. With this patch it seems to work perfectly (i.e. the same as `sturgeon` now :smile: )