### PR TITLE
Fix #90 by making bluetooth agent round

### DIFF
--- a/qml/misc/BluetoothAgent.qml
+++ b/qml/misc/BluetoothAgent.qml
@@ -36,7 +36,7 @@ Item {
     id: btAgent
 
     width: initialSize.width
-    height: initialSize.height
+    height: width
 
     Item {
         id: circleWrapper


### PR DESCRIPTION
A very blunt fix for #90 - bluetooth dialog not being round on watches with non-square displays. There might be other elements with a similar issue, but I haven't run into them yet. 