### PR TITLE
notifications: Don't switch away when there are more than one notifications left after dismissing

### DIFF
--- a/src/qml/notifications/NotificationsPanel.qml
+++ b/src/qml/notifications/NotificationsPanel.qml
@@ -121,7 +121,11 @@ Item {
                 }
             }
 
-            panelsGrid.moveTo(-first, 0)
+            if (first === 0 && notifModel.itemCount > 0) {
+                panelsGrid.moveTo(-1, 0)
+            } else {
+                panelsGrid.moveTo(-first, 0)
+            }
         }
     }
 


### PR DESCRIPTION
The notification to the right is revealed when a notification is dismissed. This works well when the left most or a notification in the middle is dismissed. However, this shows the watchface when the right most notification is dismissed. This changes the behaviour such that the notification on its left is revealed, unless no notification is available, in which case the watchface is shown.

This fixes https://github.com/AsteroidOS/asteroid-launcher/issues/50