### PR TITLE
MainScreen: Keep watchface and nightstand watchface in memory and dynamically switch the visibility.

### DIFF
--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -311,10 +311,26 @@ Item {
     Component { id: topPanel;    QuickSettings      { } }
     Component { id: leftPanel;   NotificationsPanel { panelsGrid: grid } }
     Component { id: rightPanel;  Today              { } }
-    Component { 
-        id: centerPanel; 
-        Loader { 
-            source: { return nightstandMode.active ? watchfaceNightstandSource.value : watchFaceSource.value }
+    Component {
+        id: centerPanel;
+        Item {
+            property bool nightstandWatchfaceActive: nightstandMode.active && watchfaceNightstandSource.value != watchFaceSource.value
+            Loader {
+                id: nightstandWatchfaceLoader
+                opacity: nightstandWatchfaceActive ? 1.0 : 0.0
+                visible: opacity
+                anchors.fill: parent
+                source: watchfaceNightstandSource.value
+                Behavior on opacity { NumberAnimation { duration: 200; easing.type: Easing.InCirc } }
+            }
+            Loader {
+                id: watchfaceLoader
+                opacity: !nightstandWatchfaceActive ? 1.0 : 0.0
+                visible: opacity
+                Behavior on opacity { NumberAnimation { duration: 200; easing.type: Easing.InCirc} }
+                anchors.fill: parent
+                source: watchFaceSource.value
+            }
         }
     }
     Component {


### PR DESCRIPTION
This allows for a smooth transition between the two watchfaces. If the nightstand watchface is the same as the regular watchface no switching is needed.

This stops the watchfaces from reloading every time a charger is connected.

Preview:

https://user-images.githubusercontent.com/7857908/196541942-3c58e81b-6991-4304-8f33-dd2bee1ce20a.mp4

