### PR TITLE
watchfaces: Fix issue where the month isn't updated.

### DIFF
--- a/watchfaces/000-default-digital.qml
+++ b/watchfaces/000-default-digital.qml
@@ -127,6 +127,7 @@ Item {
             id: dateCanvas
 
             property int date: 0
+            property int month: 0
 
             anchors.fill: parent
             antialiasing: true
@@ -211,6 +212,7 @@ Item {
         function onTimeChanged() {
             var hour = wallClock.time.getHours()
             var minute = wallClock.time.getMinutes()
+            var month = wallClock.time.getMonth()
             var date = wallClock.time.getDate()
             var am = hour < 12
             if(use12H.value) {
@@ -223,8 +225,9 @@ Item {
             } if(minuteCanvas.minute !== minute) {
                 minuteCanvas.minute = minute
                 minuteCanvas.requestPaint()
-            } if(dateCanvas.date !== date) {
+            } if(dateCanvas.date !== date || dateCanvas.month !== month) {
                 dateCanvas.date = date
+                dateCanvas.month = month
                 dateCanvas.requestPaint()
             } if(amPmCanvas.am != am) {
                 amPmCanvas.am = am
@@ -236,6 +239,7 @@ Item {
     Component.onCompleted: {
         var hour = wallClock.time.getHours()
         var minute = wallClock.time.getMinutes()
+        var month = wallClock.time.getMonth()
         var date = wallClock.time.getDate()
         var am = hour < 12
         if(use12H.value) {
@@ -246,6 +250,7 @@ Item {
         hourCanvas.requestPaint()
         minuteCanvas.minute = minute
         minuteCanvas.requestPaint()
+        dateCanvas.month = month
         dateCanvas.date = date
         dateCanvas.requestPaint()
         amPmCanvas.am = am

--- a/watchfaces/003-alternative-digital-2.qml
+++ b/watchfaces/003-alternative-digital-2.qml
@@ -116,6 +116,7 @@ Item {
             renderStrategy: Canvas.Cooperative
             visible: !nightstandMode.active
 
+            property int month: 0
             property int date: 0
 
             onPaint: {
@@ -271,6 +272,7 @@ Item {
         var hour = wallClock.time.getHours()
         var minute = wallClock.time.getMinutes()
         var second = wallClock.time.getSeconds()
+        var month = wallClock.time.getMonth()
         var date = wallClock.time.getDate()
         var am = hour < 12
         if(use12H.value) {
@@ -284,8 +286,9 @@ Item {
         secondCanvas.second = second
         secondCanvas.requestPaint()
         dateCanvas.date = date
+        dateCanvas.month = month
         dateCanvas.requestPaint()
-        monthCanvas.month = date
+        monthCanvas.month = month
         monthCanvas.requestPaint()
         amPmCanvas.am = am
         amPmCanvas.requestPaint()
@@ -299,6 +302,7 @@ Item {
             var hour = wallClock.time.getHours()
             var minute = wallClock.time.getMinutes()
             var second = wallClock.time.getSeconds()
+            var month = wallClock.time.getMonth()
             var date = wallClock.time.getDate()
             var am = hour < 12
             if(use12H.value) {
@@ -314,11 +318,12 @@ Item {
             } if(secondCanvas.second !== second) {
                 secondCanvas.second = second
                 secondCanvas.requestPaint()
-            } if(dateCanvas.date !== date) {
+            } if(dateCanvas.date !== date || dateCanvas.month !== month) {
+                dateCanvas.month = month
                 dateCanvas.date = date
                 dateCanvas.requestPaint()
-            } if(monthCanvas.month !== date) {
-                monthCanvas.month = date
+            } if(monthCanvas.month !== month) {
+                monthCanvas.month = month
                 monthCanvas.requestPaint()
             } if(amPmCanvas.am != am) {
                 amPmCanvas.am = am


### PR DESCRIPTION
The getDate() function returns the day of the month ([^1]) so it will never change when the month is changed. Which can naturally happen when the month is changed in the settings app or synchonized. This adds the usage of getMonth() to the relevant watchfaces to fix this issue.

[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate


(This is a draft PR until I've actually tested this completely)