### PR TITLE
Use Mce battery API and fix deprecation issues.

### DIFF
--- a/qml/quicksettings/QuickSettings.qml
+++ b/qml/quicksettings/QuickSettings.qml
@@ -29,7 +29,7 @@
  */
 
 import QtQuick 2.9
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import Nemo.DBus 2.0
 import org.nemomobile.systemsettings 1.0
 import Nemo.Ngf 1.0
@@ -44,17 +44,12 @@ Item {
     property bool forbidLeft:  true
     property bool forbidRight: true
 
-    ContextProperty {
+    MceBatteryLevel {
         id: batteryChargePercentage
-        key: "Battery.ChargePercentage"
-        value: "100"
-        Component.onCompleted: batteryChargePercentage.subscribe()
     }
 
-    ContextProperty {
-        id: batteryIsCharging
-        key: "Battery.IsCharging"
-        value: false
+    MceBatteryState {
+        id: batteryChargeState
     }
 
     DBusInterface {
@@ -149,9 +144,9 @@ Item {
         Icon {
             id: batteryIcon
             name: {
-                if(batteryIsCharging.value)                 return "ios-battery-charging"
-                else if(batteryChargePercentage.value > 15) return "ios-battery-full"
-                else                                        return "ios-battery-dead"
+                if(batteryChargeState.value == MceBatteryState.Charging) return "ios-battery-charging"
+                else if(batteryChargePercentage.percent > 15)            return "ios-battery-full"
+                else                                                     return "ios-battery-dead"
             }
             width:  parent.height/2
             height: width
@@ -161,7 +156,7 @@ Item {
         Label {
             id: batteryIndicator
             font.pixelSize: parent.height/4
-            text: batteryChargePercentage.value + "%"
+            text: batteryChargePercentage.percent + "%"
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
         }

--- a/watchfaces/011-analog-silver-swerver.qml
+++ b/watchfaces/011-analog-silver-swerver.qml
@@ -24,7 +24,7 @@
 
 import QtQuick 2.15
 import QtGraphicalEffects 1.15
-import org.freedesktop.contextkit 1.0
+import Nemo.Mce 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
@@ -40,12 +40,8 @@ Item {
 
     anchors.fill: parent
 
-    ContextProperty {
-            id: batteryChargePercentage
-
-            key: "Battery.ChargePercentage"
-            value: "100"
-            Component.onCompleted: batteryChargePercentage.subscribe()
+    MceBatteryLevel {
+        id: batteryChargePercentage
     }
 
     Image {
@@ -371,7 +367,7 @@ Item {
         Item {
             id: batteryBox
 
-            property int value: batteryChargePercentage.value
+            property int value: batteryChargePercentage.percent
 
             onValueChanged: batteryArc.requestPaint()
 


### PR DESCRIPTION
This work replaces the old context/statefs stuff in favor of Mce's new implementation for battery tracking.

This should finally fix issues like https://github.com/AsteroidOS/asteroid/issues/95 and https://github.com/AsteroidOS/asteroid/issues/94

This PR depends on https://github.com/AsteroidOS/mce/pull/9 as such it will also be marked as draft until other changes required for `lipstick` and some more debugging into `sensorfw` is fixed. Additionally, we now also need `libmce-qt` (https://git.sailfishos.org/mer-core/libmce-qt).