### PR TITLE
compositor: Smoothen circle border

### DIFF
--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -265,7 +265,6 @@ Item {
         visible: DeviceInfo.hasRoundScreen
         layer.enabled: DeviceInfo.hasRoundScreen
         layer.effect: CircleMaskShader {
-            smoothness: 0.002
             keepInner: false
         }
     }


### PR DESCRIPTION
Smoothen borders such that the display blends into the bezel.

This PR is mostly meant as a means to start a discussion on if we want this functionality in the first place :smile:

![20240908_224045](https://github.com/user-attachments/assets/91d3c388-e5b1-4b58-adba-25ffb7447af1)

If we want this we probably also need to think about non-circular displays. Perhaps we can also enable this based on a device property. For instance this feature might make sense on `sawfish` (because of the huge bezel) but not on `smelt` which doesn't have a bezel (flat tire).