### PR TITLE
Change canvas renderStrategy from Threaded to Cooperative

### DIFF
--- a/watchfaces/000-default-digital.qml
+++ b/watchfaces/000-default-digital.qml
@@ -52,7 +52,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var hour: 0
 
@@ -70,7 +70,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var minute: 0
 
@@ -88,7 +88,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: use12H.value
 
         property var am: false
@@ -108,7 +108,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var date: 0
 

--- a/watchfaces/002-analog-70s-classic.qml
+++ b/watchfaces/002-analog-70s-classic.qml
@@ -102,7 +102,7 @@ Item {
         property var rotH: (hour-3 + wallClock.time.getMinutes()/60) / 12
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -143,7 +143,7 @@ Item {
         property var rotM: (minute - 15)/60
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -187,7 +187,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -221,7 +221,7 @@ Item {
         id: nailDot
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -242,7 +242,7 @@ Item {
         id: hourStrokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -271,7 +271,7 @@ Item {
         id: min5Strokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -300,7 +300,7 @@ Item {
         id: minuteStrokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.width*0.008

--- a/watchfaces/003-alternative-digital-2.qml
+++ b/watchfaces/003-alternative-digital-2.qml
@@ -52,7 +52,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var hour: 0
 
@@ -72,7 +72,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var minute: 0
 
@@ -92,7 +92,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var date: 0
 
@@ -114,7 +114,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var month: 0
 
@@ -136,7 +136,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: use12H.value
 
         property var am: false
@@ -159,7 +159,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !use12H.value && !displayAmbient
 
         property var second: 0

--- a/watchfaces/004-alternative-scifi.qml
+++ b/watchfaces/004-alternative-scifi.qml
@@ -50,7 +50,7 @@ Item {
     Canvas {
         id: dowCanvas
         anchors.fill: parent
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")
@@ -79,7 +79,7 @@ Item {
     Canvas {
         id: hourCanvas
         anchors.fill: parent
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var hour: 0
 
@@ -109,7 +109,7 @@ Item {
     Canvas {
         id: minuteCanvas
         anchors.fill: parent
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         property var minute: 0
 
@@ -140,7 +140,7 @@ Item {
     Canvas {
         id: amPmCanvas
         anchors.fill: parent
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         property var am: false
 
         onPaint: {
@@ -170,7 +170,7 @@ Item {
     Canvas {
         id: dateCanvas
         anchors.fill: parent
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
 
         onPaint: {
             var ctx = getContext("2d")

--- a/watchfaces/005-analog-nordic.qml
+++ b/watchfaces/005-analog-nordic.qml
@@ -33,7 +33,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -100,7 +100,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -162,7 +162,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -197,7 +197,7 @@ Item {
         id: nailDot
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -215,7 +215,7 @@ Item {
         id: hourStrokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -243,7 +243,7 @@ Item {
         id: minuteStrokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.width*0.014
@@ -272,7 +272,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         property var voffset: -parent.height*0.025
         property var hoffset: parent.height*0.0
         onPaint: {

--- a/watchfaces/006-analog-50s-americana.qml
+++ b/watchfaces/006-analog-50s-americana.qml
@@ -33,7 +33,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -52,7 +52,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -88,7 +88,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.reset()
@@ -124,7 +124,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -169,7 +169,7 @@ Item {
         anchors.fill: parent
         antialiasing: true
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         property var voffset: -parent.height*0.022
         property var hoffset: -parent.height*0.007
         onPaint: {
@@ -200,7 +200,7 @@ Item {
         id: hourStrokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
 
@@ -222,7 +222,7 @@ Item {
         id: minuteStrokes
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             ctx.lineWidth = parent.width*0.007

--- a/watchfaces/007-bold-hour-bebas.qml
+++ b/watchfaces/007-bold-hour-bebas.qml
@@ -31,7 +31,7 @@ Item {
         property var centerY: parent.height/2
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -82,7 +82,7 @@ Item {
         property var minuteY: centerY+Math.sin(rotM * 2 * Math.PI)*height/2.75
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         onPaint: {
             var ctx = getContext("2d")
             var rot1 = (0 -15 )*6 *0.01745329252

--- a/watchfaces/009-contemporary-digital-rings.qml
+++ b/watchfaces/009-contemporary-digital-rings.qml
@@ -57,7 +57,7 @@ Item {
         property var second: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -77,7 +77,7 @@ Item {
         property var minute: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")
@@ -96,7 +96,7 @@ Item {
         property var hour: 0
         anchors.fill: parent
         smooth: true
-        renderStrategy: Canvas.Threaded
+        renderStrategy: Canvas.Cooperative
         visible: !displayAmbient
         onPaint: {
             var ctx = getContext("2d")


### PR DESCRIPTION
To prevent canvases to render and display sequentially in view of the user.
Cooperative renderStrategy renders all canvases to the applications global render thread and thus display all canvas at once when all have loaded/rendered.
This gives a much more "finished" impression to the user.
Since sequentially displayed parts of an application are perceived as laggy.