### PR TITLE
Change Open Sans to Noto Sans and make batterDisplay smaller when 3 digits

### DIFF
--- a/watchfaces/009-analog-scientific-v2.qml
+++ b/watchfaces/009-analog-scientific-v2.qml
@@ -289,8 +289,8 @@ Item {
             }
             font {
                 pixelSize: parent.height * .39
-                family: "Open Sans Condensed"
-                styleName:"Light"
+                family: "Noto Sans"
+                styleName: "Condensed Light"
             }
             color: "#ffffffff"
             text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
@@ -395,8 +395,8 @@ Item {
             renderType: Text.NativeRendering
             font {
                 pixelSize: parent.height * .366
-                family: "Open Sans Condensed"
-                styleName:"Light"
+                family: "Noto Sans"
+                styleName: "Condensed Light"
                 letterSpacing: -root.width * .0018
             }
             color: "#ddffffff"
@@ -488,7 +488,7 @@ Item {
             anchors.centerIn: parent
             renderType: Text.NativeRendering
             font {
-                pixelSize: parent.height * .48
+                pixelSize: parent.height * (batteryDisplay.text === "100" ? 0.46 : .48)
                 family: "Outfit"
                 styleName:"Thin"
             }


### PR DESCRIPTION
Small fix since the Open Sans Condensed font was not copied to asteroid-fonts.
Open Sans was changed to Noto Sans system wide, so doing that here too.

Battery display at 100% had a bit few spacing and is now made a tad smaller in that case.