### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/applauncher/003-turbo-list.qml
+++ b/src/applauncher/003-turbo-list.qml
@@ -106,7 +106,7 @@ ListView {
             width: parent.width
             height: parent.height
             anchors.left: parent.left
-            anchors.leftMargin: (DeviceInfo.hasRoundScreen ? bezelOffset : 0) + Dims.w(5)
+            anchors.leftMargin: (DeviceSpecs.hasRoundScreen ? bezelOffset : 0) + Dims.w(5)
 
             Item {
                 id: circleWrapper

--- a/src/applauncher/004-three-by-three.qml
+++ b/src/applauncher/004-three-by-three.qml
@@ -36,7 +36,7 @@
 import QtQuick 2.15
 import QtGraphicalEffects 1.12
 import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0 as AsteroidUtils
+import org.asteroid.utils 1.0
 
 Item {
     id: root
@@ -181,7 +181,7 @@ Item {
     Component {
         id: spacer
         Item {
-            height: AsteroidUtils.DeviceInfo.hasRoundScreen ? root.height / numColumns / 2 : 0
+            height: DeviceSpecs.hasRoundScreen ? root.height / numColumns / 2 : 0
             width: height
         }
     }

--- a/src/qml/MainScreen.qml
+++ b/src/qml/MainScreen.qml
@@ -33,9 +33,9 @@ import Nemo.Time 1.0
 import Nemo.Configuration 1.0
 import Nemo.Mce 1.0
 import org.nemomobile.lipstick 0.1
-import org.nemomobile.systemsettings 1.0 as NemoSystemSettings
+import org.nemomobile.systemsettings 1.0
 import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0 as AsteroidUtils
+import org.asteroid.utils 1.0
 import org.asteroid.launcher 1.0
 import "desktop.js" as Desktop
 
@@ -104,7 +104,7 @@ Item {
     ConfigurationValue {
         id: useBip
         key: "/org/asteroidos/settings/use-burn-in-protection"
-        defaultValue: AsteroidUtils.DeviceInfo.needsBurnInProtection
+        defaultValue: DeviceSpecs.needsBurnInProtection
     }
 
     ConfigurationValue {
@@ -130,7 +130,7 @@ Item {
         property int heightOffset
 
         // Enable/disable burn in protection.
-        enabled: AsteroidUtils.DeviceInfo.needsBurnInProtection && useBip.value
+        enabled: DeviceSpecs.needsBurnInProtection && useBip.value
 
         onHeightOffsetChanged: {
             topOffset = heightOffset/2
@@ -192,7 +192,7 @@ Item {
         id: launcherModel
     }
 
-    NemoSystemSettings.DisplaySettings { 
+    DisplaySettings { 
         id: displaySettings
     }
 

--- a/src/qml/compositor/WindowWrapperBase.qml
+++ b/src/qml/compositor/WindowWrapperBase.qml
@@ -55,6 +55,6 @@ Item {
 
     Component.onCompleted: window.parent = wrapper
 
-    layer.enabled: smoothBorders && DeviceInfo.hasRoundScreen
+    layer.enabled: smoothBorders && DeviceSpecs.hasRoundScreen
     layer.effect: CircleMaskShader { }
 }

--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -262,8 +262,8 @@ Item {
         anchors.fill: parent
         color: "black"
         z: 6
-        visible: DeviceInfo.hasRoundScreen
-        layer.enabled: DeviceInfo.hasRoundScreen
+        visible: DeviceSpecs.hasRoundScreen
+        layer.enabled: DeviceSpecs.hasRoundScreen
         layer.effect: CircleMaskShader {
             smoothness: 0.002
             keepInner: false

--- a/src/qml/firstrun/FakeAlarmclock.qml
+++ b/src/qml/firstrun/FakeAlarmclock.qml
@@ -183,6 +183,6 @@ FlatMesh {
         }
     }
 
-    layer.enabled: DeviceInfo.hasRoundScreen
+    layer.enabled: DeviceSpecs.hasRoundScreen
     layer.effect: CircleMaskShader { }
 }

--- a/src/qml/today/Today.qml
+++ b/src/qml/today/Today.qml
@@ -143,8 +143,8 @@ ListView {
             anchors.right: parent.right
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
-            leftPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
-            rightPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
+            leftPadding: DeviceSpecs.hasRoundScreen ? Dims.w(25) : 0
+            rightPadding: DeviceSpecs.hasRoundScreen ? Dims.w(25) : 0
             wrapMode: Text.WordWrap
             maximumLineCount: 1
         }

--- a/src/watchfaces/008-numerals-duo-synth-neon-green.qml
+++ b/src/watchfaces/008-numerals-duo-synth-neon-green.qml
@@ -58,7 +58,7 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             anchors {
                 bottom: root.verticalCenter
-                bottomMargin: DeviceInfo.hasRoundScreen ? root.height*0.387 : root.height*0.402
+                bottomMargin: DeviceSpecs.hasRoundScreen ? root.height*0.387 : root.height*0.402
                 horizontalCenter: root.horizontalCenter
             }
             text: wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
@@ -88,7 +88,7 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             anchors {
                 top: root.verticalCenter
-                topMargin: DeviceInfo.hasRoundScreen ? root.height*0.394 : root.height*0.406
+                topMargin: DeviceSpecs.hasRoundScreen ? root.height*0.394 : root.height*0.406
                 horizontalCenter: root.horizontalCenter
             }
             text: wallClock.time.toLocaleString(Qt.locale(), "yyyy-MM-dd")
@@ -104,10 +104,10 @@ Item {
         }
 
         Item {
-            x: DeviceInfo.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
-            y: DeviceInfo.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
-            width: DeviceInfo.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
-            height: DeviceInfo.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
+            x: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
+            y: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
+            width: DeviceSpecs.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
+            height: DeviceSpecs.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
             Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             Behavior on y { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             Behavior on width { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -57,7 +57,7 @@ Item {
             opacity: .0
             layer.enabled: true
             layer.smooth: true
-            radius: DeviceInfo.hasRoundScreen || nightstand ? width : 0
+            radius: DeviceSpecs.hasRoundScreen || nightstand ? width : 0
         }
 
         Rectangle {


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56