### PR TITLE
QuickSettings: Increase minimum brightness to 10 as in settings.

### DIFF
--- a/src/qml/quicksettings/QuickSettings.qml
+++ b/src/qml/quicksettings/QuickSettings.qml
@@ -83,7 +83,7 @@ Item {
         anchors.verticalCenter: rootitem.verticalCenter
         icon: "ios-sunny"
         onChecked: displaySettings.brightness = 100
-        onUnchecked: displaySettings.brightness = 0
+        onUnchecked: displaySettings.brightness = 10
         Component.onCompleted: updateBrightnessToggle()
     }
 


### PR DESCRIPTION
src/qml/quicksettings/QuickSettings.qml
(rootitem.brightnessToggle.onUnchecked): Set displaySettings.brightness to 10 instead of 0, matching the minimum value in the asteroid-settings app. Setting this to 0 leads to an unusable completely black screen on some hardware, e.g., LG G Watch R (lenok).

Fixes #182.