### PR TITLE
applauncher: Redesign icon highlighting

### DIFF
--- a/applauncher/005-speed-dial.qml
+++ b/applauncher/005-speed-dial.qml
@@ -83,31 +83,29 @@ Item {
             }
             onClicked: model.object.launchApplication()
 
-            Rectangle {
+            Item {
                 id: circleWrapper
-                width: parent.width * .86
-                radius: width / 2
+                width: parent.height * 0.8
                 height: width
                 anchors.centerIn: parent
-                visible: false
-                color: launcherItem.pressed | fakePressed ? "#cccccc" : "#f4f4f4"
-
-                Icon {
-                    id: icon
-
-                    width: circleWrapper.width * .7
-                    height: width
-                    anchors.centerIn: circleWrapper
-                    color: launcherItem.pressed | fakePressed ? "#444444" : "#000000"
-                    name: model.object.iconId === "" ? "ios-help" : model.object.iconId
+                Rectangle {
+                    id: circle
+                    anchors.centerIn: parent
+                    width: parent.width
+                    height: parent.height
+                    radius: width/2
+                    opacity: launcherItem.pressed | fakePressed ? 0.8 : 1.0
+                    color: (root.selectedLauncherItem == model.object) ? alb.centerColor(model.object.filePath) : "#f4f4f4"
+                    Behavior on opacity {
+                        PropertyAnimation { target: circle; duration: 70 }
+                    }
                     Behavior on color {
-                        PropertyAnimation { target: icon; property: "color"; duration: 70 }
+                        PropertyAnimation { target: circle; property: "color"; duration: 70 }
                     }
                 }
             }
 
             DropShadow {
-                id: shadow
                 anchors.fill: circleWrapper
                 horizontalOffset: 0
                 verticalOffset: 0
@@ -118,16 +116,17 @@ Item {
                 cached: true
             }
 
-            InnerShadow {
-                id: innerShadow
-                visible: (root.selectedLauncherItem == model.object)
-                fast: true
-                cached: true
-                anchors.fill: circleWrapper
-                radius: 50.0
-                samples: 16
-                color: alb.centerColor(model.object.filePath)
-                source: circleWrapper
+            Icon {
+                id: icon
+                anchors.centerIn: circleWrapper
+                width: circleWrapper.width * 0.70
+                height: width
+                opacity: launcherItem.pressed | fakePressed ? 1.0 : 0.9
+                name: model.object.iconId === "" ? "ios-help" : model.object.iconId
+                color: (root.selectedLauncherItem == model.object) ? "#ffffff" : "#000000"
+                Behavior on color {
+                    PropertyAnimation { target: icon; property: "color"; duration: 70 }
+                }
             }
         }
 

--- a/applauncher/005-speed-dial.qml
+++ b/applauncher/005-speed-dial.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - Darrel Griët <dgriet@gmail.com>
+ * Copyright (C) 2023 - Darrel Griët <dgriet@gmail.com>
  * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
  * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
  *
@@ -198,7 +198,7 @@ Item {
             anchors.centerIn: parent
             anchors.horizontalCenterOffset: -width/2
             clip: true
-            width: root.width * 0.26
+            width: Math.ceil(root.width * 0.26)
             height: root.width * 0.26
             Rectangle {
                 width: parent.width*2
@@ -220,9 +220,9 @@ Item {
         id: barRight
         anchors.centerIn: parent
         // Avoid overlap by moving to the right a pixel if needed.
-        anchors.horizontalCenterOffset: Math.ceil(width/2)
+        anchors.horizontalCenterOffset: width/2
         clip: true
-        width: root.width * 0.9
+        width: Math.ceil(root.width * 0.9)
         height: barLeft.height
         color: "#66000000"
     }


### PR DESCRIPTION
As suggested by @eLtMosen this is a redesign of the icon highlighting such that it's in the same style as the turbo list launcher. It improves the visibility of which item is selected as well.

| Old | New |
| ----  | ---- |
| ![aos-applauncher-5-01](https://user-images.githubusercontent.com/7857908/233852595-32e5e7d7-9cda-4bf9-b722-c0ed7c48980a.jpg) | ![aos-applauncher-5-1](https://user-images.githubusercontent.com/7857908/233852604-89583045-5506-4d6a-bdfa-dc2a4134ed5c.jpg) |
| ![aos-applauncher-5-02](https://user-images.githubusercontent.com/7857908/233852614-1a725a9a-ac7c-4a41-88ca-2f7c07aa9eb1.jpg) | ![aos-applauncher-5-2](https://user-images.githubusercontent.com/7857908/233852619-968f6172-0272-4c02-8c45-9d2542d5ee07.jpg) |
