### PR TITLE
Fix issue where the background color wouldn't react to launcher changes.

### DIFF
--- a/applauncher/000-default-horizontal.qml
+++ b/applauncher/000-default-horizontal.qml
@@ -130,6 +130,7 @@ ListView {
         forbidBottom = false
         forbidLeft = false
         forbidRight = false
+        launcherColorOverride = false
         if (grid.currentVerticalPos === 1) {
             grid.changeAllowedDirections()
         }

--- a/applauncher/001-three-icons-horizontal.qml
+++ b/applauncher/001-three-icons-horizontal.qml
@@ -144,6 +144,7 @@ ListView {
         forbidBottom = false
         forbidLeft = false
         forbidRight = false
+        launcherColorOverride = false
         if (grid.currentVerticalPos === 1) {
             grid.changeAllowedDirections()
         }

--- a/applauncher/002-two-columns.qml
+++ b/applauncher/002-two-columns.qml
@@ -171,6 +171,7 @@ GridView {
         forbidBottom = false
         forbidLeft = false
         forbidRight = false
+        launcherColorOverride = false
     }
 
     onContentYChanged: {

--- a/applauncher/003-turbo-list.qml
+++ b/applauncher/003-turbo-list.qml
@@ -106,7 +106,7 @@ ListView {
             width: parent.width
             height: parent.height
             anchors.left: parent.left
-            anchors.leftMargin: DeviceInfo.hasRoundScreen ? bezelOffset + Dims.w(5) : 0
+            anchors.leftMargin: (DeviceInfo.hasRoundScreen ? bezelOffset : 0) + Dims.w(5)
 
             Item {
                 id: circleWrapper

--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -238,6 +238,18 @@ Item {
         }
     }
 
+    onLauncherColorOverrideChanged: {
+        if (launcherColorOverride) {
+            bgCenterColor = Qt.binding(function() { return defaultCenterColor })
+            bgOuterColor = Qt.binding(function() { return defaultOuterColor })
+            wallpaperDarkener.opacity = Math.abs(grid.normalizedVerOffset)*0.4
+        } else {
+            bgCenterColor = Qt.binding(function() { return launcherCenterColor })
+            bgOuterColor = Qt.binding(function() { return launcherOuterColor })
+            wallpaperDarkener.opacity = 0
+        }
+    }
+
     PanelsGrid {
         id: grid 
         anchors.fill: parent


### PR DESCRIPTION
It turns out that when using the launcher color override the background color isn't properly switched  when switching the app launcher style (introduced: https://github.com/AsteroidOS/asteroid-launcher/pull/73).

This adds a handling for it such that this issue is solved. Not super happy with this approach as I hoped that the `onNormalizedVerOffsetChanged` function (https://github.com/AsteroidOS/asteroid-launcher/blob/3643892c263985553f7c63560948702a887599f7/qml/MainScreen.qml#L266) would take care of that. (It does, but only after switching to the home screen...)