### PR TITLE
Nightstand: Add support for using the regular watchface

### DIFF
--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -367,7 +367,7 @@ Item {
             bgOuterColor = Qt.binding(function() { return defaultOuterColor })
             wallpaperDarkener.opacity = Math.abs(grid.normalizedVerOffset)*0.4
         } else {
-            if (normalizedVerOffset > 0) {
+            if (grid.normalizedVerOffset > 0) {
                 bgCenterColor = Qt.binding(function() { return launcherCenterColor })
                 bgOuterColor = Qt.binding(function() { return launcherOuterColor })
             }

--- a/qml/MainScreen.qml
+++ b/qml/MainScreen.qml
@@ -258,6 +258,12 @@ Item {
         defaultValue: false
     }
 
+    ConfigurationValue {
+        id: nightstandUseCustomWatchface
+        key: "/desktop/asteroid/nightstand/use-custom-watchface"
+        defaultValue: false
+    }
+
     Item {
         id: nightstandMode
         readonly property bool active: ready || nightstandDelayTimer.running
@@ -314,7 +320,7 @@ Item {
     Component {
         id: centerPanel;
         Item {
-            property bool nightstandWatchfaceActive: nightstandMode.active && watchfaceNightstandSource.value != watchFaceSource.value
+            property bool nightstandWatchfaceActive: nightstandMode.active && nightstandUseCustomWatchface.value && watchfaceNightstandSource.value != watchFaceSource.value
             Loader {
                 id: nightstandWatchfaceLoader
                 opacity: nightstandWatchfaceActive ? 1.0 : 0.0


### PR DESCRIPTION
This follows up on https://github.com/AsteroidOS/asteroid-settings/pull/61.