### PR TITLE
Make flatmesh color change more vivid

### DIFF
--- a/applauncher/002-two-columns.qml
+++ b/applauncher/002-two-columns.qml
@@ -175,9 +175,10 @@ GridView {
     }
 
     onContentYChanged: {
-        var lowerStop = Math.floor(contentY/appsView.height)
-        var upperStop = lowerStop+1
-        var ratio = (contentY%appsView.height)/appsView.height
+        var h = (appsView.height / 2)
+        var lowerStop = Math.floor((contentY + h / 2) / h)
+        var upperStop = lowerStop + 1
+        var ratio = ((contentY + h / 2) % h) / h
 
         if(upperStop + 1 > launcherModel.itemCount || ratio == 0) {
             launcherCenterColor = alb.centerColor(launcherModel.get(lowerStop).filePath);


### PR DESCRIPTION
The color change of flatmesh followed the same scheme we had in 001-stock launcher.
- That lead to very "slow" color change of flatmesh while scrolling.
- End of scroll/overshot was green after scrolling 13 apps in 7 lines.

Change:
- Flatmesh now changes color by a factor of 2
- 7th app row ends up in blue instead of green
- This resembles are color change per scrolled line much better

Tested a larger factor of 3. But that lead to "bumps" during scroll from fast color transition.

https://user-images.githubusercontent.com/15074193/154113891-bb868546-f1ef-41be-b325-030ff7738b6b.mp4


