### PR TITLE
Make 3x3 launcher reset when view changes to watchface

### DIFF
--- a/src/applauncher/004-three-by-three.qml
+++ b/src/applauncher/004-three-by-three.qml
@@ -62,6 +62,16 @@ Item {
     property bool forbidRight:     false
     */
 
+    Connections {
+        target: grid
+        function onCurrentVerticalPosChanged() {
+            // Move app view to beginning when the watchface is visible.
+            if (grid.currentVerticalPos === 0) {
+                appsView.positionViewAtBeginning()
+            }
+        }
+    }
+
     Component {
         id: gridDelegate
 


### PR DESCRIPTION
This steals the fix from turbo-list
fixes the issue where this applauncher would get stuck when swiping down from the watchface