### PR TITLE
GestureFilterArea: Use local positioning for movement detection.

### DIFF
--- a/src/gesturefilterarea.cpp
+++ b/src/gesturefilterarea.cpp
@@ -82,7 +82,7 @@ void GestureFilterArea::mousePressEvent(QMouseEvent *event) {
         m_velocityY = 0;
         m_tracing = true;
         m_horizontal = false;
-        m_prevPos = event->windowPos();
+        m_prevPos = event->localPos();
         m_counter = 0;
     }
 }
@@ -94,8 +94,8 @@ void GestureFilterArea::mouseMoveEvent(QMouseEvent *event) {
     }
     m_counter++;
 
-    m_velocityX = (m_velocityX*(m_counter-1) + (event->windowPos().x()-m_prevPos.x()))/m_counter;
-    m_velocityY = (m_velocityY*(m_counter-1) + (event->windowPos().y()-m_prevPos.y()))/m_counter;
+    m_velocityX = (m_velocityX*(m_counter-1) + (event->localPos().x()-m_prevPos.x()))/m_counter;
+    m_velocityY = (m_velocityY*(m_counter-1) + (event->localPos().y()-m_prevPos.y()))/m_counter;
     if(m_tracing) {
         if (abs(m_velocityX) > abs(m_velocityY)) {
             if(m_velocityX > m_threshold) {
@@ -137,13 +137,13 @@ void GestureFilterArea::mouseMoveEvent(QMouseEvent *event) {
     } else if(m_pressed) {
         qreal delta;
         if(m_horizontal)
-            delta = event->windowPos().x() - m_prevPos.x();
+            delta = event->localPos().x() - m_prevPos.x();
         else
-            delta = event->windowPos().y() - m_prevPos.y();
+            delta = event->localPos().y() - m_prevPos.y();
 
         emit swipeMoved(m_horizontal, delta);
     }
-    m_prevPos = event->windowPos();
+    m_prevPos = event->localPos();
 }
 
 void GestureFilterArea::mouseReleaseEvent(QMouseEvent *event) {


### PR DESCRIPTION
This is instead of the window position.

It may occur that the GestureFilterArea is used in a nested way, where a higher level item can be rotated. This change will allow the GestureFilterArea to work as intended when it's rotated/transformed/scaled.

It essentially removes the need for this patch: https://github.com/AsteroidOS/meta-smartwatch/blob/cc4fbcf41bfe83ddba4128d54086acab6b58d65b/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher/0002-GestureFilterArea-Fix-swipe-interaction-on-rotated-s.patch.

Once this is merged a change to https://github.com/AsteroidOS/meta-smartwatch/blob/cc4fbcf41bfe83ddba4128d54086acab6b58d65b/meta-mtk6580/recipes-asteroid/asteroid-launcher/asteroid-launcher_%25.bbappend is also required.