### PR TITLE
Hide wallpaper in AOD mode, disable home screen when app is visible.

### DIFF
--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -367,6 +367,8 @@ Item {
         id: wallpaper
         width: Dims.w(110)
         height:  Dims.h(110)
+        visible: wallpaperDarkener.opacity != 1.0
+        enabled: visible
         z: -100
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter

--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -43,6 +43,9 @@ Item {
     height: Dims.h(100)
     z: splash.visible ? 10 : 0
 
+    visible: Lipstick.compositor.homeActive || aboutToOpen || aboutToClose || aboutToMinimize
+    enabled: visible
+
     AppLauncherBackground { id: alb }
 
     property var defaultCenterColor: alb.centerColor("/usr/share/asteroid-launcher/default-colors.desktop")
@@ -59,7 +62,15 @@ Item {
 
     property var compositor: Lipstick.compositor
 
+    property bool aboutToOpen: false
+    property bool aboutToClose: false
+    property bool aboutToMinimize: false
+
+    onAboutToCloseChanged: grid.moveTo(0, 0)
+    onAboutToMinimizeChanged: grid.moveTo(0, 1)
+
     Component.onCompleted: {
+        Desktop.desktop = desktop
         Desktop.panelsGrid = grid
         LipstickSettings.lockScreen(true)
         if(firstRun.isFirstRun())
@@ -334,7 +345,7 @@ Item {
         id: lockscreenDelay
         interval: 150
         repeat: false
-        onTriggered: Desktop.onAboutToClose()
+        onTriggered: grid.moveTo(0, 0)
     }
 
     Connections {

--- a/qml/compositor/WindowWrapperBase.qml
+++ b/qml/compositor/WindowWrapperBase.qml
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import QtQuick 2.9
+import QtQuick 2.15
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
@@ -43,7 +43,14 @@ Item {
     width: window !== null ? Dims.w(100) : 0
     height: window !== null ? Dims.h(100) : 0
     NumberAnimation on x { id: moveInAnimation; running: false ; to: 0; duration: 100 }
-    NumberAnimation on opacity { id: fadeInAnimation; running: false; from: 0; to: 1; duration: 100 }
+    NumberAnimation on opacity {
+        id: fadeInAnimation
+        running: false
+        from: 0
+        to: 1
+        duration: 100
+        onFinished: parent.ready = true
+    }
     function animateIn() { fadeInAnimation.start(); }
 
     Component.onCompleted: window.parent = wrapper

--- a/qml/compositor/compositor.qml
+++ b/qml/compositor/compositor.qml
@@ -51,6 +51,7 @@ Item {
     }
 
     Item {
+        property bool ready: false
         id: appLayer
         z: 2
 
@@ -89,10 +90,11 @@ Item {
 
         onGestureStarted: {
             swipeAnimation.stop()
-            if (gesture == "down")
-                Desktop.onAboutToClose()
-            else if(gesture == "right")
-                Desktop.onAboutToMinimize()
+            if (gesture == "down") {
+                Desktop.desktop.aboutToClose = true
+            } else if(gesture == "right") {
+                Desktop.desktop.aboutToMinimize = true
+            }
         }
 
         onGestureFinished: {
@@ -107,6 +109,8 @@ Item {
             } else if (comp.homeActive) {
                 cancelAnimation.start()
             }
+            Desktop.desktop.aboutToClose = false
+            Desktop.desktop.aboutToMinimize = false
         }
 
         NumberAnimation {
@@ -223,12 +227,14 @@ Item {
 
             if (isHomeWindow) {
                 parent.z = Qt.binding(function() { return w.window.rootItem.z })
+                Desktop.desktop.aboutToOpen = Qt.binding(function() {return !homeActive && !appLayer.ready })
                 comp.homeWindow = w
                 setCurrentWindow(homeWindow)
             } else if (!isNotificationWindow && !isAgentWindow && !isDialogWindow) {
                 if (topmostApplicationWindow != null) {
                     Lipstick.compositor.closeClientForWindowId(topmostApplicationWindow.window.windowId)
                 }
+                parent.ready = false
                 w.smoothBorders = true
                 w.x = width
                 w.moveInAnim.start()

--- a/qml/misc/desktop.js
+++ b/qml/misc/desktop.js
@@ -1,6 +1,5 @@
 .pragma library
 var panelsGrid
 var appLauncher
+var desktop
 
-function onAboutToClose() { panelsGrid.moveTo(0, 0) }
-function onAboutToMinimize() { panelsGrid.moveTo(0, 1) }


### PR DESCRIPTION
This allows for the disabling of qml loaded components, potentially reducing battery consumption in ambient mode.

Additionally, this disables the home screen when an app is visible, improving performance in apps by a frame or two per second as well :)