### PR TITLE
QuickPanel: Increase minimum brightness to 10 as in settings.

### DIFF
--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -553,8 +553,8 @@ Item {
             rangeMax: 100
             rangeStepSize: 10
 
-            onChecked: displaySettings.brightness = rangeMax
-            onUnchecked: displaySettings.brightness = rangeMin
+            onChecked: displaySettings.brightness = 100
+            onUnchecked: displaySettings.brightness = 10
             Component.onCompleted: toggled = displaySettings.brightness > 10
 
             onPressAndHold: rangeValue = displaySettings.brightness


### PR DESCRIPTION
src/qml/quickpanel/QuickPanel.qml
(rootitem.brightnessToggle.onUnchecked): Set displaySettings.brightness to 10 instead of rangeMin, i.e., 0, matching the minimum value in the asteroid-settings app. Setting this to 0 leads to an unusable completely black screen on some hardware, e.g., LG G Watch R (lenok). (rootitem.brightnessToggle.onChecked): Use the numeric value 100 instead of rangeMax for consistency with onUnchecked.

Fixes #182.