### PR TITLE
FirstRunConfig: Show selected default language in place instead of animating through the list.

### DIFF
--- a/qml/firstrun/FirstRunConfig.qml
+++ b/qml/firstrun/FirstRunConfig.qml
@@ -71,7 +71,7 @@ FlatMesh {
         Component.onCompleted: {
             var i = langSettings.currentIndex;
             if(i != -1)
-                langLV.currentIndex = i
+                langLV.positionViewAtIndex(i, ListView.SnapPosition)
         }
     }
 


### PR DESCRIPTION
Other components show the current selection in place, the language selector appears to be the exception to this.
