### PR TITLE
Watchfaces: default-digital: Fix warning resulting from a reference to nonexistent code.

### DIFF
--- a/watchfaces/000-default-digital.qml
+++ b/watchfaces/000-default-digital.qml
@@ -146,7 +146,6 @@ Item {
         id: nightstandMode
 
         readonly property bool active: nightstand
-        property int batteryPercentChanged: batteryChargePercentage.percent
 
         anchors.fill: parent
 
@@ -157,10 +156,6 @@ Item {
             textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
         }
         visible: nightstandMode.active
-
-        onBatteryPercentChangedChanged: {
-            batteryPercent.requestPaint()
-        }
 
         Repeater {
             id: segmentedArc


### PR DESCRIPTION
`batteryPercent` isn't actually defined in the watchface so remove the code and other unnecessary code with it.

This was introduced in: https://github.com/AsteroidOS/asteroid-launcher/pull/110.