### PR TITLE
Add additional logic to handle apps taking some time to close

### DIFF
--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -53,6 +53,7 @@ Item {
     Item {
         property bool ready: false
         id: appLayer
+        visible: comp.appActive
         z: 2
 
         opacity: (width-2*gestureArea.value)/width
@@ -102,7 +103,9 @@ Item {
                 if (gestureArea.progress >= swipeThreshold) {
                     swipeAnimation.valueTo = inverted ? -max : max
                     swipeAnimation.start()
-                    Lipstick.compositor.closeClientForWindowId(comp.topmostWindow.window.windowId)
+                    var app = comp.topmostWindow
+                    comp.topmostWindow = comp.homeWindow
+                    Lipstick.compositor.closeClientForWindowId(app.window.windowId)
                 } else {
                     cancelAnimation.start()
                 }


### PR DESCRIPTION
lipstick now closes apps gracefully instead of crashing them, which means that the app window can hang around for a bit after a close request is sent. This adds some additional logic to ensure that an app that's currently being closed doesn't steal focus from the launcher and doesn't show on the screen.
this is effectively identical to https://github.com/AsteroidOS/asteroid-launcher/pull/169 