### PR TITLE
PanelsGrid: Don't force to swipe a direction.

### DIFF
--- a/qml/misc/PanelsGrid.qml
+++ b/qml/misc/PanelsGrid.qml
@@ -181,18 +181,20 @@ GestureFilterArea {
     onSwipeReleased: {
         if(!tracing) {
             if(horizontal) {
-                if(velocity>0 && toRightAllowed)
+                var loc = contentX+currentHorizontalPos*panelWidth
+                if((loc > width/2) || velocity > 10 && toRightAllowed)
                     currentHorizontalPos--
-                else if(velocity< 0 && toLeftAllowed)
+                else if((loc < -width/2) || velocity < -10 && toLeftAllowed)
                     currentHorizontalPos++
 
                 contentAnim.property = "x"
                 contentAnim.to = -panelWidth*currentHorizontalPos
                 contentAnim.start()
             } else {
-                if(velocity>0 && toBottomAllowed)
+                var loc = contentY+currentVerticalPos*panelHeight
+                if((loc > height/2 && velocity > 0) || velocity > 10 && toBottomAllowed)
                     currentVerticalPos--
-                else if(velocity< 0 && toTopAllowed)
+                else if((loc < -height/2 && velocity < 0) || velocity < -10 && toTopAllowed)
                     currentVerticalPos++
 
                 contentAnim.property = "y"


### PR DESCRIPTION
Don't force a swipe when the finger is released.

When starting a swipe it would always move the grid into a new direction, it was never possible to stay at the current panel.
This adds support to stay at the current panel and uses two methods for swiping: position and velocity.
For position: If a panel is swiped over half way to a new panel it will swipe to the new panel.
For velocity: If a panel isn't over half way to a new panel but has a high velocity to it, it will also go to the new panel.



Here's the before:

https://user-images.githubusercontent.com/7857908/142073168-e90a0417-6e3d-47a5-96e4-6f2b4e57ef43.mp4

And here's the after:

https://user-images.githubusercontent.com/7857908/142073199-e2c4fc9c-2022-413c-be04-dd0ddefd3a9a.mp4



My only concern about this code is the use of the velocity number `10`, it's not very descriptive. But during testing it seemed to work fine for `sawfish`, `sturgeon` and `ray`.

