### PR TITLE
Improve legibility, Fix spacing issues in settings page

### DIFF
--- a/applauncher/000-default-horizontal.qml
+++ b/applauncher/000-default-horizontal.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2021 Timo Könnecke <github.com/eLtMosen>
+ *               2015 Florent Revest <revestflo@gmail.com>
  *               2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
  *               2012 Timur Kristóf <venemo@fedoraproject.org>
  *               2011 Tom Swindell <t.swindell@rubyx.co.uk>
@@ -53,7 +54,7 @@ ListView {
     Connections {
         target: grid
         function onCurrentVerticalPosChanged() {
-            if (grid.currentVerticalPos == 1) {
+            if (grid.currentVerticalPos === 1) {
                 grid.changeAllowedDirections()
             }
         }
@@ -64,7 +65,7 @@ ListView {
     delegate: MouseArea {
         id: launcherItem
         width: appsListView.width
-        height: appsListView.width
+        height: width
         enabled: !appsListView.dragging
 
         onClicked: model.object.launchApplication()
@@ -75,8 +76,8 @@ ListView {
             Rectangle {
                 id: circle
                 anchors.centerIn: parent
-                width: parent.width*0.7
-                height: parent.height*0.7
+                width: parent.width * 0.7
+                height: width
                 radius: width/2
                 color: launcherItem.pressed | fakePressed ? "#cccccc" : "#f4f4f4"
             }
@@ -86,7 +87,7 @@ ListView {
             horizontalOffset: 0
             verticalOffset: 0
             radius: 8.0
-            samples: 17
+            samples: 12
             color: "#80000000"
             source: circleWrapper
             cached: true
@@ -95,11 +96,11 @@ ListView {
         Icon {
             id: icon
             anchors.centerIn: parent
-            anchors.verticalCenterOffset: -Dims.h(3)
+            anchors.verticalCenterOffset: -parent.height * 0.03
             width: parent.width * 0.31
             height: width
-            color: "#666666"
-            name: model.object.iconId == "" ? "ios-help" : model.object.iconId
+            color: launcherItem.pressed | fakePressed ? "#444444" : "#666666"
+            name: model.object.iconId === "" ? "ios-help" : model.object.iconId
         }
 
         Label {
@@ -107,9 +108,9 @@ ListView {
             anchors.top: icon.bottom
             width: parent.width * 0.5
             horizontalAlignment: Text.AlignHCenter
-            anchors.topMargin: Dims.h(4)
+            anchors.topMargin: parent.height * 0.04
             anchors.horizontalCenter: parent.horizontalCenter
-            color: "#666666"
+            color: launcherItem.pressed | fakePressed ? "#444444" : "#666666"
             font.pixelSize: ((appsListView.width > appsListView.height ? appsListView.height : appsListView.width) / Dims.l(100)) * Dims.l(5)
             font.weight: Font.Medium
             text: model.object.title.toUpperCase() + localeManager.changesObserver
@@ -129,7 +130,7 @@ ListView {
         forbidBottom = false
         forbidLeft = false
         forbidRight = false
-        if (grid.currentVerticalPos == 1) {
+        if (grid.currentVerticalPos === 1) {
             grid.changeAllowedDirections()
         }
     }
@@ -139,7 +140,7 @@ ListView {
         var upperStop = lowerStop+1
         var ratio = (contentX%appsListView.width)/appsListView.width
 
-        if(upperStop + 1 > launcherModel.itemCount || ratio == 0) {
+        if(upperStop + 1 > launcherModel.itemCount || ratio === 0) {
             launcherCenterColor = alb.centerColor(launcherModel.get(lowerStop).filePath);
             launcherOuterColor = alb.outerColor(launcherModel.get(lowerStop).filePath);
             return;

--- a/applauncher/001-three-icons-horizontal.qml
+++ b/applauncher/001-three-icons-horizontal.qml
@@ -42,8 +42,8 @@ ListView {
     anchors.fill: parent
     clip: true
 
-    preferredHighlightBegin: width /2 - currentItem.width /2
-    preferredHighlightEnd: width /2 + currentItem.width /2
+    preferredHighlightBegin: width / 2 - currentItem.width / 2
+    preferredHighlightEnd: width / 2 + currentItem.width / 2
     highlightRangeMode: ListView.StrictlyEnforceRange
     contentY: -(width / 2 - (width / 4))
 
@@ -59,7 +59,7 @@ ListView {
     Connections {
         target: grid
         function onCurrentVerticalPosChanged() {
-            if (grid.currentVerticalPos == 1) {
+            if (grid.currentVerticalPos === 1) {
                 grid.changeAllowedDirections()
             }
         }
@@ -70,7 +70,7 @@ ListView {
     delegate: MouseArea {
         id: launcherItem
         width: appsListView.width / 2
-        height: appsListView.width / 2
+        height: width
         enabled: !appsListView.dragging
 
         onClicked: model.object.launchApplication()
@@ -81,8 +81,8 @@ ListView {
             Rectangle {
                 id: circle
                 anchors.centerIn: parent
-                width: parent.width*0.8
-                height: parent.height*0.8
+                width: parent.width * 0.8
+                height: width
                 radius: width/2
                 color: launcherItem.pressed | fakePressed ? "#cccccc" : "#f4f4f4"
             }
@@ -92,7 +92,7 @@ ListView {
             horizontalOffset: 0
             verticalOffset: 0
             radius: 8.0
-            samples: 17
+            samples: 12
             color: "#80000000"
             source: circleWrapper
             cached: true
@@ -103,8 +103,8 @@ ListView {
             anchors.centerIn: parent
             width: parent.width * 0.6
             height: width
-            color: "#666666"
-            name: model.object.iconId == "" ? "ios-help" : model.object.iconId
+            color: launcherItem.pressed | fakePressed ? "#444444" : "#666666"
+            name: model.object.iconId === "" ? "ios-help" : model.object.iconId
         }
 
         Label {
@@ -112,12 +112,22 @@ ListView {
             anchors.top: icon.bottom
             width: parent.width
             horizontalAlignment: Text.AlignHCenter
-            anchors.topMargin: Dims.h(6)
+            anchors.topMargin: parent.height * 0.12
             anchors.horizontalCenter: parent.horizontalCenter
             color: "#ffffff"
             font.pixelSize: ((appsListView.width > appsListView.height ? appsListView.height : appsListView.width) / Dims.l(100)) * Dims.l(5)
-            font.weight: Font.Medium
+            font.styleName: "SemiCondensed Bold"
+            font.letterSpacing: parent.width * 0.002
             text: model.object.title.toUpperCase() + localeManager.changesObserver
+            layer.enabled: true
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 0
+                verticalOffset: 0
+                radius: 3.0
+                samples: 3
+                color: "#80000000"
+            }
         }
     }
 
@@ -134,7 +144,7 @@ ListView {
         forbidBottom = false
         forbidLeft = false
         forbidRight = false
-        if (grid.currentVerticalPos == 1) {
+        if (grid.currentVerticalPos === 1) {
             grid.changeAllowedDirections()
         }
     }

--- a/applauncher/002-two-columns.qml
+++ b/applauncher/002-two-columns.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Darrel Griët <dgriet@gmail.com>
+ *               2021 Timo Könnecke <github.com/eLtMosen>
  *               2015 Florent Revest <revestflo@gmail.com>
  *               2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
  *               2012 Timur Kristóf <venemo@fedoraproject.org>
@@ -41,11 +42,11 @@ GridView {
     snapMode: GridView.SnapToRow
     anchors.fill: parent
     clip: true
-    cellHeight: appsView.height/2
-    cellWidth: appsView.width/2
+    cellHeight: appsView.height / 2
+    cellWidth: appsView.width / 2
 
-    preferredHighlightBegin: width /2 - currentItem.width /2
-    preferredHighlightEnd: width /2 + currentItem.width /2
+    preferredHighlightBegin: width / 2 - currentItem.width / 2
+    preferredHighlightEnd: width / 2 + currentItem.width / 2
     highlightRangeMode: ListView.StrictlyEnforceRange
     contentY: -(width / 2 - (width / 4))
 
@@ -62,10 +63,10 @@ GridView {
         target: grid
         function onCurrentVerticalPosChanged() {
             // Move app view to beginning when the watchface is visible.
-            if (grid.currentVerticalPos == 0) {
+            if (grid.currentVerticalPos === 0) {
                 appsView.highlightMoveDuration = 0
                 appsView.currentIndex = 0
-            } else if (grid.currentVerticalPos == 1) {
+            } else if (grid.currentVerticalPos === 1) {
                 appsView.highlightMoveDuration = 1500
                 forbidTop = false
                 grid.changeAllowedDirections()
@@ -75,30 +76,41 @@ GridView {
 
     onAtYBeginningChanged: {
         // Make sure that the grid doesn't move when the app view is visible.
-        if ((grid.currentHorizontalPos == 0) && (grid.currentVerticalPos == 1)) {
+        if ((grid.currentHorizontalPos === 0) && (grid.currentVerticalPos === 1)) {
             forbidTop = !atYBeginning
             grid.changeAllowedDirections()
         }
     }
 
     model: launcherModel
+    property int index: 0
+    /* index to help assign different spacing
+       to odd and even indexed items so they
+       vertically center in two columns. */
+    onChildrenChanged: index++
 
     delegate: MouseArea {
         id: launcherItem
         width: appsView.width / 2
-        height: appsView.width / 2
+        height: width
         enabled: !appsView.dragging
 
         onClicked: model.object.launchApplication()
 
         Item {
             id: circleWrapper
-            anchors.fill: parent
+            width: parent.width * 0.76
+            height: width
+            anchors {
+                verticalCenter: parent.verticalCenter
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: index % 2 ? -parent.width * 0.045 : parent.width * 0.045
+            }
             Rectangle {
                 id: circle
                 anchors.centerIn: parent
-                width: parent.width*0.8
-                height: parent.height*0.8
+                width: parent.width
+                height: parent.height
                 radius: width/2
                 color: launcherItem.pressed | fakePressed ? "#cccccc" : "#f4f4f4"
             }
@@ -108,7 +120,7 @@ GridView {
             horizontalOffset: 0
             verticalOffset: 0
             radius: 8.0
-            samples: 17
+            samples: 12
             color: "#80000000"
             source: circleWrapper
             cached: true
@@ -116,11 +128,11 @@ GridView {
 
         Icon {
             id: icon
-            anchors.centerIn: parent
-            width: parent.width * 0.6
+            anchors.centerIn: circleWrapper
+            width: parent.width * 0.55
             height: width
-            color: "#666666"
-            name: model.object.iconId == "" ? "ios-help" : model.object.iconId
+            color: launcherItem.pressed | fakePressed ? "#444444" : "#666666"
+            name: model.object.iconId === "" ? "ios-help" : model.object.iconId
         }
 
         Label {
@@ -128,12 +140,22 @@ GridView {
             anchors.top: icon.bottom
             width: parent.width
             horizontalAlignment: Text.AlignHCenter
-            anchors.topMargin: Dims.h(5)
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.topMargin: parent.height * 0.116
+            anchors.horizontalCenter: circleWrapper.horizontalCenter
             color: "#ffffff"
             font.pixelSize: ((appsView.width > appsView.height ? appsView.height : appsView.width) / Dims.l(100)) * Dims.l(5)
-            font.weight: Font.Medium
+            font.styleName: "SemiCondensed Bold"
+            font.letterSpacing: parent.width * 0.002
             text: model.object.title.toUpperCase() + localeManager.changesObserver
+            layer.enabled: true
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 0
+                verticalOffset: 0
+                radius: 3.0
+                samples: 3
+                color: "#80000000"
+            }
         }
     }
 


### PR DESCRIPTION
To improve legibility,

- `font.styleName` set to SemiCondensed Bold in app launchers 001- and 002-
- DropShadow added to the `icon.Text` in app launchers 001- and 002-
![grafik](https://user-images.githubusercontent.com/15074193/145307785-6c02c007-976e-45d6-9c5c-041623dc0b46.png)

- During `launcherItem.pressed | fakePressed` not only the circleWrappers color is changed to highlight an input. In 001- and 002- additionally the `icon` gets proportionally darkened to "#444444" as well as the icon.Text in 000-default due to being same color then the icon.
- Centered 002-two-column Items with equal spacing left, right and in between the 2 columns
![appdrawer-000-002fix](https://user-images.githubusercontent.com/15074193/145307854-c136a241-b300-45a9-b54c-b3a876ace8d5.jpg)

Solve spacing issues in Launcher settings page

- Change size definition of icontopMargin from `Dim.h(x)` to `parent.height * x` to adapt to smaller environment when shown in Launcher Settings page.
- Same for the `icon` in 000-default.
![grafik](https://user-images.githubusercontent.com/15074193/145308410-4dae37cf-ec1d-4f82-8368-11357e2a6ff6.png)




