### PR TITLE
PanelsGrid: Make sure that only the needed panels are visible. (Fixes lag!)

### DIFF
--- a/qml/misc/PanelsGrid.qml
+++ b/qml/misc/PanelsGrid.qml
@@ -116,10 +116,11 @@ GestureFilterArea {
         var currentPanel = panels[currentHorizontalPos + "x" + currentVerticalPos]
         if(currentPanel === undefined) return
 
-        var topPanelName =    currentHorizontalPos + "x" + (currentVerticalPos-1)
-        var bottomPanelName = currentHorizontalPos + "x" + (currentVerticalPos+1)
-        var leftPanelName =   (currentHorizontalPos-1) + "x" + currentVerticalPos
-        var rightPanelName =  (currentHorizontalPos+1) + "x" + currentVerticalPos
+        var currentPanelName = currentHorizontalPos + "x" + currentVerticalPos
+        var topPanelName =     currentHorizontalPos + "x" + (currentVerticalPos-1)
+        var bottomPanelName =  currentHorizontalPos + "x" + (currentVerticalPos+1)
+        var leftPanelName =    (currentHorizontalPos-1) + "x" + currentVerticalPos
+        var rightPanelName =   (currentHorizontalPos+1) + "x" + currentVerticalPos
 
         toTopAllowed    = false
         toBottomAllowed = false
@@ -132,6 +133,9 @@ GestureFilterArea {
                 else if(name.localeCompare(bottomPanelName)===0 && currentPanel.forbidBottom !== true) toTopAllowed = true
                 else if(name.localeCompare(leftPanelName)===0 && currentPanel.forbidLeft !== true)     toRightAllowed = true
                 else if(name.localeCompare(rightPanelName)===0 && currentPanel.forbidRight !== true)   toLeftAllowed = true
+
+                if (name.localeCompare(currentPanelName)===0) panels[name].visible = true
+                else panels[name].visible = false
             }
         }
     }
@@ -143,6 +147,16 @@ GestureFilterArea {
 
     property alias contentX: content.x
     property alias contentY: content.y
+
+    onContentXChanged: {
+        panels[(currentHorizontalPos+1) + "x" + currentVerticalPos].visible = true
+        panels[(currentHorizontalPos-1) + "x" + currentVerticalPos].visible = true
+    }
+
+    onContentYChanged: {
+        panels[currentHorizontalPos + "x" + (currentVerticalPos-1)].visible = true
+        panels[currentHorizontalPos + "x" + (currentVerticalPos+1)].visible = true
+    }
 
     onSwipeMoved: {
         if(horizontal) {


### PR DESCRIPTION
This work succeeds https://github.com/AsteroidOS/asteroid-launcher/pull/57
The main change is this work only makes one panel when not moving. While the previous work would enable all surrounding panels. This reduces the lag even further while also having the potential to improve battery life for Always-on-Display as only a single panel is rendered when updating the watchface every minute.

This greatly reduces the lag that is observed when multiple notifications exist.
This commit changes the visibility of all panels to be invisible by default with the exception of the current panel in view.
When the panel is moved it makes the two panels adjacent visible (A swipe is either horizontal or vertical so no need to make all four neighboring panels visible.).

Here is a before and after comparison:

https://user-images.githubusercontent.com/7857908/120078140-49353b80-c0ae-11eb-9ec8-0c01295ca1fc.mp4


This fixes https://github.com/AsteroidOS/asteroid/issues/160

