### PR TITLE
[001-three-icons...] Fix app colors while scrolling

### DIFF
--- a/applauncher/001-three-icons-horizontal.qml
+++ b/applauncher/001-three-icons-horizontal.qml
@@ -151,8 +151,8 @@ ListView {
     }
 
     onContentXChanged: {
-        var lowerStop = Math.floor(contentX/appsListView.width)
-        var upperStop = lowerStop+1
+        var lowerStop = Math.floor((contentX * 2)/appsListView.width)
+        var upperStop = lowerStop + 1
         var ratio = (contentX%appsListView.width)/appsListView.width
 
         if(upperStop + 1 > launcherModel.itemCount || ratio == 0) {

--- a/applauncher/001-three-icons-horizontal.qml
+++ b/applauncher/001-three-icons-horizontal.qml
@@ -151,21 +151,10 @@ ListView {
     }
 
     onContentXChanged: {
-        var lowerStop = Math.floor((contentX * 2)/appsListView.width)
+        var w = (appsListView.width / 2)
+        var lowerStop = Math.floor((contentX + w/2) / w)
         var upperStop = lowerStop + 1
-        var ratio = (contentX%appsListView.width)/appsListView.width
-
-        if(upperStop + 1 > launcherModel.itemCount || ratio == 0) {
-            launcherCenterColor = alb.centerColor(launcherModel.get(lowerStop).filePath);
-            launcherOuterColor = alb.outerColor(launcherModel.get(lowerStop).filePath);
-            return;
-        }
-
-        if(lowerStop < 0) {
-            launcherCenterColor = alb.centerColor(launcherModel.get(0).filePath);
-            launcherOuterColor = alb.outerColor(launcherModel.get(0).filePath);
-            return;
-        }
+        var ratio = ((contentX + w/2)%w)/w
 
         var upperCenterColor = alb.centerColor(launcherModel.get(upperStop).filePath);
         var lowerCenterColor = alb.centerColor(launcherModel.get(lowerStop).filePath);

--- a/applauncher/001-three-icons-horizontal.qml
+++ b/applauncher/001-three-icons-horizontal.qml
@@ -156,6 +156,18 @@ ListView {
         var upperStop = lowerStop + 1
         var ratio = ((contentX + w/2)%w)/w
 
+        if(upperStop + 1 > launcherModel.itemCount || ratio == 0) {
+            launcherCenterColor = alb.centerColor(launcherModel.get(lowerStop).filePath);
+            launcherOuterColor = alb.outerColor(launcherModel.get(lowerStop).filePath);
+            return;
+        }
+
+        if(lowerStop < 0) {
+            launcherCenterColor = alb.centerColor(launcherModel.get(0).filePath);
+            launcherOuterColor = alb.outerColor(launcherModel.get(0).filePath);
+            return;
+        }
+
         var upperCenterColor = alb.centerColor(launcherModel.get(upperStop).filePath);
         var lowerCenterColor = alb.centerColor(launcherModel.get(lowerStop).filePath);
 


### PR DESCRIPTION
Small fix to show the correct app colors below the app starter while scrolling horizontally.
### Before, wrong behaviour:

https://user-images.githubusercontent.com/15074193/152158437-ea562496-6406-499a-99b4-4cc22653d916.mp4


### After, fixed behaviour

https://user-images.githubusercontent.com/15074193/152158559-29621956-88ce-4064-9383-baa527270b41.mp4


