### PR TITLE
[000-default-horizontal] Enhance legibility

### DIFF
--- a/applauncher/000-default-horizontal.qml
+++ b/applauncher/000-default-horizontal.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2022 Timo Könnecke <github.com/eLtMosen>
  *               2015 Florent Revest <revestflo@gmail.com>
  *               2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
  *               2012 Timur Kristóf <venemo@fedoraproject.org>
@@ -37,6 +37,7 @@ import org.asteroid.controls 1.0
 
 ListView {
     id: appsListView
+
     orientation: ListView.Horizontal
     snapMode: ListView.SnapToItem
     anchors.fill: parent
@@ -64,56 +65,74 @@ ListView {
 
     delegate: MouseArea {
         id: launcherItem
+
         width: appsListView.width
         height: width
         enabled: !appsListView.dragging
 
         onClicked: model.object.launchApplication()
 
-        Item {
-            id: circleWrapper
-            anchors.fill: parent
-            Rectangle {
-                id: circle
-                anchors.centerIn: parent
-                width: parent.width * 0.7
-                height: width
-                radius: width/2
-                color: launcherItem.pressed | fakePressed ? "#cccccc" : "#f4f4f4"
-            }
-        }
         DropShadow {
             anchors.fill: circleWrapper
             horizontalOffset: 0
             verticalOffset: 0
             radius: 8.0
-            samples: 12
-            color: "#80000000"
+            samples: 17
+            color: "#66000000"
             source: circleWrapper
             cached: true
         }
 
+        Item {
+            id: circleWrapper
+
+            anchors.fill: parent
+
+            Rectangle {
+                id: circle
+
+                anchors.centerIn: parent
+                width: parent.width * .65
+                height: width
+                radius: width/2
+                color: launcherItem.pressed | fakePressed ? "#dddddd" : "#f8f8f8"
+                opacity: launcherItem.pressed | fakePressed ? .6 : 1
+
+                Behavior on opacity { NumberAnimation { duration: 100 } }
+            }
+        }
+
         Icon {
             id: icon
-            anchors.centerIn: parent
-            anchors.verticalCenterOffset: -parent.height * 0.03
-            width: parent.width * 0.31
-            height: width
-            color: launcherItem.pressed | fakePressed ? "#444444" : "#666666"
+
             name: model.object.iconId === "" ? "ios-help" : model.object.iconId
+            anchors {
+                centerIn: parent
+                verticalCenterOffset: -parent.height * 0.03
+            }
+            width: parent.width * .30
+            height: width
+            color: launcherItem.pressed | fakePressed ? "#333" : "#666"
         }
 
         Label {
             id: iconText
-            anchors.top: icon.bottom
+
+            text: model.object.title.toUpperCase() + localeManager.changesObserver
+            anchors {
+                top: icon.bottom
+                topMargin: parent.height * 0.024
+                horizontalCenter: parent.horizontalCenter
+            }
             width: parent.width * 0.5
             horizontalAlignment: Text.AlignHCenter
-            anchors.topMargin: parent.height * 0.04
-            anchors.horizontalCenter: parent.horizontalCenter
-            color: launcherItem.pressed | fakePressed ? "#444444" : "#666666"
-            font.pixelSize: ((appsListView.width > appsListView.height ? appsListView.height : appsListView.width) / Dims.l(100)) * Dims.l(5)
-            font.weight: Font.Medium
-            text: model.object.title.toUpperCase() + localeManager.changesObserver
+            color: launcherItem.pressed | fakePressed ? "#333" : "#666"
+            font {
+                pixelSize: ((appsListView.width > appsListView.height ?
+                                 appsListView.height :
+                                 appsListView.width) / Dims.l(100)) * Dims.l(5)
+                styleName: "SemiBold"
+            }
         }
     }
 


### PR DESCRIPTION
Due to the app-color-theme update and addition of several new launchers, it was discussed that the stock launcher now appears to have too large circleWrapper in comparison. The new app colors would be more noticeable when the circle gets smaller and covers less of the background.

- Change circle size from 0.7 to 0.65 parent size
- Adapt font top margin accordingly
- Select SemiBold font style for better legibility due to more weight
- Darken icon and text from #444 to #333
- Change Icon size to .3 from 3.1 to reduce anti aliasing due to an even divider. 
- Make circle transparent instead of darker to slightly color it in the app color
- Make circle Dropshadow slightly darker
- Add 100ms transition anim to onPressed toggle

One benefit i observed is slightly less screen tearing while scrolling on sparrow.

Before/After

https://user-images.githubusercontent.com/15074193/154825058-6f9358ed-d064-4c57-ae9e-9a931f65f935.mp4

onPressed Before/After

https://user-images.githubusercontent.com/15074193/154825078-466b505a-9720-465e-bf40-dd77f9d13e74.mp4

Scroll behviour

https://user-images.githubusercontent.com/15074193/154825193-1faabdb5-6be4-47e1-8447-05765c0ee271.mp4



