### PR TITLE
Implement nightstand mode

### DIFF
--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -68,6 +68,13 @@ Item {
     property bool aboutToClose: false
     property bool aboutToMinimize: false
 
+    /*
+     * The nightstand property is for use by watchfaces to signal them to, for example,
+     * enable a visual display of battery charge level, as with a ring around the perimeter
+     * of the watch that wouldn't normally be displayed.
+     */
+    property alias nightstand: nightstandMode.active
+
     onAboutToCloseChanged: grid.moveTo(0, 0)
     onAboutToMinimizeChanged: grid.moveTo(0, 1)
 


### PR DESCRIPTION
This corresponds to https://github.com/AsteroidOS/asteroid/issues/151
and https://github.com/AsteroidOS/asteroid-settings/issues/48 and is the
complementary change required to complete the implementation of
nightstand mode.

When the user has nightstand mode enabled, when a charging cable is
detected, the display changes to the user-selected watchface and
brightness for that mode.  It also starts a timer with the delay
interval set by the user.  If the charging cable is disconnected, the
timer will wait for at least that delay before changing back to the
daytime watchface.  Note that in ambient mode, the timing is suspended
for intervals so the delay may be longer than set by the user.

Signed-off-by: Ed Beroset <beroset@ieee.org>