### PR TITLE
Fix off-by-one error in agenda display

### DIFF
--- a/src/qml/today/Today.qml
+++ b/src/qml/today/Today.qml
@@ -45,7 +45,7 @@ ListView {
     }
 
     property int year: todayClock.time.getFullYear()
-    property int month: todayClock.time.getMonth()+1
+    property int month: todayClock.time.getMonth()
     property int day: todayClock.time.getDate()
 
     ConfigurationValue {
@@ -152,8 +152,8 @@ ListView {
 
     model: AgendaModel {
         id: agendaModel
-        startDate: new Date(year, month, day)
-        endDate: startDate
+        startDate: new Date(year, month, day, 0, 0, 0)
+        endDate: new Date(year, month, day, 23, 59, 59)
     }
 
     delegate: Component {


### PR DESCRIPTION
As noted by aranor.16 on Matrix chat, the watch is supposed to show today's agenda items when you swipe left, but there was an off-by-one error that only showed items for the next month on the same day.  This has been fixed, and it now works perfectly with the calendar.