### PR TITLE
MainScreen: Disable burn in protection based on a setting.

### DIFF
--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -33,6 +33,7 @@ import Nemo.Time 1.0
 import Nemo.Configuration 1.0
 import org.nemomobile.lipstick 0.1
 import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
 import org.asteroid.launcher 1.0
 import "desktop.js" as Desktop
 
@@ -73,6 +74,12 @@ Item {
         }
     }
 
+    ConfigurationValue {
+        id: useBip
+        key: "/org/asteroidos/settings/use-burn-in-protection"
+        defaultValue: DeviceInfo.needsBurnInProtection
+    }
+
     Item {
         id: burnInProtectionManager
 
@@ -90,7 +97,7 @@ Item {
         property int heightOffset
 
         // Enable/disable burn in protection.
-        enabled: true
+        enabled: DeviceInfo.needsBurnInProtection && useBip.value
 
         onHeightOffsetChanged: {
             topOffset = heightOffset/2


### PR DESCRIPTION
This PR adds support for disabling burn in protection via DeviceInfo a default is setup (i.e. add `MACHINE_PREFER_BURN_IN_PROTECTION = false` to https://github.com/AsteroidOS/meta-dory-hybris/blob/master/conf/machine/dory.conf). Then using Nemos Configuration it can actually be switched on or off.

An additional change could be added to the settings app such that the setting is only visible when `MACHINE_PREFER_BURN_IN_PROTECTION = true`. As this option will always be disabled ONLY for LCDs.