### PR TITLE
Fix launcher with fixed qtwayland app close behaviour

### DIFF
--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -53,6 +53,7 @@ Item {
     Item {
         property bool ready: false
         id: appLayer
+        visible: comp.appActive
         z: 2
 
         opacity: (width-2*gestureArea.value)/width
@@ -102,7 +103,9 @@ Item {
                 if (gestureArea.progress >= swipeThreshold) {
                     swipeAnimation.valueTo = inverted ? -max : max
                     swipeAnimation.start()
-                    Lipstick.compositor.closeClientForWindowId(comp.topmostWindow.window.windowId)
+                    var app = comp.topmostWindow
+                    comp.topmostWindow = comp.homeWindow
+                    Lipstick.compositor.closeClientForWindowId(app.window.windowId)
                 } else {
                     cancelAnimation.start()
                 }


### PR DESCRIPTION
If we merge https://github.com/AsteroidOS/meta-asteroid/pull/180 , asteroid-launcher may hang after applications are closed as they currently keep focus. This commit fixes that by making the application invisible as soon as it is dismissed, which allows it to finish closing itself in the background. The application layer is made visible as soon as another application is added to the stack.
This does assume that applications are fine with closing themselves in the background. This might not be ideal, but it's not a regression as applications would previously just crash when dismissed by the user. 