### PR TITLE
MainScreen: Use stock watchface for nightstand mode.

### DIFF
--- a/src/qml/MainScreen.qml
+++ b/src/qml/MainScreen.qml
@@ -243,7 +243,7 @@ Item {
     ConfigurationValue {
         id: watchfaceNightstandSource
         key: "/desktop/asteroid/nightstand/watchface"
-        defaultValue: "file:///usr/share/asteroid-launcher/watchfaces/005-analog-nordic.qml"
+        defaultValue: "file:///usr/share/asteroid-launcher/watchfaces/000-default-digital.qml"
     }
 
     ConfigurationValue {


### PR DESCRIPTION
The analog-nordic watchface was moved to the community watchfaces, this meant that errors would be printed when the launcher is started.
Switch back to the stock watchface as we now have charging rings for all stock watchfaces in nightstand mode.