### PR TITLE
PanelsGrid: Allow up to 5 visible panels.

### DIFF
--- a/qml/misc/PanelsGrid.qml
+++ b/qml/misc/PanelsGrid.qml
@@ -116,10 +116,11 @@ GestureFilterArea {
         var currentPanel = panels[currentHorizontalPos + "x" + currentVerticalPos]
         if(currentPanel === undefined) return
 
-        var topPanelName =    currentHorizontalPos + "x" + (currentVerticalPos-1)
-        var bottomPanelName = currentHorizontalPos + "x" + (currentVerticalPos+1)
-        var leftPanelName =   (currentHorizontalPos-1) + "x" + currentVerticalPos
-        var rightPanelName =  (currentHorizontalPos+1) + "x" + currentVerticalPos
+        var currentPanelName = currentHorizontalPos + "x" + currentVerticalPos
+        var topPanelName =     currentHorizontalPos + "x" + (currentVerticalPos-1)
+        var bottomPanelName =  currentHorizontalPos + "x" + (currentVerticalPos+1)
+        var leftPanelName =    (currentHorizontalPos-1) + "x" + currentVerticalPos
+        var rightPanelName =   (currentHorizontalPos+1) + "x" + currentVerticalPos
 
         toTopAllowed    = false
         toBottomAllowed = false
@@ -128,10 +129,27 @@ GestureFilterArea {
 
         for(var name in panels) {
             if(panels[name] !== undefined) {
-                if(name.localeCompare(topPanelName)===0 && currentPanel.forbidTop !== true)            toBottomAllowed = true
-                else if(name.localeCompare(bottomPanelName)===0 && currentPanel.forbidBottom !== true) toTopAllowed = true
-                else if(name.localeCompare(leftPanelName)===0 && currentPanel.forbidLeft !== true)     toRightAllowed = true
-                else if(name.localeCompare(rightPanelName)===0 && currentPanel.forbidRight !== true)   toLeftAllowed = true
+                if(name.localeCompare(topPanelName)===0) {
+                    if (currentPanel.forbidTop !== true) toBottomAllowed = true
+                    panels[name].visible = true;
+                }
+                else if(name.localeCompare(bottomPanelName)===0) {
+                    if (currentPanel.forbidBottom !== true) toTopAllowed = true
+                    panels[name].visible = true;
+                }
+                else if(name.localeCompare(leftPanelName)===0) {
+                    if (currentPanel.forbidLeft !== true) toRightAllowed = true
+                    panels[name].visible = true;
+                }
+                else if(name.localeCompare(rightPanelName)===0) {
+                    if (currentPanel.forbidRight !== true) toLeftAllowed = true
+                    panels[name].visible = true;
+                }
+                else if(name.localeCompare(currentPanelName)===0) {
+                    panels[name].visible = true;
+                } else {
+                    panels[name].visible = false;
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes the lag when many panels are registered.
Whenever a panel is moved the changeAllowedDirections() function is called, this function iterates over every panel and checks if it is allowed to move into a given direction.
This function is now also used to make panels invisible when they are not directly reachable using a single swipe. This makes it such that the currently active panel and its surrounding panels are only visible/rendered.
This makes it such that only the watchface panel is visible/rendered when the app launcher panel is visible. Previously when all other panels are also visible/rendered it would cause for a sluggishness feel. Now this isn't the case anymore.


## Before and after
This is with the same amount of notifications (~8)
Laggy/before            |  Smooth/after
:------------------------:|:-------------------------:
![laggy](https://user-images.githubusercontent.com/7857908/119236629-d02b6680-bb38-11eb-8632-5ac2dd9e8683.gif) | ![smooth](https://user-images.githubusercontent.com/7857908/119236627-cdc90c80-bb38-11eb-8208-1e791f91981d.gif)

Here are some higher resolution versions to make the effect even more clear:

Laggy/before:

https://user-images.githubusercontent.com/7857908/119236462-da993080-bb37-11eb-91e6-adbaa758a5b2.mp4

Smooth/after:

https://user-images.githubusercontent.com/7857908/119236388-68c0e700-bb37-11eb-9d9a-0afee623be04.mp4

This should fix https://github.com/AsteroidOS/asteroid/issues/160