### PR TITLE
[asteroid-launcher.pro] Add watchfaces-preview to INSTALL instruction

### DIFF
--- a/asteroid-launcher.pro
+++ b/asteroid-launcher.pro
@@ -54,4 +54,4 @@ watchfaces-img.files =  watchfaces-img/*
 watchfaces-preview.path = /usr/share/asteroid-launcher/watchfaces-preview
 watchfaces-preview.files =  watchfaces-preview/*
 
-INSTALLS = target applauncher watchfaces watchfaces-img
+INSTALLS = target applauncher watchfaces watchfaces-img watchfaces-preview


### PR DESCRIPTION
Correct small oversight while integrating the watchfaces-preview folder.