### PR TITLE
quickpanel: volume: Fix issue where toggle state would go out of sync

### DIFF
--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -703,6 +703,13 @@ Item {
             }
 
             Connections {
+                target: volumeControl
+                function onVolumeChanged() {
+                    soundToggle.toggled = !(preMuteLevel.value > 0);
+                }
+            }
+
+            Connections {
                 target: preMuteLevel
                 function onValueChanged() {
                     soundToggle.toggled = !(preMuteLevel.value > 0);


### PR DESCRIPTION
This usually happens when the volume and premute volume are at 0.