### PR TITLE
MainScreen: Use MceChargerType instead of MceCableState.

### DIFF
--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -165,8 +165,8 @@ Item {
         updateFrequency: WallClock.Second
     }
 
-    MceCableState {
-        id: mceCableState
+    MceChargerType {
+        id: mceChargerType
     }
 
     ConfigurationValue {
@@ -261,7 +261,7 @@ Item {
     Item {
         id: nightstandMode
         readonly property bool active: ready || nightstandDelayTimer.running
-        readonly property bool ready: nightstandEnabled.value && mceCableState.connected
+        readonly property bool ready: nightstandEnabled.value && mceChargerType.type != MceChargerType.None
         property int oldBrightness: 100
         onReadyChanged: {
             if (ready) {


### PR DESCRIPTION
Some platforms don't need a physical connection to charge (wireless charging) this will break the current use of `MceCableState`. Instead we can use the `MceChargerType` which handles the varying charger types (wireless charging included). Additionally, this should fix nightstand detection on devices where usb-moded isn't functioning properly.

This fixes the nightstand detection on at least: `beluga` and `smelt`. And I've tested if there are regressions on `catfish`.