### PR TITLE
[Watchfaces performance] watchface code quality and performance refactor

### DIFF
--- a/src/watchfaces/000-default-digital.qml
+++ b/src/watchfaces/000-default-digital.qml
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -41,15 +15,14 @@ Item {
     anchors.fill: parent
 
     function twoDigits(x) {
-        if (x<10) return "0" + x;
-        else      return x;
+        return x < 10 ? "0" + x : "" + x
     }
 
     function prepareContext(ctx) {
         ctx.reset()
         ctx.fillStyle = "white"
         ctx.textAlign = "center"
-        ctx.textBaseline = 'middle';
+        ctx.textBaseline = "middle"
         ctx.shadowColor = "black"
         ctx.shadowOffsetX = 0
         ctx.shadowOffsetY = 0
@@ -76,16 +49,13 @@ Item {
                 property int hour: 0
 
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-
                     ctx.font = "57 " + height * .36 + "px Roboto"
-                    ctx.fillText(twoDigits(hour), width * .378, height * .537);
+                    ctx.fillText(twoDigits(hour), width * .378, height * .537)
                 }
             }
 
@@ -95,16 +65,13 @@ Item {
                 property int minute: 0
 
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-
                     ctx.font = "30 " + height * .18 + "px Roboto"
-                    ctx.fillText(twoDigits(minute), width * .717, height * .473);
+                    ctx.fillText(twoDigits(minute), width * .717, height * .473)
                 }
             }
 
@@ -112,19 +79,17 @@ Item {
                 id: amPmCanvas
 
                 property bool am: false
+                property string ap: ""
 
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
                 visible: use12H.value
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-
                     ctx.font = "25 " + height / 15 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP"), width * .894, height * .371);
+                    ctx.fillText(ap, width * .894, height * .371)
                 }
             }
 
@@ -133,17 +98,16 @@ Item {
 
                 property int date: 0
                 property int month: 0
+                property string dateText: ""
 
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
                     ctx.font = "25 " + height / 13 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "d MMM"), width * .719, height * .595);
+                    ctx.fillText(dateText, width * .719, height * .595)
                 }
             }
         }
@@ -155,12 +119,9 @@ Item {
 
             anchors.fill: parent
 
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
+            layer.enabled: true
+            layer.samples: 4
+
             visible: nightstandMode.active
 
             Repeater {
@@ -174,15 +135,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .055
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -191,7 +152,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -220,22 +181,27 @@ Item {
                 var month = wallClock.time.getMonth()
                 var date = wallClock.time.getDate()
                 var am = hour < 12
-                if(use12H.value) {
+                if (use12H.value) {
                     hour = hour % 12
-                    if (hour === 0) hour = 12;
+                    if (hour === 0) hour = 12
                 }
-                if(hourCanvas.hour !== hour) {
+                if (hourCanvas.hour !== hour) {
                     hourCanvas.hour = hour
                     hourCanvas.requestPaint()
-                } if(minuteCanvas.minute !== minute) {
+                }
+                if (minuteCanvas.minute !== minute) {
                     minuteCanvas.minute = minute
                     minuteCanvas.requestPaint()
-                } if(dateCanvas.date !== date || dateCanvas.month !== month) {
+                }
+                if (dateCanvas.date !== date || dateCanvas.month !== month) {
                     dateCanvas.date = date
                     dateCanvas.month = month
+                    dateCanvas.dateText = wallClock.time.toLocaleString(Qt.locale(), "d MMM")
                     dateCanvas.requestPaint()
-                } if(amPmCanvas.am != am) {
+                }
+                if (amPmCanvas.am !== am) {
                     amPmCanvas.am = am
+                    amPmCanvas.ap = wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP")
                     amPmCanvas.requestPaint()
                 }
             }
@@ -247,7 +213,7 @@ Item {
             var month = wallClock.time.getMonth()
             var date = wallClock.time.getDate()
             var am = hour < 12
-            if(use12H.value) {
+            if (use12H.value) {
                 hour = hour % 12
                 if (hour === 0) hour = 12
             }
@@ -257,12 +223,13 @@ Item {
             minuteCanvas.requestPaint()
             dateCanvas.month = month
             dateCanvas.date = date
+            dateCanvas.dateText = wallClock.time.toLocaleString(Qt.locale(), "d MMM")
             dateCanvas.requestPaint()
             amPmCanvas.am = am
+            amPmCanvas.ap = wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP")
             amPmCanvas.requestPaint()
-
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .1 : .32)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .1 : .7)})
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .1 : .32) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .1 : .7) })
         }
     }
 }

--- a/src/watchfaces/001-words-worte-palabras-mots.qml
+++ b/src/watchfaces/001-words-worte-palabras-mots.qml
@@ -1,37 +1,11 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2021 - Oliver Geneser <olivergeneser@gmail.com>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2014 - Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2021 Oliver Geneser <olivergeneser@gmail.com>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -54,7 +28,6 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
 
@@ -86,6 +59,7 @@ Item {
                     var hoursListmenos = ["<b>doce</b><br>menos", "<b>una</b><br>menos", "<b>dos</b><br>menos", "<b>tres</b><br>menos", "<b>cuatro</b><br>menos", "<b>cinco</b><br>menos", "<b>seis</b><br>menos", "<b>siete</b><br>menos", "<b>ocho</b><br>menos", "<b>nueve</b><br>menos", "<b>diez</b><br>menos", "<b>once</b><br>menos"]
                     var nextHour = [false, false, false, false, false, false, false, true, true, true, true, true, true]
                     var enPunto = [true, false, false, false, false, false, false, false, false, false, false, false, true]
+
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
 
@@ -94,7 +68,6 @@ Item {
                     if (enPunto[minutes]) {
                         var generatedString = hoursList[hours] + newline + minutesList[minutes]
                     } else {
-                        //also use next hour to decide between y or menos
                         if (nextHour[minutes]) {
                             var generatedString = hoursListmenos[hours] + newline + minutesList[minutes]
                         } else {
@@ -105,30 +78,30 @@ Item {
                 }
 
                 function generateTimeDe(time) {
-                    var nextHour   = [false, false, false, false, false, true, true, true, true, true, true, true, true]
+                    var nextHour = [false, false, false, false, false, true, true, true, true, true, true, true, true]
+
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
 
                     var minutesList = ["uhr", "fünf<br>nach", "zehn<br>nach", "viertel<br>nach", "zwanzig<br>nach", "fünf<br>vor halb", "halb", "fünf<br>nach halb", "zwanzig<br>vor", "viertel<br>vor", "zehn<br>vor", "fünf<br>vor", "uhr"]
                     var hoursList = ["<b>zwölf</b>", minutesList[minutes] === "uhr" ? "<b>ein</b>" : "<b>eins</b>", "<b>zwei</b>", "<b>drei</b>", "<b>vier</b>", "<b>fünf</b>", "<b>sechs</b>", "<b>sieben</b>", "<b>acht</b>", "<b>neun</b>", "<b>zehn</b>", "<b>elf</b>"]
                     var minutesFirst = [false, true, true, true, true, true, true, true, true, true, true, true, false]
-                    var hourSuffix = [false, false, false, false ,false, false, false, false, false, false, false, false, false]
+                    var hourSuffix = [false, false, false, false, false, false, false, false, false, false, false, false, false]
 
                     var newline = "<br>"
 
                     if (hourSuffix[minutes]) {
                         if (minutesFirst[minutes]) {
-                            var generatedString = minutesList[minutes] + newline + hoursList[hours] +" uhr"
+                            var generatedString = minutesList[minutes] + newline + hoursList[hours] + " uhr"
                         } else {
-                            var generatedString = hoursList[hours]+ newline + " uhr" + newline + minutesList[minutes]}
+                            var generatedString = hoursList[hours] + newline + " uhr" + newline + minutesList[minutes]
+                        }
                     } else {
-
-                            if (minutesFirst[minutes]) {
-                                var generatedString = minutesList[minutes] + newline + hoursList[hours]
-                            } else {
-                                var generatedString = hoursList[hours] + newline + minutesList[minutes]
-                            }
-
+                        if (minutesFirst[minutes]) {
+                            var generatedString = minutesList[minutes] + newline + hoursList[hours]
+                        } else {
+                            var generatedString = hoursList[hours] + newline + minutesList[minutes]
+                        }
                     }
                     return generatedString
                 }
@@ -202,8 +175,6 @@ Item {
                                   Qt.locale().name.substring(0,2) === "da" ?
                                       generateTimeDa(wallClock.time) :
                                       generateTimeEn(wallClock.time)
-
-
             }
 
             layer.enabled: true
@@ -212,7 +183,7 @@ Item {
                 horizontalOffset: 4
                 verticalOffset: 4
                 radius: 8.0
-                samples: 17
+                samples: 9
                 color: "#60000000"
             }
 
@@ -269,7 +240,8 @@ Item {
                     }
                     visible: nightstandMode.active
                     color: "#ffffffff"
-                    style: Text.Outline; styleColor: "#80000000"
+                    style: Text.Outline
+                    styleColor: "#80000000"
                     text: batteryChargePercentage.percent + "%"
                 }
             }
@@ -282,12 +254,8 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
 
             Repeater {
@@ -301,15 +269,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .024
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -318,7 +286,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -348,8 +316,8 @@ Item {
         }
 
         Component.onCompleted: {
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .2)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .2)})
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .2) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .2) })
         }
     }
 }

--- a/src/watchfaces/002-analog-70s-classic.qml
+++ b/src/watchfaces/002-analog-70s-classic.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -41,18 +26,16 @@ Item {
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
-        property real radian: .01745
-
+        // Hour strokes — static, paints once only
         Canvas {
             id: hourStrokes
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
             visible: !nightstandMode.active
+
             onPaint: {
                 var ctx = getContext("2d")
-
                 ctx.lineWidth = parent.width * .025
                 ctx.strokeStyle = Qt.rgba(1, 1, 1, .9)
                 ctx.shadowColor = Qt.rgba(0, 0, 0, .8)
@@ -61,7 +44,7 @@ Item {
                 ctx.shadowBlur = 2
                 ctx.translate(parent.width / 2, parent.height / 2)
                 for (var i = 0; i < 12; i++) {
-                    if ((i % 3) == 0) {
+                    if ((i % 3) === 0) {
                         ctx.beginPath()
                         ctx.moveTo(0, height * .36)
                         ctx.lineTo(0, height * .46)
@@ -72,16 +55,16 @@ Item {
             }
         }
 
+        // 5-minute strokes — static, paints once only
         Canvas {
             id: min5Strokes
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
             visible: !nightstandMode.active
+
             onPaint: {
                 var ctx = getContext("2d")
-
                 ctx.lineWidth = parent.width * .016
                 ctx.strokeStyle = Qt.rgba(1, 1, 1, .9)
                 ctx.shadowColor = Qt.rgba(0, 0, 0, .8)
@@ -90,8 +73,7 @@ Item {
                 ctx.shadowBlur = 2
                 ctx.translate(parent.width / 2, parent.height / 2)
                 for (var i = 0; i < 12; i++) {
-                    if ((i % 3) != 0) {
-
+                    if ((i % 3) !== 0) {
                         ctx.beginPath()
                         ctx.moveTo(0, height * .41)
                         ctx.lineTo(0, height * .46)
@@ -102,13 +84,14 @@ Item {
             }
         }
 
+        // Minute strokes — static, paints once only
         Canvas {
             id: minuteStrokes
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
             visible: !nightstandMode.active
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.lineWidth = parent.width * .008
@@ -119,14 +102,13 @@ Item {
                 ctx.shadowBlur = 1
                 ctx.translate(parent.width / 2, parent.height / 2)
                 for (var i = 0; i < 60; i++) {
-                    // do not paint a minute stroke when there is an hour stroke
-                    if ((i % 5) != 0) {
+                    if ((i % 5) !== 0) {
                         ctx.beginPath()
                         ctx.moveTo(0, height * .41)
                         ctx.lineTo(0, height * .46)
                         ctx.stroke()
                     }
-                    ctx.rotate(Math.PI/30)
+                    ctx.rotate(Math.PI / 30)
                 }
             }
         }
@@ -134,18 +116,19 @@ Item {
         Text {
             id: dayDisplay
 
-            property real offset: height * .5
-
-            visible: !nightstandMode.active
-            font.pixelSize: parent.height / 24
-            color: Qt.rgba(1, 1, 1, .7)
-            font.family: "League Spartan"
-            horizontalAlignment: Text.AlignHCenter
-            style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, .4)
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 verticalCenter: parent.verticalCenter
                 verticalCenterOffset: -parent.height * .23
+            }
+            visible: !nightstandMode.active
+            horizontalAlignment: Text.AlignHCenter
+            color: Qt.rgba(1, 1, 1, .7)
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .4)
+            font {
+                pixelSize: parent.height / 24
+                family: "League Spartan"
             }
             text: Qt.formatDate(wallClock.time, "dddd").toUpperCase()
         }
@@ -153,41 +136,40 @@ Item {
         Text {
             id: digitalDisplay
 
-            property real offset: height * .6
-
-            visible: !nightstandMode.active
-            color: Qt.rgba(1, 1, 1, .7)
-            horizontalAlignment: Text.AlignHCenter
-            style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, .4)
-            font {
-                pixelSize: parent.height / 14
-                family: "League Spartan"
-            }
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: dayDisplay.bottom
                 topMargin: parent.height * .0156
             }
-            text: if (use12H.value) {
-                      wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) + wallClock.time.toLocaleString(Qt.locale(), ":mm") }
-                  else
-                      wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
+            visible: !nightstandMode.active
+            horizontalAlignment: Text.AlignHCenter
+            color: Qt.rgba(1, 1, 1, .7)
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .4)
+            font {
+                pixelSize: parent.height / 14
+                family: "League Spartan"
+            }
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) +
+                                 wallClock.time.toLocaleString(Qt.locale(), ":mm") :
+                                 wallClock.time.toLocaleString(Qt.locale(), "HH:mm")
         }
 
         Text {
             id: dateDisplay
 
-            color: Qt.rgba(1, 1, 1, .7)
-            horizontalAlignment: Text.AlignHCenter
-            style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, .4)
-            font {
-                pixelSize: parent.height / 10
-                family: "League Spartan"
-            }
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 verticalCenter: parent.verticalCenter
                 verticalCenterOffset: parent.height * .164
+            }
+            horizontalAlignment: Text.AlignHCenter
+            color: Qt.rgba(1, 1, 1, .7)
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .4)
+            font {
+                pixelSize: parent.height / 10
+                family: "League Spartan"
             }
             text: Qt.formatDate(wallClock.time, "d").toUpperCase()
         }
@@ -195,16 +177,17 @@ Item {
         Text {
             id: monthDisplay
 
-            color: Qt.rgba(1, 1, 1, .7)
-            horizontalAlignment: Text.AlignHCenter
-            style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, .4)
-            font {
-                pixelSize: parent.height / 20
-                family: "League Spartan"
-            }
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: dateDisplay.bottom
+            }
+            horizontalAlignment: Text.AlignHCenter
+            color: Qt.rgba(1, 1, 1, .7)
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .4)
+            font {
+                pixelSize: parent.height / 20
+                family: "League Spartan"
             }
             text: Qt.formatDate(wallClock.time, "MMMM").toUpperCase()
         }
@@ -216,13 +199,14 @@ Item {
                 centerIn: parent
                 verticalCenterOffset: -parent.width * .18
             }
+            visible: nightstandMode.active
+            color: segmentedArc.colorArray[segmentedArc.chargecolor]
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .4)
             font {
                 pixelSize: parent.width / 11
                 family: "League Spartan"
             }
-            visible: nightstandMode.active
-            color: segmentedArc.colorArray[segmentedArc.chargecolor]
-            style: Text.Outline; styleColor: Qt.rgba(0, 0, 0, .4)
             text: batteryChargePercentage.percent
         }
 
@@ -230,15 +214,16 @@ Item {
             id: hourHand
 
             property int hour: 0
-            property real rotH: (hour - 3 + wallClock.time.getMinutes() / 60) / 12
+            property int minute: 0
+            property real rotH: (hour - 3 + minute / 60) / 12
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
-                ctx.lineCap="round"
+                ctx.lineCap = "round"
                 ctx.beginPath()
                 ctx.shadowColor = Qt.rgba(0, 0, 0, .8)
                 ctx.shadowOffsetX = 2
@@ -246,8 +231,7 @@ Item {
                 ctx.shadowBlur = 3
                 ctx.lineWidth = parent.width * .034
                 ctx.strokeStyle = Qt.rgba(1, 1, 1, 1)
-                ctx.moveTo(parent.width / 2,
-                           parent.height / 2)
+                ctx.moveTo(parent.width / 2, parent.height / 2)
                 ctx.lineTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * .227,
                            parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * .227)
                 ctx.stroke()
@@ -257,7 +241,7 @@ Item {
                 ctx.shadowOffsetX = 0
                 ctx.shadowOffsetY = 0
                 ctx.shadowBlur = 0
-                ctx.lineWidth = parent.width*.015
+                ctx.lineWidth = parent.width * .015
                 ctx.strokeStyle = Qt.rgba(0, 0, 0, 1)
                 ctx.moveTo(parent.width / 2 + Math.cos(rotH * 2 * Math.PI) * width * .10,
                            parent.height / 2 + Math.sin(rotH * 2 * Math.PI) * width * .10)
@@ -275,12 +259,12 @@ Item {
             property real rotM: (minute - 15) / 60
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
-                ctx.lineCap="round"
+                ctx.lineCap = "round"
                 ctx.beginPath()
                 ctx.shadowColor = Qt.rgba(0, 0, 0, .8)
                 ctx.shadowOffsetX = 1
@@ -288,13 +272,10 @@ Item {
                 ctx.shadowBlur = 3
                 ctx.lineWidth = parent.width * .034
                 ctx.strokeStyle = Qt.rgba(1, 1, 1, 1)
-                //circle in center
                 ctx.arc(parent.width / 2, parent.height / 2, parent.height * .014, 0, 2 * Math.PI, false)
-                ctx.moveTo(parent.width / 2,
-                           parent.height / 2)
-                //outer line
+                ctx.moveTo(parent.width / 2, parent.height / 2)
                 ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * .327,
-                        parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * .327)
+                           parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * .327)
                 ctx.stroke()
                 ctx.closePath()
                 ctx.lineWidth = parent.width * .015
@@ -304,11 +285,10 @@ Item {
                 ctx.shadowOffsetX = 0
                 ctx.shadowOffsetY = 0
                 ctx.shadowBlur = 0
-                //inner line
                 ctx.moveTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * .17,
                            parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * .17)
                 ctx.lineTo(parent.width / 2 + Math.cos(rotM * 2 * Math.PI) * width * .324,
-                        parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * .324)
+                           parent.height / 2 + Math.sin(rotM * 2 * Math.PI) * width * .324)
                 ctx.stroke()
                 ctx.closePath()
             }
@@ -320,9 +300,9 @@ Item {
             property int second: 0
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
             visible: !displayAmbient
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
@@ -331,11 +311,11 @@ Item {
                 ctx.shadowOffsetY = 1
                 ctx.shadowBlur = 2
                 ctx.strokeStyle = "red"
-                ctx.lineWidth = parent.height*.008
+                ctx.lineWidth = parent.height * .008
                 ctx.beginPath()
-                ctx.moveTo(parent.width/2, parent.height/2)
+                ctx.moveTo(parent.width / 2, parent.height / 2)
                 ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .1,
-                        parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .1)
+                           parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .1)
                 ctx.stroke()
                 ctx.closePath()
                 ctx.beginPath()
@@ -344,18 +324,19 @@ Item {
                 ctx.fill()
                 ctx.moveTo(parent.width / 2, parent.height / 2)
                 ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * .32,
-                        parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .32)
+                           parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .32)
                 ctx.stroke()
                 ctx.closePath()
             }
         }
 
+        // Static center nail dot — paints once only
         Canvas {
             id: nailDot
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
@@ -378,13 +359,9 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Repeater {
                 id: segmentedArc
@@ -397,15 +374,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .028
                 property real scalefactor: .42 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -414,7 +391,7 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -441,32 +418,39 @@ Item {
                 var hour = wallClock.time.getHours()
                 var minute = wallClock.time.getMinutes()
                 var second = wallClock.time.getSeconds()
-                if(secondHand.second !== second) {
+                if (secondHand.second !== second) {
                     secondHand.second = second
                     secondHand.requestPaint()
-                }if(hourHand.hour !== hour) {
+                }
+                if (hourHand.hour !== hour) {
                     hourHand.hour = hour
-                }if(minuteHand.minute !== minute) {
+                }
+                if (minuteHand.minute !== minute) {
                     minuteHand.minute = minute
+                    hourHand.minute = minute
                     minuteHand.requestPaint()
                     hourHand.requestPaint()
                 }
             }
-         }
+        }
 
-         Component.onCompleted: {
-             var hour = wallClock.time.getHours()
-             var minute = wallClock.time.getMinutes()
-             var second = wallClock.time.getSeconds()
-             secondHand.second = second
-             secondHand.requestPaint()
-             minuteHand.minute = minute
-             minuteHand.requestPaint()
-             hourHand.hour = hour
-             hourHand.requestPaint()
-             burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .12 : .07)})
-             burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .12 : .07)})
-         }
+        Component.onCompleted: {
+            var hour = wallClock.time.getHours()
+            var minute = wallClock.time.getMinutes()
+            var second = wallClock.time.getSeconds()
+            secondHand.second = second
+            secondHand.requestPaint()
+            minuteHand.minute = minute
+            minuteHand.requestPaint()
+            hourHand.hour = hour
+            hourHand.minute = minute
+            hourHand.requestPaint()
+            hourStrokes.requestPaint()
+            min5Strokes.requestPaint()
+            minuteStrokes.requestPaint()
+            nailDot.requestPaint()
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .12 : .07) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .12 : .07) })
+        }
     }
-
 }

--- a/src/watchfaces/003-alternative-digital-2.qml
+++ b/src/watchfaces/003-alternative-digital-2.qml
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -41,15 +15,14 @@ Item {
     anchors.fill: parent
 
     function twoDigits(x) {
-        if (x < 10) return "0" + x;
-        else      return x;
+        return x < 10 ? "0" + x : "" + x
     }
 
     function prepareContext(ctx) {
         ctx.reset()
         ctx.fillStyle = "white"
         ctx.textAlign = "center"
-        ctx.textBaseline = 'middle';
+        ctx.textBaseline = "middle"
         ctx.shadowColor = Qt.rgba(0, 0, 0, .80)
         ctx.shadowOffsetX = parent.height * .00625
         ctx.shadowOffsetY = parent.height * .00625
@@ -67,109 +40,97 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
 
             Canvas {
                 id: hourCanvas
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
 
                 property int hour: 0
+
+                anchors.fill: parent
+                renderStrategy: Canvas.Cooperative
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-
-                    ctx.font = "60 " + parent.height*.39 + "px Roboto"
+                    ctx.font = "60 " + parent.height * .39 + "px Roboto"
                     ctx.fillText(twoDigits(hour),
                                  parent.width * .5,
-                                 parent.height * .34);
+                                 parent.height * .34)
                 }
             }
 
             Canvas {
                 id: minuteCanvas
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-
                 property int minute: 0
+
+                anchors.fill: parent
+                renderStrategy: Canvas.Cooperative
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-
                     ctx.font = "26 " + parent.height * .38 + "px Roboto"
                     ctx.fillText(twoDigits(minute),
                                  parent.width * .5,
-                                 parent.height * .74);
+                                 parent.height * .74)
                 }
             }
 
             Canvas {
                 id: dateCanvas
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-                visible: !nightstandMode.active
-
                 property int month: 0
                 property int date: 0
+
+                anchors.fill: parent
+                renderStrategy: Canvas.Cooperative
+                visible: !nightstandMode.active
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625 //2 px on 320x320
+                    ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "left"
                     ctx.textBaseline = "left"
                     ctx.font = "60 " + parent.height * .09 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "dd"),
+                    ctx.fillText(twoDigits(date),
                                  parent.width / 10 * 1.75,
-                                 parent.height * .505);
+                                 parent.height * .505)
                 }
             }
 
             Canvas {
                 id: monthCanvas
 
+                property int month: 0
+                property string monthName: ""
+
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
                 visible: !nightstandMode.active
-
-                property int month: 0
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625 //2 px on 320x320
+                    ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "center"
-                    ctx.font = "40 " +parent.height * .07 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "MMMM").toUpperCase(),
-                                 parent.width / 2,
-                                 parent.height * .509);
+                    ctx.font = "40 " + parent.height * .07 + "px Raleway"
+                    ctx.fillText(monthName, parent.width / 2, parent.height * .509)
                 }
             }
 
             Canvas {
                 id: amPmCanvas
 
+                property bool am: false
+                property string apText: ""
+
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
                 visible: use12H.value && !nightstandMode.active
-
-                property bool am: false
 
                 onPaint: {
                     var ctx = getContext("2d")
@@ -177,23 +138,19 @@ Item {
                     ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "right"
                     ctx.textBaseline = "right"
-                    ctx.font = "72 " +parent.height * .072 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP").slice(0, 2),
-                                 parent.width / 10 * 8.3,
-                                 parent.height * .509);
+                    ctx.font = "72 " + parent.height * .072 + "px Raleway"
+                    ctx.fillText(apText, parent.width / 10 * 8.3, parent.height * .509)
                 }
             }
 
             Canvas {
                 id: secondCanvas
 
+                property int second: 0
+
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
                 visible: !use12H.value && !displayAmbient && !nightstandMode.active
-
-                property int second: 0
 
                 onPaint: {
                     var ctx = getContext("2d")
@@ -201,10 +158,10 @@ Item {
                     ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "right"
                     ctx.textBaseline = "right"
-                    ctx.font = "60 " +parent.height * .08 + "px Roboto"
+                    ctx.font = "60 " + parent.height * .08 + "px Roboto"
                     ctx.fillText(twoDigits(second),
                                  parent.width / 10 * 8.1,
-                                 parent.height * .506);
+                                 parent.height * .506)
                 }
             }
         }
@@ -216,13 +173,9 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Repeater {
                 id: segmentedArc
@@ -235,15 +188,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .05
                 property real scalefactor: .46 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -252,7 +205,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -273,34 +226,6 @@ Item {
             id: batteryChargePercentage
         }
 
-        Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var second = wallClock.time.getSeconds()
-            var month = wallClock.time.getMonth()
-            var date = wallClock.time.getDate()
-            var am = hour < 12
-            if(use12H.value) {
-                hour = hour % 12
-                if (hour === 0) hour = 12
-            }
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            secondCanvas.second = second
-            secondCanvas.requestPaint()
-            dateCanvas.date = date
-            dateCanvas.month = month
-            dateCanvas.requestPaint()
-            monthCanvas.month = month
-            monthCanvas.requestPaint()
-            amPmCanvas.am = am
-            amPmCanvas.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .2)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .2)})
-        }
-
         Connections {
             target: wallClock
             function onTimeChanged() {
@@ -310,28 +235,33 @@ Item {
                 var month = wallClock.time.getMonth()
                 var date = wallClock.time.getDate()
                 var am = hour < 12
-                if(use12H.value) {
+                if (use12H.value) {
                     hour = hour % 12
-                    if (hour === 0) hour = 12;
+                    if (hour === 0) hour = 12
                 }
-                if(hourCanvas.hour !== hour) {
+                if (hourCanvas.hour !== hour) {
                     hourCanvas.hour = hour
                     hourCanvas.requestPaint()
-                } if(minuteCanvas.minute !== minute) {
+                }
+                if (minuteCanvas.minute !== minute) {
                     minuteCanvas.minute = minute
                     minuteCanvas.requestPaint()
-                } if(secondCanvas.second !== second) {
+                }
+                if (secondCanvas.second !== second) {
                     secondCanvas.second = second
                     secondCanvas.requestPaint()
-                } if(dateCanvas.date !== date || dateCanvas.month !== month) {
+                }
+                if (dateCanvas.date !== date || dateCanvas.month !== month) {
                     dateCanvas.month = month
                     dateCanvas.date = date
                     dateCanvas.requestPaint()
-                } if(monthCanvas.month !== month) {
                     monthCanvas.month = month
+                    monthCanvas.monthName = wallClock.time.toLocaleString(Qt.locale(), "MMMM").toUpperCase()
                     monthCanvas.requestPaint()
-                } if(amPmCanvas.am != am) {
+                }
+                if (amPmCanvas.am !== am) {
                     amPmCanvas.am = am
+                    amPmCanvas.apText = wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP").slice(0, 2)
                     amPmCanvas.requestPaint()
                 }
             }
@@ -347,6 +277,36 @@ Item {
                 monthCanvas.requestPaint()
                 amPmCanvas.requestPaint()
             }
+        }
+
+        Component.onCompleted: {
+            var hour = wallClock.time.getHours()
+            var minute = wallClock.time.getMinutes()
+            var second = wallClock.time.getSeconds()
+            var month = wallClock.time.getMonth()
+            var date = wallClock.time.getDate()
+            var am = hour < 12
+            if (use12H.value) {
+                hour = hour % 12
+                if (hour === 0) hour = 12
+            }
+            hourCanvas.hour = hour
+            hourCanvas.requestPaint()
+            minuteCanvas.minute = minute
+            minuteCanvas.requestPaint()
+            secondCanvas.second = second
+            secondCanvas.requestPaint()
+            dateCanvas.date = date
+            dateCanvas.month = month
+            dateCanvas.requestPaint()
+            monthCanvas.month = month
+            monthCanvas.monthName = wallClock.time.toLocaleString(Qt.locale(), "MMMM").toUpperCase()
+            monthCanvas.requestPaint()
+            amPmCanvas.am = am
+            amPmCanvas.apText = wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP").slice(0, 2)
+            amPmCanvas.requestPaint()
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .2) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .2) })
         }
     }
 }

--- a/src/watchfaces/004-alternative-scifi.qml
+++ b/src/watchfaces/004-alternative-scifi.qml
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -41,8 +15,7 @@ Item {
     anchors.fill: parent
 
     function twoDigits(x) {
-        if (x<10) return "0"+x;
-        else      return x;
+        return x < 10 ? "0" + x : "" + x
     }
 
     function prepareContext(ctx) {
@@ -65,12 +38,13 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
 
             Canvas {
                 id: dowCanvas
+
+                property string dow: ""
 
                 anchors.fill: parent
                 renderStrategy: Canvas.Cooperative
@@ -81,21 +55,8 @@ Item {
                     ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "center"
                     ctx.textBaseline = "middle"
-
-                    var bold = "0 "
-                    var px = "px "
-
-                    var centerX = width * .373
-                    var centerY = height / 2 * .57
-                    var verticalOffset = height * .05
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
-
-                    var fontSize = height * .051
-                    var fontFamily = "Xolonium"
-                    ctx.font = bold + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                    ctx.font = "0 " + height * .051 + "px Xolonium"
+                    ctx.fillText(dow, width * .373, height / 2 * .57 + height * .05)
                 }
             }
 
@@ -112,21 +73,8 @@ Item {
                     prepareContext(ctx)
                     ctx.textAlign = "right"
                     ctx.textBaseline = "right"
-
-                    var bold = "60 "
-                    var px = "px "
-
-                    var centerX = width / 2 * 1.25
-                    var centerY = height / 2
-                    var verticalOffset = height * .12
-
-                    var text;
-                    text = twoDigits(hour)
-
-                    var fontSize = height * .36
-                    var fontFamily = "Xolonium"
-                    ctx.font = bold + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                    ctx.font = "60 " + height * .36 + "px Xolonium"
+                    ctx.fillText(twoDigits(hour), width / 2 * 1.25, height / 2 + height * .12)
                 }
             }
 
@@ -144,28 +92,15 @@ Item {
                     ctx.shadowBlur = 3
                     ctx.textAlign = "left"
                     ctx.textBaseline = "left"
-
-                    var thin = "0 "
-                    var px = "px "
-
-                    var centerX = width / 2 * 1.268
-                    var centerY = height / 2
-                    var verticalOffset = height * .112
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale(), "mm")
-
-                    var fontSize = height * .17
-                    var fontFamily = "Xolonium"
-                    ctx.font = thin + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                    ctx.font = "0 " + height * .17 + "px Xolonium"
+                    ctx.fillText(twoDigits(minute), width / 2 * 1.268, height / 2 + height * .112)
                 }
             }
 
             Canvas {
                 id: amPmCanvas
 
-                property bool am: false
+                property string ap: ""
 
                 anchors.fill: parent
                 renderStrategy: Canvas.Cooperative
@@ -173,54 +108,30 @@ Item {
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-                    ctx.shadowBlur = parent.height*.00625 //2 px on 320x320
+                    ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "left"
                     ctx.textBaseline = "left"
-
-                    var bold = "64 "
-                    var px = "px "
-
-                    var centerX = width / 2 * 1.29
-                    var centerY = height / 2 * .83
-                    var verticalOffset = height * .05
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toUpperCase()
-
-                    var fontSize = height * .057
-                    var fontFamily = "Xolonium"
-                    ctx.font = bold + fontSize + px + fontFamily;
-                    if(use12H.value) ctx.fillText(text, centerX, centerY + verticalOffset);
+                    ctx.font = "64 " + height * .057 + "px Xolonium"
+                    if (use12H.value) ctx.fillText(ap, width / 2 * 1.29, height / 2 * .83 + height * .05)
                 }
             }
 
             Canvas {
                 id: dateCanvas
 
+                property string date: ""
+
                 anchors.fill: parent
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
                     var ctx = getContext("2d")
                     prepareContext(ctx)
-                    ctx.shadowBlur = parent.height*.00625
+                    ctx.shadowBlur = parent.height * .00625
                     ctx.textAlign = "center"
                     ctx.textBaseline = "middle"
-
-                    var thin = "0 "
-                    var px = "px "
-
-                    var centerX = width * .626
-                    var centerY = height / 2 * 1.27
-                    var verticalOffset = height * .05
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale(), "dd MMMM").toUpperCase()
-
-                    var fontSize = height * .051
-                    var fontFamily = "Xolonium"
-                    ctx.font = thin + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                    ctx.font = "0 " + height * .051 + "px Xolonium"
+                    ctx.fillText(date, width * .626, height / 2 * 1.27 + height * .05)
                 }
             }
         }
@@ -232,27 +143,20 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .024
                 property real scalefactor: .42 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -261,7 +165,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -282,14 +186,15 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: -parent.width * .3
                 }
+                visible: nightstandMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
+                style: Text.Outline
+                styleColor: "#80000000"
                 font {
                     pixelSize: parent.width / 20
                     family: "Xolonium"
                     styleName: "Bold"
                 }
-                visible: nightstandMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
                 text: batteryChargePercentage.percent + "%"
             }
         }
@@ -298,47 +203,30 @@ Item {
             id: batteryChargePercentage
         }
 
-        Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var am = hour < 12
-            if(use12H.value) {
-                hour = hour % 12
-                if (hour === 0) hour = 12
-            }
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            dateCanvas.requestPaint()
-            dowCanvas.requestPaint()
-            amPmCanvas.am = am
-            amPmCanvas.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .12 : .2)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .12 : .2)})
-        }
-
         Connections {
             target: wallClock
             function onTimeChanged() {
                 var hour = wallClock.time.getHours()
                 var minute = wallClock.time.getMinutes()
-                var date = wallClock.time.getDate()
-                var am = hour < 12
-                if(use12H.value) {
+                if (use12H.value) {
                     hour = hour % 12
-                    if (hour === 0) hour = 12;
+                    if (hour === 0) hour = 12
                 }
-                if(hourCanvas.hour !== hour) {
+                if (hourCanvas.hour !== hour) {
                     hourCanvas.hour = hour
                     hourCanvas.requestPaint()
-                } if(minuteCanvas.minute !== minute) {
+                }
+                if (minuteCanvas.minute !== minute) {
                     minuteCanvas.minute = minute
                     minuteCanvas.requestPaint()
-                    dateCanvas.requestPaint()
+                    dowCanvas.dow = wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
                     dowCanvas.requestPaint()
-                } if(amPmCanvas.am != am) {
-                    amPmCanvas.am = am
+                    dateCanvas.date = wallClock.time.toLocaleString(Qt.locale(), "dd MMMM").toUpperCase()
+                    dateCanvas.requestPaint()
+                }
+                var ap = wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toUpperCase()
+                if (amPmCanvas.ap !== ap) {
+                    amPmCanvas.ap = ap
                     amPmCanvas.requestPaint()
                 }
             }
@@ -353,6 +241,27 @@ Item {
                 dowCanvas.requestPaint()
                 amPmCanvas.requestPaint()
             }
+        }
+
+        Component.onCompleted: {
+            var hour = wallClock.time.getHours()
+            var minute = wallClock.time.getMinutes()
+            if (use12H.value) {
+                hour = hour % 12
+                if (hour === 0) hour = 12
+            }
+            hourCanvas.hour = hour
+            hourCanvas.requestPaint()
+            minuteCanvas.minute = minute
+            minuteCanvas.requestPaint()
+            dowCanvas.dow = wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
+            dowCanvas.requestPaint()
+            dateCanvas.date = wallClock.time.toLocaleString(Qt.locale(), "dd MMMM").toUpperCase()
+            dateCanvas.requestPaint()
+            amPmCanvas.ap = wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toUpperCase()
+            amPmCanvas.requestPaint()
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .12 : .2) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .12 : .2) })
         }
     }
 }

--- a/src/watchfaces/005-analog-circle-shades.qml
+++ b/src/watchfaces/005-analog-circle-shades.qml
@@ -1,28 +1,12 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtGraphicalEffects 1.15
@@ -49,14 +33,9 @@ Item {
             id: batterySegments
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: !displayAmbient || nightstand
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(root.width * 2, root.height * 2)
-            }
 
             Repeater {
                 id: segmentedArc
@@ -82,7 +61,7 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -104,137 +83,82 @@ Item {
 
             anchors.fill: root
 
+            // second hand has no layer — continuous 60fps rotation would force constant recomposite
             Image {
                 id: secondSVG
 
+                anchors.fill: handBox
                 visible: !displayAmbient
                 source: imgPath + "second.svg"
-                anchors.fill: handBox
 
                 transform: Rotation {
+                    id: secondRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getSeconds() * 6)
-
-                    Behavior on angle {
-                        enabled: !displayAmbient
-
-                        RotationAnimation {
-                            duration: 1000
-                            direction: RotationAnimation.Clockwise
-                        }
-                    }
-                }
-
-                layer {
-                    enabled: true
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 0
-                        verticalOffset: 0
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .8)
-                    }
                 }
             }
 
             Text {
                 id: secondDisplay
 
-                property real rotM: ((wallClock.time.getSeconds() - 15) / 60)
-                property real centerX: parent.width / 2 - width / 1.9
-                property real centerY: parent.height / 2 - height / 2.06
-
                 visible: !displayAmbient
-
-                font{
+                color: "white"
+                font {
                     pixelSize: parent.height * .082
                     family: "Roboto Flex"
                     letterSpacing: -parent.height * .005
-                }
-                color: "white"
-                x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .366
-                y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.height * .366
-                text: wallClock.time.toLocaleString(Qt.locale(), "ss")
-
-                Behavior on x {
-                    enabled: !displayAmbient
-
-                    NumberAnimation {
-                        duration: 1000
-                    }
-                }
-
-                Behavior on y {
-                    enabled: !displayAmbient
-
-                    NumberAnimation {
-                        duration: 1000
-                    }
                 }
             }
 
             Image {
                 id: minuteSVG
 
-                source: imgPath + "minute.svg"
                 anchors.fill: handBox
+                source: imgPath + "minute.svg"
 
                 transform: Rotation {
+                    id: minuteRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
                 }
 
-                layer {
-                    enabled: true
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 0
-                        verticalOffset: 0
-                        radius: 15.0
-                        samples: 31
-                        color: Qt.rgba(0, 0, 0, .8)
-                    }
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 0
+                    verticalOffset: 0
+                    radius: 15.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .8)
                 }
             }
 
             Text {
                 id: minuteDisplay
 
-                property real rotM: ((wallClock.time.getMinutes() - 15 + (wallClock.time.getSeconds() / 60)) / 60)
-                property real centerX: parent.width / 2 - width / 1.92
-                property real centerY: parent.height / 2 - height / 2.04
-
-                font{
+                color: "black"
+                font {
                     pixelSize: parent.height * .12
                     family: "Roboto Flex"
                     styleName: "Medium"
                     letterSpacing: -parent.height * .006
                 }
-                color: "black"
-                x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.height * .214
-                y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .214
-                text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
 
             Image {
                 id: hourSVG
 
-                source:imgPath + "hour.svg"
                 anchors.fill: parent
+                source: imgPath + "hour.svg"
 
-                layer {
-                    enabled: true
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 0
-                        verticalOffset: 0
-                        radius: 20.0
-                        samples: 41
-                        color: Qt.rgba(0, 0, 0, .8)
-                    }
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 0
+                    verticalOffset: 0
+                    radius: 20.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .8)
                 }
             }
         }
@@ -247,17 +171,57 @@ Item {
                 verticalCenterOffset: parent.height * .004
                 horizontalCenterOffset: -parent.height * .0012
             }
+            color: "black"
             font {
                 pixelSize: parent.height * .18
                 family: "Roboto Flex"
                 styleName: "Medium"
                 letterSpacing: -parent.height * .005
             }
-            color: "black"
-            text: if (use12H.value) {
-                      wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) }
-                  else
-                      wallClock.time.toLocaleString(Qt.locale(), "HH")
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
+                                 wallClock.time.toLocaleString(Qt.locale(), "HH")
+        }
+
+        // 16ms Timer drives both second hand rotation and orbiting secondDisplay position
+        // using new Date() for millisecond precision — eliminates Behavior catch-up on return
+        Timer {
+            interval: 16
+            repeat: true
+            running: !displayAmbient && visible
+
+            onTriggered: {
+                var now = new Date()
+                var secMs = now.getSeconds() * 1000 + now.getMilliseconds()
+                secondRot.angle = secMs * 6 / 1000
+                var rotS = (secMs / 1000 - 15) / 60
+                secondDisplay.x = root.width / 2 - secondDisplay.width / 1.9 + Math.cos(rotS * 2 * Math.PI) * root.width * .366
+                secondDisplay.y = root.height / 2 - secondDisplay.height / 2.06 + Math.sin(rotS * 2 * Math.PI) * root.height * .366
+            }
+        }
+
+        Connections {
+            target: wallClock
+            function onTimeChanged() {
+                var min = wallClock.time.getMinutes()
+                var sec = wallClock.time.getSeconds()
+                minuteRot.angle = min * 6 + sec * 6 / 60
+                var rotM = (min - 15 + sec / 60) / 60
+                minuteDisplay.x = root.width / 2 - minuteDisplay.width / 1.92 + Math.cos(rotM * 2 * Math.PI) * root.height * .214
+                minuteDisplay.y = root.height / 2 - minuteDisplay.height / 2.04 + Math.sin(rotM * 2 * Math.PI) * root.width * .214
+                minuteDisplay.text = wallClock.time.toLocaleString(Qt.locale(), "mm")
+                secondDisplay.text = wallClock.time.toLocaleString(Qt.locale(), "ss")
+            }
+        }
+
+        Component.onCompleted: {
+            var min = wallClock.time.getMinutes()
+            var sec = wallClock.time.getSeconds()
+            minuteRot.angle = min * 6 + sec * 6 / 60
+            var rotM = (min - 15 + sec / 60) / 60
+            minuteDisplay.x = root.width / 2 - minuteDisplay.width / 1.92 + Math.cos(rotM * 2 * Math.PI) * root.height * .214
+            minuteDisplay.y = root.height / 2 - minuteDisplay.height / 2.04 + Math.sin(rotM * 2 * Math.PI) * root.width * .214
+            minuteDisplay.text = wallClock.time.toLocaleString(Qt.locale(), "mm")
+            secondDisplay.text = wallClock.time.toLocaleString(Qt.locale(), "ss")
         }
     }
 }

--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -1,27 +1,12 @@
-﻿/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+﻿// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -38,9 +23,6 @@ Item {
 
     property string imgPath: "../watchfaces-img/analog-weather-satellite-"
 
-    // Radian per degree used by all canvas arcs
-    property real rad: .01745
-
     // Element sizes, positioning, linewidth and opacity
     property real switchSize: root.width * .1375
     property real boxSize: root.width * .35
@@ -54,22 +36,18 @@ Item {
     property real inactiveContentOpacity: !displayAmbient ? .5 : .3
 
     // Color definition
-    property string customRed: "#DB5461" // Indian Red
-    property string customBlue: "#1E96FC" // Dodger Blue
-    property string customGreen: "#26C485" // Ocean Green
-    property string customOrange: "#FFC600" // Mikado Yellow
-    property string boxColor: "#E8DCB9" // Dutch White
-    property string switchColor: "#A2D6F9" // Uranian Blue
+    property string customRed: "#DB5461"
+    property string customBlue: "#1E96FC"
+    property string customGreen: "#26C485"
+    property string customOrange: "#FFC600"
+    property string boxColor: "#E8DCB9"
+    property string switchColor: "#A2D6F9"
 
-    // Set day to use in the weatherBox to today.
     property int dayNb: 0
 
     function kelvinToTemperatureString(kelvin) {
-        var celsius = (kelvin - 273);
-        if(!useFahrenheit.value)
-            return celsius + "°";
-        else
-            return Math.round(((celsius) * 9 / 5) + 32) + "°";
+        var celsius = kelvin - 273
+        return !useFahrenheit.value ? celsius + "°" : Math.round((celsius * 9 / 5) + 32) + "°"
     }
 
     Item {
@@ -78,8 +56,6 @@ Item {
         anchors.centerIn: parent
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
-
-
 
         MceBatteryState {
             id: batteryChargeState
@@ -96,23 +72,18 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: root
+            layer.enabled: true
+            layer.samples: 4
             visible: dockMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(dockMode.width * 2, dockMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: 0.016
                 property real scalefactor: 0.39 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: dockMode
 
@@ -123,7 +94,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: width / 2
-                    startY: height * ( 0.5 - chargeArc.scalefactor)
+                    startY: height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: dockMode.width / 2
@@ -144,14 +115,15 @@ Item {
                     centerIn: dockMode
                     verticalCenterOffset: dockMode.width * 0.22
                 }
+                visible: dockMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
+                style: Text.Outline
+                styleColor: "#80000000"
                 font {
                     pixelSize: dockMode.width * .15
                     family: "Noto Sans"
                     styleName: "Condensed Light"
                 }
-                visible: dockMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
                 text: batteryChargePercentage.percent
             }
         }
@@ -161,79 +133,69 @@ Item {
 
             anchors.fill: parent
 
-            // Slight dropshadow under all Items.
             layer.enabled: true
             layer.effect: DropShadow {
                 transparentBorder: true
                 horizontalOffset: 1
                 verticalOffset: 1
                 radius: 6.0
-                samples: 13
+                samples: 9
                 color: Qt.rgba(0, 0, 0, .7)
             }
 
             Repeater {
-                    model: 60
+                model: 60
+                Rectangle {
+                    property real rotM: (index - 15) / 60
+                    property real centerX: root.width / 2 - width / 2
+                    property real centerY: root.height / 2 - height / 2
 
-                    Rectangle {
-                        id: minuteStrokes
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
+                    visible: index % 5
+                    antialiasing: true
+                    color: "#55ffffff"
+                    width: root.width * .005
+                    height: root.height * .018
 
-                        property real rotM: (index - 15) / 60
-                        property real centerX: root.width / 2 - width / 2
-                        property real centerY: root.height / 2 - height / 2
-
-                        x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
-                        y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
-                        visible: index % 5
-                        antialiasing: true
-                        color: "#55ffffff"
-                        width: root.width * .005
-                        height: root.height * .018
-                        transform: Rotation {
-                            origin.x: width / 2
-                            origin.y: height / 2
-                            angle: (index) * 6
-                        }
+                    transform: Rotation {
+                        origin.x: width / 2
+                        origin.y: height / 2
+                        angle: index * 6
                     }
                 }
+            }
 
             Repeater {
-                // Hour numerals. hourModeSwitch toggles the 12/24hour display.
                 model: 12
-
                 Text {
-                    id: hourNumbers
-
                     property real rotM: ((index * 5) - 15) / 60
                     property real centerX: root.width / 2 - width / 2
                     property real centerY: root.height / 2 - height / 2
 
-                    antialiasing : true
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
+                    antialiasing: true
+                    color: hourSVG.toggle24h && index === 0 ? customGreen : "white"
+                    opacity: inactiveContentOpacity
                     font {
                         pixelSize: root.height * .06
                         family: "Noto Sans"
                         styleName: "Bold"
                     }
-                    x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
-                    y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
-                    color: hourSVG.toggle24h && index === 0 ? customGreen : "white"
-                    opacity: inactiveContentOpacity
                     text: (index === 0 ? 12 : index)
 
                     transform: Rotation {
                         origin.x: width / 2
                         origin.y: height / 2
-                        angle: index === 6 ?
-                                   0 :
-                                   ([4, 5, 7, 8].includes(index)) ?
-                                       (index * 30) + 180 :
-                                       index * 30
+                        angle: index === 6 ? 0 :
+                               ([4, 5, 7, 8].includes(index)) ? (index * 30) + 180 :
+                               index * 30
                     }
                 }
             }
 
             Item {
-                // Wrapper for digital time related objects. Hour, minute and AP following units setting.
                 id: digitalBox
 
                 anchors {
@@ -252,17 +214,15 @@ Item {
                         rightMargin: digitalBox.width * .01
                         verticalCenter: digitalBox.verticalCenter
                     }
+                    color: "#ccffffff"
                     font {
                         pixelSize: digitalBox.width * .46
                         family: "Noto Sans"
                         styleName: "Regular"
                         letterSpacing: -digitalBox.width * .001
                     }
-                    color: "#ccffffff"
-                    text: if (use12H.value) {
-                              wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2)}
-                          else
-                              wallClock.time.toLocaleString(Qt.locale(), "HH")
+                    text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
+                                        wallClock.time.toLocaleString(Qt.locale(), "HH")
                 }
 
                 Text {
@@ -273,13 +233,13 @@ Item {
                         bottom: digitalHour.bottom
                         leftMargin: digitalBox.width * .01
                     }
+                    color: "#ddffffff"
                     font {
                         pixelSize: digitalBox.width * .46
                         family: "Noto Sans"
                         styleName: "Light"
                         letterSpacing: -digitalBox.width * .001
                     }
-                    color: "#ddffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "mm")
                 }
 
@@ -292,21 +252,18 @@ Item {
                         bottom: digitalMinutes.verticalCenter
                         bottomMargin: -digitalBox.width * .22
                     }
+                    visible: use12H.value
+                    color: "#ddffffff"
                     font {
                         pixelSize: digitalBox.width * 0.14
                         family: "Noto Sans"
                         styleName: "Condensed"
                     }
-                    visible: use12H.value
-                    color: "#ddffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
                 }
             }
 
             Item {
-                // Wrapper for weather related elements. Contains a weatherIcon and maxTemp display.
-                // "No weather data" text is shown when no data is available.
-                // ConfigurationValue depends on Nemo.Configuration 1.0
                 id: weatherBox
 
                 anchors {
@@ -318,14 +275,12 @@ Item {
 
                 ConfigurationValue {
                     id: timestampDay0
-
                     key: "/org/asteroidos/weather/timestamp-day0"
                     defaultValue: 0
                 }
 
                 ConfigurationValue {
                     id: useFahrenheit
-
                     key: "/org/asteroidos/settings/use-fahrenheit"
                     defaultValue: false
                 }
@@ -344,47 +299,44 @@ Item {
 
                 property bool weatherSynced: maxTemp.value != 0
 
-                Canvas {
-                    id: weatherArc
-
-                    anchors.fill: weatherBox
+                // Static background circle for weather box — fill + inner border ring
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: weatherBox.width * 0.86
+                    height: width
+                    radius: width / 2
+                    antialiasing: true
+                    color: "#22ffffff"
+                    border.color: boxColor
+                    border.width: innerArcLineWidth
                     opacity: inactiveArcOpacity
-                    smooth: true
                     visible: !dockMode.active
-                    renderStrategy : Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.lineWidth = outerArcLineWidth
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#33ffffff"
-                        ctx.beginPath()
-                        ctx.arc(weatherBox.width / 2,
-                                weatherBox.height / 2,
-                                weatherBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(weatherBox.width / 2,
-                                weatherBox.height / 2,
-                                weatherBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = boxColor
-                        ctx.lineWidth = innerArcLineWidth
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
+                }
+
+                // Outer ring stroke — static full circle
+                Shape {
+                    anchors.fill: parent
+                    opacity: inactiveArcOpacity
+                    visible: !dockMode.active
+
+                    ShapePath {
+                        strokeColor: "#33ffffff"
+                        strokeWidth: outerArcLineWidth
+                        fillColor: "transparent"
+                        capStyle: ShapePath.RoundCap
+
+                        PathAngleArc {
+                            centerX: weatherBox.width / 2
+                            centerY: weatherBox.height / 2
+                            radiusX: weatherBox.width * .43
+                            radiusY: weatherBox.height * .43
+                            startAngle: -90
+                            sweepAngle: 360
+                        }
                     }
                 }
 
                 Icon {
-                    // WeatherIcons depends on import 'weathericons.js' as WeatherIcons
                     id: iconDisplay
 
                     anchors {
@@ -393,8 +345,8 @@ Item {
                     }
                     width: weatherBox.width * .42
                     height: width
-                    opacity: activeContentOpacity
                     visible: weatherBox.weatherSynced
+                    opacity: activeContentOpacity
                     name: WeatherIcons.getIconName(owmId.value)
                 }
 
@@ -416,12 +368,12 @@ Item {
                         styleName: weatherBox.weatherSynced ? "Medium" : "Bold"
                         pixelSize: weatherBox.width * (weatherBox.weatherSynced ? .30 : .14)
                     }
-                    text: weatherBox.weatherSynced ? kelvinToTemperatureString(maxTemp.value) : "NO<br>WEATHER<br>DATA"
+                    text: weatherBox.weatherSynced ? kelvinToTemperatureString(maxTemp.value) :
+                                                    "NO<br>WEATHER<br>DATA"
                 }
             }
 
             Item {
-                // Wrapper for date related objects, day name, day number and month short code.
                 id: dayBox
 
                 anchors {
@@ -431,42 +383,40 @@ Item {
                 width: boxSize
                 height: width
 
-                Canvas {
-                    id: dayArc
-
-                    anchors.fill: dayBox
+                // Static background circle for day box — fill + inner border ring
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: dayBox.width * 0.86
+                    height: width
+                    radius: width / 2
+                    antialiasing: true
+                    color: "#22ffffff"
+                    border.color: boxColor
+                    border.width: innerArcLineWidth
                     opacity: inactiveArcOpacity
-                    smooth: true
                     visible: !dockMode.active
-                    renderStrategy : Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(dayBox.width / 2,
-                                dayBox.height / 2,
-                                dayBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = boxColor
-                        ctx.lineWidth = innerArcLineWidth
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = outerArcLineWidth
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#33ffffff"
-                        ctx.beginPath()
-                        ctx.arc(dayBox.width / 2,
-                                dayBox.height / 2,
-                                dayBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
+                }
+
+                // Outer ring stroke — static full circle
+                Shape {
+                    anchors.fill: parent
+                    opacity: inactiveArcOpacity
+                    visible: !dockMode.active
+
+                    ShapePath {
+                        strokeColor: "#33ffffff"
+                        strokeWidth: outerArcLineWidth
+                        fillColor: "transparent"
+                        capStyle: ShapePath.RoundCap
+
+                        PathAngleArc {
+                            centerX: dayBox.width / 2
+                            centerY: dayBox.height / 2
+                            radiusX: dayBox.width * .43
+                            radiusY: dayBox.height * .43
+                            startAngle: -90
+                            sweepAngle: 360
+                        }
                     }
                 }
 
@@ -477,29 +427,27 @@ Item {
                         centerIn: dayBox
                         verticalCenterOffset: -dayBox.width * .25
                     }
+                    color: "#ffffffff"
+                    opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
                     font {
                         pixelSize: dayBox.width * .14
                         family: "Barlow"
                         styleName: "Bold"
                     }
-                    color: "#ffffffff"
-                    opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
                     text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 3).toUpperCase()
                 }
 
                 Text {
                     id: dayNumber
 
-                    anchors {
-                        centerIn: dayBox
-                    }
+                    anchors.centerIn: dayBox
+                    color: "#ffffffff"
+                    opacity: activeContentOpacity
                     font {
                         pixelSize: dayBox.width * .38
                         family: "Noto Sans"
                         styleName: "Condensed"
                     }
-                    color: "#ffffffff"
-                    opacity: activeContentOpacity
                     text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
                 }
 
@@ -510,25 +458,21 @@ Item {
                         centerIn: dayBox
                         verticalCenterOffset: dayBox.width * .25
                     }
+                    color: "#ffffffff"
+                    opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
                     font {
                         pixelSize: dayBox.width * .14
                         family: "Barlow"
                         styleName: "Bold"
                     }
-                    color: "#ffffffff"
-                    opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
                     text: wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase()
                 }
             }
 
             Item {
-                // Wrapper for the battery related elements
-                // MceBatteryLevel and MceBatteryState depend on Nemo.Mce 1.0
                 id: batteryBox
 
                 property int value: batteryChargePercentage.percent
-
-                onValueChanged: batteryArc.requestPaint()
 
                 anchors {
                     centerIn: dialBox
@@ -538,76 +482,68 @@ Item {
                 height: width
                 visible: !dockMode.active
 
-                Canvas {
-                    id: batteryArc
+                // Static background circle — fill + inner border ring
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: batteryBox.width * 0.86
+                    height: width
+                    radius: width / 2
+                    antialiasing: true
+                    color: "#22ffffff"
+                    border.color: "#77ffffff"
+                    border.width: innerArcLineWidth
+                    opacity: activeArcOpacity
+                }
 
+                // Battery progress arc — sweepAngle binding updates automatically on battery change
+                Shape {
                     anchors.fill: batteryBox
                     opacity: activeArcOpacity
-                    smooth: true
-                    renderStrategy : Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(batteryBox.width / 2,
-                                batteryBox.height / 2,
-                                batteryBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = innerArcLineWidth
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = outerArcLineWidth
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = batteryBox.value < 30 ?
-                                    customRed :
-                                    batteryBox.value < 60 ?
-                                        customOrange :
-                                        customGreen
-                        ctx.beginPath()
-                        ctx.arc(batteryBox.width / 2,
-                                batteryBox.height / 2,
-                                batteryBox.width * .43,
-                                270 * rad,
-                                ((batteryBox.value/100*360)+270) * rad,
-                                false
-                                );
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    ShapePath {
+                        strokeColor: batteryBox.value < 30 ? customRed :
+                                     batteryBox.value < 60 ? customOrange :
+                                     customGreen
+                        strokeWidth: outerArcLineWidth
+                        fillColor: "transparent"
+                        capStyle: ShapePath.RoundCap
+
+                        PathAngleArc {
+                            centerX: batteryBox.width / 2
+                            centerY: batteryBox.height / 2
+                            radiusX: batteryBox.width * .43
+                            radiusY: batteryBox.height * .43
+                            startAngle: -90
+                            sweepAngle: batteryBox.value / 100 * 360
+                        }
                     }
                 }
 
                 Icon {
                     id: batteryIcon
 
-                    name: "ios-flash"
-                    visible: batteryChargeState.value === MceBatteryState.Charging
                     anchors {
                         centerIn: batteryBox
                         verticalCenterOffset: -batteryBox.height * .26
                     }
+                    visible: batteryChargeState.value === MceBatteryState.Charging
+                    opacity: inactiveContentOpacity
                     width: batteryBox.width * .25
                     height: width
-                    opacity: inactiveContentOpacity
+                    name: "ios-flash"
                 }
 
                 Text {
                     id: batteryDisplay
 
-                    anchors {
-                        centerIn: batteryBox
-                    }
+                    anchors.centerIn: batteryBox
+                    color: "#ffffffff"
+                    opacity: activeContentOpacity
                     font {
                         pixelSize: batteryBox.width * .38
                         family: "Noto Sans"
                         styleName: "Condensed"
                     }
-                    color: "#ffffffff"
-                    opacity: activeContentOpacity
                     text: batteryBox.value
                 }
 
@@ -618,20 +554,19 @@ Item {
                         centerIn: batteryBox
                         verticalCenterOffset: batteryBox.width * .25
                     }
+                    color: "#ffffffff"
+                    opacity: inactiveContentOpacity
                     font {
                         pixelSize: batteryBox.width * .14
                         family: "Barlow"
                         styleName: "Bold"
                     }
-                    color: "#ffffffff"
-                    opacity: inactiveContentOpacity
                     text: "%"
                 }
             }
         }
 
         Item {
-            // Wrapper for the analog hands
             id: handBox
 
             width: root.width
@@ -646,31 +581,22 @@ Item {
                 width: handBox.width
                 height: handBox.height
                 source: imgPath + "hour-12h.svg"
-                antialiasing: true
-                smooth: true
 
                 transform: Rotation {
+                    id: hourRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: hourSVG.toggle24h ?
-                               (wallClock.time.getHours() * 15) + (wallClock.time.getMinutes() * .25) :
-                               (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * .5)
                 }
 
-                layer {
-                    enabled: true
-                    samples: 4
-                    smooth: true
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    // DropShadow depends on import QtGraphicalEffects 1.15
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 3
-                        verticalOffset: 3
-                        radius: 8.0
-                        samples: 17
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                layer.enabled: true
+                layer.samples: 4
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 3
+                    verticalOffset: 3
+                    radius: 8.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
@@ -681,71 +607,72 @@ Item {
                 width: handBox.width
                 height: handBox.height
                 source: imgPath + "minute.svg"
-                antialiasing: true
-                smooth: true
 
                 transform: Rotation {
+                    id: minuteRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
                 }
 
-                layer {
-                    enabled: true
-                    samples: 4
-                    smooth: true
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 5
-                        verticalOffset: 5
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                layer.enabled: true
+                layer.samples: 4
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 5
+                    verticalOffset: 5
+                    radius: 10.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
+            // second hand has no layer — continuous 60fps rotation would force constant recomposite
             Image {
                 id: secondSVG
 
                 anchors.centerIn: handBox
                 width: handBox.width
                 height: handBox.height
-                source: imgPath + "second.svg"
-                antialiasing: true
-                smooth: true
                 visible: !displayAmbient && !dockMode.active
+                source: imgPath + "second.svg"
 
                 transform: Rotation {
+                    id: secondRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: wallClock.time.getSeconds() * 6
-
-                    Behavior on angle {
-                        enabled: !displayAmbient && !nightstand
-                        RotationAnimation {
-                            duration: 1000
-                            direction: RotationAnimation.Clockwise
-                        }
-                    }
-                }
-
-                layer {
-                    enabled: true
-                    samples: 4
-                    smooth: true
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 5
-                        verticalOffset: 5
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
                 }
             }
+        }
+
+        // 16ms sweep timer for continuous second hand — eliminates Behavior catch-up on return
+        Timer {
+            interval: 16
+            repeat: true
+            running: !displayAmbient && !dockMode.active && visible
+
+            onTriggered: {
+                var now = new Date()
+                secondRot.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+            }
+        }
+
+        Connections {
+            target: wallClock
+            function onTimeChanged() {
+                var h = wallClock.time.getHours()
+                var min = wallClock.time.getMinutes()
+                var sec = wallClock.time.getSeconds()
+                hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5
+                minuteRot.angle = min * 6 + sec * 6 / 60
+            }
+        }
+
+        Component.onCompleted: {
+            var h = wallClock.time.getHours()
+            var min = wallClock.time.getMinutes()
+            var sec = wallClock.time.getSeconds()
+            hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5
+            minuteRot.angle = min * 6 + sec * 6 / 60
         }
     }
 }

--- a/src/watchfaces/007-digital-outfit.qml
+++ b/src/watchfaces/007-digital-outfit.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -41,13 +25,9 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: root
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Repeater {
                 id: segmentedArc
@@ -60,15 +40,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .05
                 property real scalefactor: .46 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -77,7 +57,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -113,14 +93,14 @@ Item {
                     verticalCenterOffset: -watchfaceRoot.height * .218
                 }
                 renderType: Text.NativeRendering
+                color: "#ffffff"
+                horizontalAlignment: Text.AlignHCenter
                 font {
                     pixelSize: watchfaceRoot.height * .4
                     letterSpacing: watchfaceRoot.height * .006
                     family: "Outfit"
                     styleName: "Medium"
                 }
-                color: "#ffffff"
-                horizontalAlignment: Text.AlignHCenter
                 text: use12H.value ?
                           wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
                           wallClock.time.toLocaleString(Qt.locale(), "HH")
@@ -151,7 +131,6 @@ Item {
                 id: monthDisplay
 
                 anchors.centerIn: watchfaceRoot
-
                 renderType: Text.NativeRendering
                 color: "#ddffffff"
                 horizontalAlignment: Text.AlignHCenter
@@ -189,7 +168,7 @@ Item {
                 horizontalOffset: 4
                 verticalOffset: 4
                 radius: 7.0
-                samples: 15
+                samples: 9
                 color: "#99000000"
             }
         }

--- a/src/watchfaces/008-numerals-duo-synth-neon-green.qml
+++ b/src/watchfaces/008-numerals-duo-synth-neon-green.qml
@@ -1,26 +1,11 @@
-/*
-* Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
-*               2021 - Darrel Griët <dgriet@gmail.com>
-*               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
-*               2015 - Florent Revest <revestflo@gmail.com>
-*               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
-*                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
-*                      Arto Jalkanen <ajalkane@gmail.com>
-* All rights reserved.
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Lesser General Public License as
-* published by the Free Software Foundation, either version 2.1 of the
-* License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+// SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2021 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -45,21 +30,20 @@ Item {
         Text {
             id: dowDisplay
 
-            z: 0
+            anchors {
+                bottom: root.verticalCenter
+                bottomMargin: DeviceSpecs.hasRoundScreen ? root.height * 0.387 : root.height * 0.402
+                horizontalCenter: root.horizontalCenter
+            }
             visible: !displayAmbient
+            color: "white"
+            opacity: 0.95
+            horizontalAlignment: Text.AlignHCenter
             font {
                 pixelSize: root.height * 0.054
                 family: "Sunflower"
                 styleName: "Light"
-                letterSpacing: root.height*0.003
-            }
-            color: "white"
-            opacity: 0.95
-            horizontalAlignment: Text.AlignHCenter
-            anchors {
-                bottom: root.verticalCenter
-                bottomMargin: DeviceSpecs.hasRoundScreen ? root.height*0.387 : root.height*0.402
-                horizontalCenter: root.horizontalCenter
+                letterSpacing: root.height * 0.003
             }
             text: wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
             layer.enabled: true
@@ -68,7 +52,7 @@ Item {
                 horizontalOffset: 0
                 verticalOffset: 3
                 radius: 12.0
-                samples: 16
+                samples: 9
                 color: "#fe16a2"
             }
         }
@@ -76,20 +60,19 @@ Item {
         Text {
             id: dateDisplay
 
-            z: 0
+            anchors {
+                top: root.verticalCenter
+                topMargin: DeviceSpecs.hasRoundScreen ? root.height * 0.394 : root.height * 0.406
+                horizontalCenter: root.horizontalCenter
+            }
             visible: !displayAmbient
+            color: "white"
+            opacity: 0.95
+            horizontalAlignment: Text.AlignHCenter
             font {
                 pixelSize: root.height * 0.056
                 family: "Sunflower"
                 styleName: "Light"
-            }
-            color: "white"
-            opacity: 0.95
-            horizontalAlignment: Text.AlignHCenter
-            anchors {
-                top: root.verticalCenter
-                topMargin: DeviceSpecs.hasRoundScreen ? root.height*0.394 : root.height*0.406
-                horizontalCenter: root.horizontalCenter
             }
             text: wallClock.time.toLocaleString(Qt.locale(), "yyyy-MM-dd")
             layer.enabled: true
@@ -98,16 +81,17 @@ Item {
                 horizontalOffset: 0
                 verticalOffset: -3
                 radius: 12.0
-                samples: 16
+                samples: 9
                 color: "#fe16a2"
             }
         }
 
         Item {
-            x: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
-            y: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
+            x: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width / 2 - length / 2 : !displayAmbient ? length * 0.1 : 0)
+            y: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height / 2 - length / 2 : !displayAmbient ? length * 0.1 : 0)
             width: DeviceSpecs.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
             height: DeviceSpecs.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
+
             Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             Behavior on y { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             Behavior on width { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
@@ -116,7 +100,6 @@ Item {
             LinearGradient {
                 id: greenColor
                 anchors.fill: parent
-                smooth: true
                 visible: false
                 start: Qt.point(0, 0)
                 end: Qt.point(300, 300)
@@ -129,7 +112,6 @@ Item {
             LinearGradient {
                 id: whiteColor
                 anchors.fill: parent
-                smooth: true
                 visible: false
                 start: Qt.point(0, 0)
                 end: Qt.point(300, 300)
@@ -139,46 +121,45 @@ Item {
                 }
             }
 
-           Image {
-               id: topLeft
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width*0.135)
-               y: parseInt(parent.height*0.045)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(0, 1) + ".png"
-           }
-           Image {
-               id: topRight
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width/2 + parent.width*0.03)
-               y: parseInt(parent.height*0.045)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(1, 2) + ".png"
-           }
-           Image {
-               id: bottomLeft
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width*0.135)
-               y: parseInt(parent.height/2 + parent.height*0.025)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(0, 1) + ".png"
-           }
-           Image {
-               id: bottomRight
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width/2 + parent.width*0.03)
-               y: parseInt(parent.height/2 + parent.height*0.025)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(1, 2) + ".png"
-           }
+            Image {
+                id: topLeft
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width * 0.135)
+                y: parseInt(parent.height * 0.045)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(0, 1) + ".png"
+            }
+
+            Image {
+                id: topRight
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width / 2 + parent.width * 0.03)
+                y: parseInt(parent.height * 0.045)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(1, 2) + ".png"
+            }
+
+            Image {
+                id: bottomLeft
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width * 0.135)
+                y: parseInt(parent.height / 2 + parent.height * 0.025)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(0, 1) + ".png"
+            }
+
+            Image {
+                id: bottomRight
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width / 2 + parent.width * 0.03)
+                y: parseInt(parent.height / 2 + parent.height * 0.025)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(1, 2) + ".png"
+            }
 
             OpacityMask {
                 invert: true
@@ -191,10 +172,11 @@ Item {
                     horizontalOffset: 1
                     verticalOffset: 1
                     radius: 12.0
-                    samples: 20
+                    samples: 9
                     color: "#f800ff"
                 }
             }
+
             OpacityMask {
                 invert: true
                 anchors.fill: topRight
@@ -206,10 +188,11 @@ Item {
                     horizontalOffset: -1
                     verticalOffset: 1
                     radius: 12.0
-                    samples: 20
+                    samples: 9
                     color: "#f800ff"
                 }
             }
+
             OpacityMask {
                 invert: true
                 anchors.fill: bottomLeft
@@ -221,10 +204,11 @@ Item {
                     horizontalOffset: -1
                     verticalOffset: -1
                     radius: 12.0
-                    samples: 20
+                    samples: 9
                     color: "#9600ff"
                 }
             }
+
             OpacityMask {
                 invert: true
                 anchors.fill: bottomRight
@@ -236,7 +220,7 @@ Item {
                     horizontalOffset: 1
                     verticalOffset: -1
                     radius: 12.0
-                    samples: 20
+                    samples: 9
                     color: "#9600ff"
                 }
             }

--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -32,7 +17,10 @@ Item {
     anchors.fill: parent
 
     property string imgPath: "../watchfaces-img/analog-scientific-v2-"
+    // rad kept for batteryArc canvas which uses radial gradient — not convertible to PathAngleArc
     property real rad: .01745
+    property int currentMonth: 0
+    property string currentDayName: ""
 
     MceBatteryLevel {
         id: batteryChargePercentage
@@ -42,7 +30,6 @@ Item {
         id: root
 
         anchors.centerIn: parent
-
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
@@ -58,63 +45,54 @@ Item {
                 horizontalOffset: 2
                 verticalOffset: 2
                 radius: 5.0
-                samples: 11
+                samples: 9
                 color: "#99000000"
             }
 
             Repeater {
                 model: 60
-
                 Rectangle {
-                    id: minuteStrokes
-
                     property real rotM: (index - 15) / 60
                     property real centerX: root.width / 2 - width / 2
                     property real centerY: root.height / 2 - height / 2
 
-                    x: index % 5 ? centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * .488 :
-                                   centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * .480
-                    y: index % 5 ? centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * .488 :
-                                   centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * .480
-                    antialiasing : true
+                    x: index % 5 ? centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .488 :
+                                   centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .480
+                    y: index % 5 ? centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .488 :
+                                   centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .480
+                    antialiasing: true
                     color: index % 5 ? "#77ffffff" : "#ffffffff"
                     width: index % 5 ? parent.width * .0066 : parent.width * .009
                     height: index % 5 ? parent.height * .026 : parent.height * .038
+
                     transform: Rotation {
                         origin.x: width / 2
                         origin.y: height / 2
-                        angle: (index) * 6
+                        angle: index * 6
                     }
                 }
             }
 
             Repeater {
                 model: 12
-
                 Text {
-                    id: hourNumbers
-
-                    property real rotM: ((index * 5 ) - 15) / 60
+                    property real rotM: ((index * 5) - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
                     property real centerY: parent.height / 2 - height / 2
 
-                    x: index === 10 ?
-                           centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .378 :
-                           index === 11 ?
-                               centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .388 :
-                               centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .4
-                    y: index === 10 ?
-                           centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .378 :
-                           index === 11 ?
-                               centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .388 :
-                               centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .4
+                    x: index === 10 ? centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .378 :
+                       index === 11 ? centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .388 :
+                                      centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .4
+                    y: index === 10 ? centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .378 :
+                       index === 11 ? centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .388 :
+                                      centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .4
+                    horizontalAlignment: Text.AlignHCenter
+                    color: "#ffffffff"
                     font {
                         pixelSize: parent.height * .088
                         family: "Outfit"
                         styleName: "Regular"
                     }
-                    horizontalAlignment: Text.AlignHCenter
-                    color: "#ffffffff"
                     text: index === 0 ? "12" : index
                 }
             }
@@ -122,16 +100,16 @@ Item {
             Image {
                 id: asteroidLogo
 
-                visible: !displayAmbient
-                source: "../watchfaces-img/asteroid-logo.svg"
-                antialiasing: true
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: -parent.height * .272
                 }
+                visible: !displayAmbient
+                antialiasing: true
+                opacity: .7
                 width: parent.width * .12
                 height: parent.height * .12
-                opacity: .7
+                source: "../watchfaces-img/asteroid-logo.svg"
 
                 Text {
                     id: asteroidSlogan
@@ -140,20 +118,19 @@ Item {
                         centerIn: parent
                         verticalCenterOffset: -parent.height * .005
                     }
+                    visible: !displayAmbient
+                    color: "white"
+                    horizontalAlignment: Text.AlignHCenter
                     font {
                         pixelSize: parent.height * .31
                         family: "Raleway"
                     }
-                    visible: !displayAmbient
-                    color: "white"
-                    horizontalAlignment: Text.AlignHCenter
                     text: "<b>AsteroidOS</b><br>Free Your Wrist"
                 }
+
                 MouseArea {
                     anchors.fill: parent
-                    onPressAndHold: asteroidLogo.visible ?
-                                        asteroidLogo.visible = false :
-                                        asteroidLogo.visible = true
+                    onPressAndHold: asteroidLogo.visible = !asteroidLogo.visible
                 }
             }
 
@@ -166,17 +143,15 @@ Item {
                     verticalCenter: parent.verticalCenter
                     verticalCenterOffset: -parent.width * .124
                 }
+                color: "#bbffffff"
                 font {
                     pixelSize: parent.height * .15
                     family: "Open Sans"
                     styleName: "Regular"
                     letterSpacing: -parent.width * .001
                 }
-                color: "#bbffffff"
-                text: if (use12H.value) {
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2)}
-                      else
-                          wallClock.time.toLocaleString(Qt.locale(), "HH")
+                text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
+                                     wallClock.time.toLocaleString(Qt.locale(), "HH")
             }
 
             Text {
@@ -187,13 +162,13 @@ Item {
                     bottom: digitalDisplay.bottom
                     leftMargin: root.width * .004
                 }
+                color: "#ccffffff"
                 font {
                     pixelSize: root.height * .15
                     family: "Open Sans"
                     styleName: "Light"
                     letterSpacing: -parent.width * .001
                 }
-                color: "#ccffffff"
                 text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
 
@@ -206,22 +181,18 @@ Item {
                     bottom: digitalMinutes.verticalCenter
                     bottomMargin: -parent.width * .012
                 }
+                visible: use12H.value
+                color: "#ddffffff"
                 font {
                     pixelSize: root.height * .06
                     family: "Open Sans Condensed"
                     styleName: "Regular"
                 }
-                visible: use12H.value
-                color: "#ddffffff"
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
             }
 
             Item {
                 id: dayBox
-
-                property var day: wallClock.time.toLocaleString(Qt.locale(), "dd")
-
-                onDayChanged: dayArc.requestPaint()
 
                 anchors {
                     centerIn: parent
@@ -231,41 +202,37 @@ Item {
                 width: parent.width * .22
                 height: parent.height * .22
 
-                Canvas {
-                    id: dayArc
+                // Static background circle — fill + inner border ring
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: parent.width * 0.9
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
+                    border.color: "#77ffffff"
+                    border.width: root.height * .002
+                    opacity: !displayAmbient ? 1 : .3
+                }
 
+                // Day of week progress arc — declarative binding updates automatically
+                Shape {
                     anchors.fill: parent
                     opacity: !displayAmbient ? 1 : .3
-                    smooth: true
-                    renderStrategy: Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .45,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = root.height * .002
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = root.height * .005
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#ff98E2C6"
-                        ctx.beginPath()
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .456,
-                                169 * rad,
-                                ((wallClock.time.getDay() / 7 * 360) + 169) * rad,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    ShapePath {
+                        strokeColor: "#ff98E2C6"
+                        strokeWidth: root.height * .005
+                        fillColor: "transparent"
+                        capStyle: ShapePath.RoundCap
+
+                        PathAngleArc {
+                            centerX: dayBox.width / 2
+                            centerY: dayBox.height / 2
+                            radiusX: dayBox.width * .456
+                            radiusY: dayBox.height * .456
+                            startAngle: 169
+                            sweepAngle: wallClock.time.getDay() / 7 * 360
+                        }
                     }
                 }
 
@@ -274,10 +241,9 @@ Item {
                     visible: !displayAmbient
 
                     Text {
-                        id: dayStrokes
-
-                        property bool currentDayHighlight: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd") === wallClock.time.toLocaleString(Qt.locale(), "ddd")
-                        property real rotM: ((index * 8.7) -15) / 60
+                        // static Date objects for locale day name lookup — only re-evaluates when currentDayName changes
+                        property bool currentDayHighlight: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd") === currentDayName
+                        property real rotM: ((index * 8.7) - 15) / 60
                         property real centerX: parent.width / 2 - width / 2
                         property real centerY: parent.height / 2 - height / 2
 
@@ -285,18 +251,15 @@ Item {
                         y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .35
                         antialiasing: true
                         opacity: !displayAmbient ? 1 : .6
-                        color: currentDayHighlight ?
-                                   "#ffffffff" :
-                                   "#88ffffff"
+                        color: currentDayHighlight ? "#ffffffff" : "#88ffffff"
                         font {
                             pixelSize: currentDayHighlight ? root.height * .036 : root.height * .03
                             letterSpacing: parent.width * .004
                             family: "Outfit"
-                            styleName: currentDayHighlight ?
-                                            "Bold" :
-                                            "Regular"
+                            styleName: currentDayHighlight ? "Bold" : "Regular"
                         }
                         text: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
+
                         transform: Rotation {
                             origin.x: width / 2
                             origin.y: height / 2
@@ -312,22 +275,18 @@ Item {
                         centerIn: parent
                         verticalCenterOffset: -root.width * .003
                     }
+                    color: "#ffffffff"
                     font {
                         pixelSize: parent.height * .39
                         family: "Noto Sans"
                         styleName: "Condensed Light"
                     }
-                    color: "#ffffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
                 }
             }
 
             Item {
                 id: monthBox
-
-                property var month: wallClock.time.toLocaleString(Qt.locale(), "mm")
-
-                onMonthChanged: monthArc.requestPaint()
 
                 anchors {
                     centerIn: parent
@@ -337,41 +296,37 @@ Item {
                 width: parent.width * .22
                 height: parent.height * .22
 
-                Canvas {
-                    id: monthArc
+                // Static background circle — fill + inner border ring
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: parent.width * 0.9
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
+                    border.color: "#77ffffff"
+                    border.width: root.height * .002
+                    opacity: !displayAmbient ? 1 : .3
+                }
 
+                // Month progress arc — sweepAngle binding from lifted root.currentMonth property
+                Shape {
                     anchors.fill: parent
                     opacity: !displayAmbient ? 1 : .3
-                    smooth: true
-                    renderStrategy: Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .45,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = root.height * .002
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = root.height * .005
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#ff98E2C6"
-                        ctx.beginPath()
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .456,
-                                270 * rad,
-                                ((wallClock.time.toLocaleString(Qt.locale(),"MM") / 12 * 360) + 270) * rad,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    ShapePath {
+                        strokeColor: "#ff98E2C6"
+                        strokeWidth: root.height * .005
+                        fillColor: "transparent"
+                        capStyle: ShapePath.RoundCap
+
+                        PathAngleArc {
+                            centerX: monthBox.width / 2
+                            centerY: monthBox.height / 2
+                            radiusX: monthBox.width * .456
+                            radiusY: monthBox.height * .456
+                            startAngle: -90
+                            sweepAngle: currentMonth / 12 * 360
+                        }
                     }
                 }
 
@@ -379,10 +334,8 @@ Item {
                     model: 12
 
                     Text {
-                        id: monthStrokes
-
-                        property bool currentMonthHighlight: Number(wallClock.time.toLocaleString(Qt.locale(), "MM")) === index ||
-                                                             Number(wallClock.time.toLocaleString(Qt.locale(), "MM")) === index + 12
+                        // currentMonth compared against index — evaluates only when currentMonth changes
+                        property bool currentMonthHighlight: currentMonth === index || currentMonth === index + 12
                         property real rotM: ((index * 5) - 15) / 60
                         property real centerX: parent.width / 2 - width / 2
                         property real centerY: parent.height / 2 - height / 2
@@ -391,24 +344,19 @@ Item {
                         y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .35
                         antialiasing: true
                         opacity: !displayAmbient ? 1 : .6
+                        color: currentMonthHighlight ? "#ffffffff" : "#88ffffff"
                         font {
-                            pixelSize: currentMonthHighlight ?
-                                           root.height * .036 :
-                                           root.height * .03
+                            pixelSize: currentMonthHighlight ? root.height * .036 : root.height * .03
                             letterSpacing: parent.width * .004
                             family: "Outfit"
-                            styleName: currentMonthHighlight ?
-                                           "Bold" :
-                                           "Regular"
+                            styleName: currentMonthHighlight ? "Bold" : "Regular"
                         }
-                        color:  currentMonthHighlight ?
-                                    "#ffffffff" :
-                                    "#88ffffff"
                         text: index === 0 ? 12 : index
+
                         transform: Rotation {
                             origin.x: width / 2
                             origin.y: height / 2
-                            angle: (index * 30)
+                            angle: index * 30
                         }
                     }
                 }
@@ -418,13 +366,13 @@ Item {
 
                     anchors.centerIn: parent
                     renderType: Text.NativeRendering
+                    color: "#ddffffff"
                     font {
                         pixelSize: parent.height * .366
                         family: "Noto Sans"
                         styleName: "Condensed Light"
                         letterSpacing: -root.width * .0018
                     }
-                    color: "#ddffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase()
                 }
             }
@@ -434,8 +382,6 @@ Item {
 
                 property int value: batteryChargePercentage.percent
 
-                onValueChanged: batteryArc.requestPaint()
-
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: parent.width * .206
@@ -443,15 +389,16 @@ Item {
                 width: parent.width * .26
                 height: parent.height * .26
 
+                onValueChanged: batteryArc.requestPaint()
+
                 Canvas {
                     id: batteryArc
 
-                    property int hour: 0
-
-                    opacity: !displayAmbient ? 1 : .3
+                    // radial gradient battery arc — kept as Canvas since QtShapes has no radial gradient support
                     anchors.fill: parent
-                    smooth: true
                     renderStrategy: Canvas.Cooperative
+                    opacity: !displayAmbient ? 1 : .3
+
                     onPaint: {
                         var ctx = getContext("2d")
                         ctx.reset()
@@ -462,44 +409,40 @@ Item {
                                 parent.width * .45,
                                 270 * rad,
                                 360,
-                                false);
+                                false)
                         ctx.strokeStyle = "#77ffffff"
                         ctx.lineWidth = root.height * .002
                         ctx.stroke()
                         ctx.fill()
                         ctx.closePath()
-                        var gradient = ctx.createRadialGradient (parent.width / 2,
-                                                                 parent.height / 2,
-                                                                 0,
-                                                                 parent.width / 2,
-                                                                 parent.height / 2,
-                                                                 parent.width * .46
-                                                                 )
+                        var gradient = ctx.createRadialGradient(parent.width / 2,
+                                                                parent.height / 2,
+                                                                0,
+                                                                parent.width / 2,
+                                                                parent.height / 2,
+                                                                parent.width * .46)
                         gradient.addColorStop(.44,
                                               batteryChargePercentage.percent < 30 ?
-                                                  "#00EF476F" :
-                                                  batteryChargePercentage.percent < 60 ?
-                                                      "#00D0E562" :
-                                                      "#0023F0C7"
-                                              )
+                                              "#00EF476F" :
+                                              batteryChargePercentage.percent < 60 ?
+                                              "#00D0E562" :
+                                              "#0023F0C7")
                         gradient.addColorStop(.97,
                                               batteryChargePercentage.percent < 30 ?
-                                                  "#ffEF476F" :
-                                                  batteryChargePercentage.percent < 60 ?
-                                                      "#ffD0E562" :
-                                                      "#ff23F0C7"
-                                              )
+                                              "#ffEF476F" :
+                                              batteryChargePercentage.percent < 60 ?
+                                              "#ffD0E562" :
+                                              "#ff23F0C7")
                         ctx.lineWidth = root.height * .005
-                        ctx.lineCap="round"
+                        ctx.lineCap = "round"
                         ctx.strokeStyle = gradient
                         ctx.beginPath()
                         ctx.arc(parent.width / 2,
                                 parent.height / 2,
                                 parent.width * .456,
                                 270 * rad,
-                                ((batteryChargePercentage.percent/100*360)+270) * rad,
-                                false
-                                );
+                                ((batteryChargePercentage.percent / 100 * 360) + 270) * rad,
+                                false)
                         ctx.lineTo(parent.width / 2,
                                    parent.height / 2)
                         ctx.stroke()
@@ -512,35 +455,33 @@ Item {
 
                     anchors.centerIn: parent
                     renderType: Text.NativeRendering
+                    color: "#ffffffff"
                     font {
                         pixelSize: parent.height * (batteryDisplay.text === "100" ? 0.46 : .48)
                         family: "Outfit"
-                        styleName:"Thin"
+                        styleName: "Thin"
                     }
-                    color: "#ffffffff"
                     text: batteryChargePercentage.percent
 
                     Text {
-                         id: batteryPercent
+                        id: batteryPercent
 
-                         anchors {
-                             centerIn: batteryDisplay
-                             verticalCenterOffset: parent.height*.34
-                         }
-                         font {
-                             pixelSize: parent.height * .194
-                             family: "Open Sans"
-                             styleName:"Regular"
-                         }
-                         renderType: Text.NativeRendering
-                         horizontalAlignment: Text.AlignHCenter
-                         lineHeightMode: Text.FixedHeight
-                         lineHeight: parent.height * .94
-                         color: !displayAmbient ?
-                                    "#bbffffff" :
-                                    "#55ffffff"
-                         text: "BAT<br>%"
-                     }
+                        anchors {
+                            centerIn: batteryDisplay
+                            verticalCenterOffset: parent.height * .34
+                        }
+                        renderType: Text.NativeRendering
+                        horizontalAlignment: Text.AlignHCenter
+                        lineHeightMode: Text.FixedHeight
+                        lineHeight: parent.height * .94
+                        color: !displayAmbient ? "#bbffffff" : "#55ffffff"
+                        font {
+                            pixelSize: parent.height * .194
+                            family: "Open Sans"
+                            styleName: "Regular"
+                        }
+                        text: "BAT<br>%"
+                    }
                 }
             }
         }
@@ -553,37 +494,29 @@ Item {
             Image {
                 id: hourSVG
 
+                property bool toggle24h: false
+
                 anchors.centerIn: handBox
-                source: imgPath + (displayAmbient ? "hour-bw.svg" : "hour.svg")
-                antialiasing: true
                 width: handBox.width
                 height: handBox.height
+                antialiasing: true
+                source: imgPath + (displayAmbient ? "hour-bw.svg" : "hour.svg")
+
                 transform: Rotation {
+                    id: hourRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: hourSVG.toggle24h ?
-                               (wallClock.time.getHours() * 15) + (wallClock.time.getMinutes() * .25) :
-                               (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * .5)
-                    Behavior on angle {
-                        RotationAnimation {
-                            duration: 500
-                            direction: RotationAnimation.Clockwise
-                            easing.type: Easing.InOutQuad
-                        }
-                    }
                 }
-                layer {
-                    enabled: true
-                    samples: 2
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 4
-                        verticalOffset: 4
-                        radius: 7.0
-                        samples: 15
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+
+                layer.enabled: true
+                layer.samples: 2
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 4
+                    verticalOffset: 4
+                    radius: 7.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
@@ -591,78 +524,56 @@ Item {
                 id: minuteSVG
 
                 anchors.centerIn: handBox
-                source: imgPath + (displayAmbient ? "minute-bw.svg" : "minute.svg")
-                antialiasing: true
                 width: handBox.width
                 height: handBox.height
+                antialiasing: true
+                source: imgPath + (displayAmbient ? "minute-bw.svg" : "minute.svg")
+
                 transform: Rotation {
+                    id: minuteRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
-                    Behavior on angle {
-                        RotationAnimation {
-                            duration: 1000
-                            direction: RotationAnimation.Clockwise
-                        }
-                    }
                 }
-                layer {
-                    enabled: true
-                    samples: 2
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 5
-                        verticalOffset: 5
-                        radius: 9.0
-                        samples: 19
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+
+                layer.enabled: true
+                layer.samples: 2
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 5
+                    verticalOffset: 5
+                    radius: 9.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
+            // second hand has no layer — continuous 60fps rotation would force constant recomposite
             Image {
                 id: secondSVG
 
                 anchors.centerIn: handBox
-                source: imgPath + "second.svg"
-                antialiasing: true
-                visible: !displayAmbient
                 width: handBox.width
                 height: handBox.height
+                antialiasing: true
+                visible: !displayAmbient
+                source: imgPath + "second.svg"
+
                 transform: Rotation {
+                    id: secondRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getSeconds() * 6)
-                }
-                layer {
-                    enabled: true
-                    samples: 2
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 7
-                        verticalOffset: 7
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
                 }
             }
         }
+
         Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
 
             Repeater {
@@ -676,15 +587,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .016
                 property real scalefactor: .50 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -693,7 +604,7 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -708,6 +619,40 @@ Item {
                     }
                 }
             }
+        }
+
+        Timer {
+            interval: 16
+            repeat: true
+            running: !displayAmbient && visible
+
+            onTriggered: {
+                var now = new Date()
+                secondRot.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+            }
+        }
+
+        Connections {
+            target: wallClock
+            function onTimeChanged() {
+                var h = wallClock.time.getHours()
+                var min = wallClock.time.getMinutes()
+                var sec = wallClock.time.getSeconds()
+                hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5
+                minuteRot.angle = min * 6 + sec * 6 / 60
+                currentMonth = Number(wallClock.time.toLocaleString(Qt.locale(), "MM"))
+                currentDayName = wallClock.time.toLocaleString(Qt.locale(), "ddd")
+            }
+        }
+
+        Component.onCompleted: {
+            var h = wallClock.time.getHours()
+            var min = wallClock.time.getMinutes()
+            var sec = wallClock.time.getSeconds()
+            hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5
+            minuteRot.angle = min * 6 + sec * 6 / 60
+            currentMonth = Number(wallClock.time.toLocaleString(Qt.locale(), "MM"))
+            currentDayName = wallClock.time.toLocaleString(Qt.locale(), "ddd")
         }
     }
 }

--- a/src/watchfaces/010-analog-aviator.qml
+++ b/src/watchfaces/010-analog-aviator.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -39,7 +23,6 @@ Item {
         id: root
 
         anchors.centerIn: parent
-
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
@@ -49,13 +32,8 @@ Item {
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
 
             Repeater {
@@ -69,15 +47,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .015
                 property real scalefactor: .49 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -86,7 +64,7 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -114,7 +92,7 @@ Item {
                 horizontalOffset: 2
                 verticalOffset: 2
                 radius: 12.0
-                samples: 17
+                samples: 9
                 color: "#bb000000"
             }
 
@@ -125,14 +103,15 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: -parent.height * 0.324
                 }
-                source: "../watchfaces-img/asteroid-logo-white.svg"
                 antialiasing: true
-
+                opacity: 1
                 width: parent.width / 5.5
                 height: parent.height / 5.5
-                opacity: 1
+                source: "../watchfaces-img/asteroid-logo-white.svg"
                 state: currentColor
-                states: State { name: "black"
+
+                states: State {
+                    name: "black"
                     PropertyChanges {
                         target: asteroidLogo
                         source: "../watchfaces-img/asteroid-logo-black.svg"
@@ -148,20 +127,22 @@ Item {
                     verticalCenterOffset: -parent.height * 0.146
                 }
                 visible: !displayAmbient
+                color: "#bbffffff"
+                horizontalAlignment: Text.AlignHCenter
                 font {
                     pixelSize: parent.height * 0.048
                     family: "Raleway"
                 }
-                color: "#bbffffff"
-                horizontalAlignment: Text.AlignHCenter
                 text: "<b>AsteroidOS</b><br>Free Your Wrist"
                 state: currentColor
-                states: State { name: "black";
+
+                states: State {
+                    name: "black"
                     PropertyChanges { target: asteroidSlogan; color: "black" }
                 }
                 transitions: Transition {
                     from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    ColorAnimation { duration: 300 }
                 }
             }
 
@@ -170,52 +151,53 @@ Item {
 
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: parent.height*0.14
+                    verticalCenterOffset: parent.height * 0.14
                 }
                 visible: !displayAmbient
+                color: "#bbffffff"
+                horizontalAlignment: Text.AlignHCenter
                 font {
                     pixelSize: parent.height * 0.052
                     family: "Raleway"
                 }
-                color: "#bbffffff"
-                horizontalAlignment: Text.AlignHCenter
                 text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b> MMMM<br>yyyy")
                 state: currentColor
-                states: State { name: "black";
+
+                states: State {
+                    name: "black"
                     PropertyChanges { target: dateDisplay; color: "black" }
                 }
                 transitions: Transition {
                     from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    ColorAnimation { duration: 300 }
                 }
             }
 
             Text {
                 id: apDisplay
 
-                property int day: wallClock.time.toLocaleString(Qt.locale(), "d")
-                property int month: wallClock.time.toLocaleString(Qt.locale(), "M")
-
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: parent.height / 3.8
-                    horizontalCenterOffset: parent.width/3.8
+                    horizontalCenterOffset: parent.width / 3.8
                 }
+                color: "white"
+                horizontalAlignment: Text.AlignHCenter
                 font {
                     pixelSize: parent.height * 0.065
                     family: "PTSans"
                     styleName: "Regular"
                 }
-                color: "white"
-                horizontalAlignment: Text.AlignHCenter
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
                 state: currentColor
-                states: State { name: "black";
+
+                states: State {
+                    name: "black"
                     PropertyChanges { target: apDisplay; color: "black" }
                 }
                 transitions: Transition {
                     from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    ColorAnimation { duration: 300 }
                 }
             }
 
@@ -227,115 +209,111 @@ Item {
                     verticalCenterOffset: parent.height / 3.8
                     horizontalCenterOffset: -parent.width / 3.8
                 }
+                color: "white"
+                horizontalAlignment: Text.AlignHCenter
                 font {
-                    pixelSize: parent.height*0.065
+                    pixelSize: parent.height * 0.065
                     family: "PTSans"
                     styleName: "Regular"
                 }
-                color: "white"
-                horizontalAlignment: Text.AlignHCenter
                 text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
                 state: currentColor
-                states: State { name: "black";
+
+                states: State {
+                    name: "black"
                     PropertyChanges { target: dowDisplay; color: "black" }
                 }
                 transitions: Transition {
                     from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    ColorAnimation { duration: 300 }
                 }
             }
 
             Repeater {
                 model: 60
-
                 Rectangle {
-                    id: minuteStrokes
-
-                    property real rotM: ((index) - 15) / 60
+                    property real rotM: (index - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
                     property real centerY: parent.height / 2 - height / 2
 
                     visible: index % 5
-                    antialiasing : true
-                    x: centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
-                    y: centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
+                    antialiasing: true
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
                     color: "#bbffffff"
                     width: parent.width * 0.0055
                     height: parent.height * 0.04
-                    transform: Rotation { origin.x: width / 2; origin.y: height / 2; angle: (index) * 6}
+
+                    transform: Rotation { origin.x: width / 2; origin.y: height / 2; angle: index * 6 }
                     state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: minuteStrokes; color: "black" }
+
+                    states: State {
+                        name: "black"
+                        PropertyChanges { target: parent; color: "black" }
                     }
                     transitions: Transition {
                         from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 300 }
+                        ColorAnimation { duration: 300 }
                     }
                 }
             }
 
             Repeater {
                 model: 4
-
                 Text {
-                    id: hourNumbers
-
-                    property real rotM: ((index * 15 ) - 15) / 60
+                    property real rotM: ((index * 15) - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
-                    property real centerY: parent.height / 2 - height / 2.0
+                    property real centerY: parent.height / 2 - height / 2
 
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
+                    color: "#ccffffff"
                     font {
                         pixelSize: parent.height * 0.21
                         family: "Signika"
                     }
-                    x: centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
-                    y: centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
-                    color: "#ccffffff"
-                    text: if (index === 0)
-                              ""
-                          else
-                              index * 3
+                    text: index === 0 ? "" : index * 3
                     state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: hourNumbers; color: "black" }
+
+                    states: State {
+                        name: "black"
+                        PropertyChanges { target: parent; color: "black" }
                     }
                     transitions: Transition {
                         from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 300 }
+                        ColorAnimation { duration: 300 }
                     }
                 }
             }
 
             Repeater {
                 model: 12
-
                 Rectangle {
-                    id: hourStrokes
-
-                    property real rotM: ((index * 5 ) - 15) / 60
+                    property real rotM: ((index * 5) - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
                     property real centerY: parent.height / 2 - height / 2
 
                     width: parent.width * 0.020
                     height: [0, 3, 6, 9].includes(index) ? parent.height * 0.04 : parent.height * 0.13
-                    x: if ([0, 3, 6, 9].includes(index))
-                           centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
-                       else
-                           centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.44
-                    y: if ([0, 3, 6, 9].includes(index))
-                           centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
-                       else
-                           centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.44
-                    antialiasing : true
+                    x: [0, 3, 6, 9].includes(index) ?
+                       centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48 :
+                       centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.44
+                    y: [0, 3, 6, 9].includes(index) ?
+                       centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48 :
+                       centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.44
+                    antialiasing: true
                     color: "#ccffffff"
-                    transform: Rotation { origin.x: width / 2; origin.y: height / 2; angle: (index * 5) * 6}
+
+                    transform: Rotation { origin.x: width / 2; origin.y: height / 2; angle: index * 5 * 6 }
                     state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: hourStrokes; color: "black" }
+
+                    states: State {
+                        name: "black"
+                        PropertyChanges { target: parent; color: "black" }
                     }
                     transitions: Transition {
                         from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 300 }
+                        ColorAnimation { duration: 300 }
                     }
                 }
             }
@@ -345,28 +323,28 @@ Item {
             id: hourSVG
 
             anchors.fill: root
+            source: imgPath + "hour-ambient.svg"
 
-            source: !displayAmbient ? imgPath + "hour-ambient.svg" : imgPath + "hour-ambient.svg"
             transform: Rotation {
-                origin.x: root.width / 2;
-                origin.y: root.height / 2;
-                angle: (wallClock.time.getHours()*30) + (wallClock.time.getMinutes() * 0.5)
+                id: hourRot
+                origin.x: root.width / 2
+                origin.y: root.height / 2
             }
+
             layer.enabled: true
             layer.effect: DropShadow {
                 transparentBorder: true
                 horizontalOffset: 4
                 verticalOffset: 4
                 radius: 6.0
-                samples: 17
+                samples: 9
                 color: "#22000000"
             }
             state: currentColor
-            states: State { name: "black"
-                PropertyChanges {
-                    target: hourSVG
-                    source: imgPath + "hour.svg"
-                }
+
+            states: State {
+                name: "black"
+                PropertyChanges { target: hourSVG; source: imgPath + "hour.svg" }
             }
         }
 
@@ -374,87 +352,112 @@ Item {
             id: minuteSVG
 
             anchors.fill: root
+            source: imgPath + "minute-ambient.svg"
 
-            source: !displayAmbient ? imgPath + "minute-ambient.svg" : imgPath + "minute-ambient.svg"
             transform: Rotation {
-                origin.x: root.width / 2;
-                origin.y: root.height / 2;
-                angle: (wallClock.time.getMinutes()*6)+(wallClock.time.getSeconds() * 6 / 60)
+                id: minuteRot
+                origin.x: root.width / 2
+                origin.y: root.height / 2
             }
+
             layer.enabled: true
             layer.effect: DropShadow {
                 transparentBorder: true
                 horizontalOffset: 6
                 verticalOffset: 6
                 radius: 8.0
-                samples: 17
+                samples: 9
                 color: "#22000000"
             }
             state: currentColor
-            states: State { name: "black"
-                PropertyChanges {
-                    target: minuteSVG
-                    source: imgPath + "minute.svg"
-                }
+
+            states: State {
+                name: "black"
+                PropertyChanges { target: minuteSVG; source: imgPath + "minute.svg" }
             }
         }
 
+        // second hand has no layer — 16ms Timer rotation would force constant 60fps recomposite
         Image {
             id: secondSVG
 
             property int toggle: 1
 
             anchors.fill: root
-
             visible: !displayAmbient
             source: imgPath + "second-ambient.svg"
+
             transform: Rotation {
-                origin.x: root.width / 2;
-                origin.y: root.height / 2;
-                angle: (wallClock.time.getSeconds() * 6)
+                id: secondRot
+                origin.x: root.width / 2
+                origin.y: root.height / 2
             }
-            layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 8
-                verticalOffset: 8
-                radius: 9.0
-                samples: 12
-                color: "#22000000"
-            }
+
             MouseArea {
                 anchors.fill: parent
                 onDoubleClicked: {
-                   if (secondSVG.toggle === 1) {
+                    if (secondSVG.toggle === 1) {
                         currentColor = "black"
                         secondSVG.toggle = 0
-                   } else {
+                    } else {
                         currentColor = ""
                         secondSVG.toggle = 1
                     }
                 }
             }
             state: currentColor
-            states: State { name: "black"
-                PropertyChanges {
-                    target: secondSVG
-                    source: imgPath + "second.svg"
+
+            states: State {
+                name: "black"
+                PropertyChanges { target: secondSVG; source: imgPath + "second.svg" }
+            }
+        }
+
+        Timer {
+            interval: 16
+            repeat: true
+            running: !displayAmbient && visible
+
+            onTriggered: {
+                var now = new Date()
+                secondRot.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+            }
+        }
+
+        Connections {
+            target: wallClock
+            function onTimeChanged() {
+                var h = wallClock.time.getHours()
+                var min = wallClock.time.getMinutes()
+                var sec = wallClock.time.getSeconds()
+                hourRot.angle = h * 30 + min * 0.5
+                minuteRot.angle = min * 6 + sec * 6 / 60
+            }
+        }
+
+        Connections {
+            target: compositor
+            function onDisplayAmbientEntered() {
+                if (currentColor === "black") {
+                    currentColor = ""
+                    userColor = "black"
+                } else {
+                    userColor = ""
+                }
+            }
+            function onDisplayAmbientLeft() {
+                if (userColor === "black") {
+                    currentColor = "black"
                 }
             }
         }
-    }
 
-    Connections {
-        target: compositor
-        onDisplayAmbientEntered: if (currentColor == "black") {
-                                     currentColor = ""
-                                     userColor = "black"
-                                 }
-                                 else
-                                     userColor = ""
-
-        onDisplayAmbientLeft:    if (userColor == "black") {
-                                     currentColor = "black"
-                                 }
+        Component.onCompleted: {
+            var h = wallClock.time.getHours()
+            var min = wallClock.time.getMinutes()
+            var sec = wallClock.time.getSeconds()
+            hourRot.angle = h * 30 + min * 0.5
+            minuteRot.angle = min * 6 + sec * 6 / 60
+        }
     }
 }

--- a/src/watchfaces/011-bold-hour-bebas.qml
+++ b/src/watchfaces/011-bold-hour-bebas.qml
@@ -1,27 +1,12 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -37,7 +22,6 @@ Item {
         id: root
 
         anchors.centerIn: parent
-
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
@@ -51,28 +35,31 @@ Item {
             Canvas {
                 id: minuteArc
 
+                property int minute: 0
                 property real centerX: parent.width / 2
                 property real centerY: parent.height / 2
 
                 anchors.fill: parent
                 renderStrategy: Canvas.Cooperative
                 visible: !displayAmbient && !nightstandMode.active
+
                 onPaint: {
                     var ctx = getContext("2d")
-                    var rot = (wallClock.time.getMinutes() -15 ) * 6
+                    var rot = (minute - 15) * 6
                     ctx.reset()
-                    ctx.lineWidth = parent.width*.0031
-                    var gradient = ctx.createConicalGradient (centerX, centerY, 90 * .01745)
-                        gradient.addColorStop(1 - (wallClock.time.getMinutes() / 60), Qt.rgba(1, 1, 1, .4))
-                        gradient.addColorStop(1 - (wallClock.time.getMinutes() / 60 / 6), Qt.rgba(1, 1, 1, 0))
-                    var gradient2 = ctx.createConicalGradient (centerX, centerY, 90 * .01745)
-                        gradient2.addColorStop(1 - (wallClock.time.getMinutes() / 60), Qt.rgba(1, 1, 1, .5))
-                        gradient2.addColorStop(1 - (wallClock.time.getMinutes() / 60 / 6), Qt.rgba(1, 1, 1, .01))
+                    ctx.lineWidth = parent.width * .0031
+                    // conical gradient arc — kept as Canvas since PathAngleArc has no conical gradient support
+                    var gradient = ctx.createConicalGradient(centerX, centerY, 90 * .01745)
+                    gradient.addColorStop(1 - (minute / 60), Qt.rgba(1, 1, 1, .4))
+                    gradient.addColorStop(1 - (minute / 60 / 6), Qt.rgba(1, 1, 1, 0))
+                    var gradient2 = ctx.createConicalGradient(centerX, centerY, 90 * .01745)
+                    gradient2.addColorStop(1 - (minute / 60), Qt.rgba(1, 1, 1, .5))
+                    gradient2.addColorStop(1 - (minute / 60 / 6), Qt.rgba(1, 1, 1, .01))
                     ctx.fillStyle = gradient
                     ctx.strokeStyle = gradient2
                     ctx.beginPath()
-                    ctx.arc(centerX, centerY, width / 2.75, -90 * .017453, rot * .017453, false);
-                    ctx.lineTo(centerX, centerY);
+                    ctx.arc(centerX, centerY, width / 2.75, -90 * .017453, rot * .017453, false)
+                    ctx.lineTo(centerX, centerY)
                     ctx.fill()
                     ctx.stroke()
                 }
@@ -81,71 +68,41 @@ Item {
             Text {
                 id: hourDisplay
 
+                anchors.centerIn: parent
                 renderType: Text.NativeRendering
-                anchors {
-                    horizontalCenter: parent.horizontalCenter
-                    verticalCenter: parent.verticalCenter
-                }
+                color: Qt.rgba(1, 1, 1, .9)
+                opacity: .9
+                horizontalAlignment: Text.AlignHCenter
+                style: Text.Outline
+                styleColor: Qt.rgba(0, 0, 0, .2)
                 font {
                     pixelSize: parent.height * .87
                     family: "BebasKai"
-                    styleName:"Bold"
+                    styleName: "Bold"
                 }
-                color: Qt.rgba(1, 1, 1, .9)
-                opacity: .9
-                style: Text.Outline;
-                styleColor: Qt.rgba(0, 0, 0, .2)
-                horizontalAlignment: Text.AlignHCenter
-                text: if (use12H.value) {
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) }
-                      else
-                          wallClock.time.toLocaleString(Qt.locale(), "HH")
+                text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
+                                     wallClock.time.toLocaleString(Qt.locale(), "HH")
             }
 
-            Canvas {
+            // Minute hand tip dot — Rectangle replaces Canvas circle
+            Rectangle {
                 id: minuteCircle
 
-                property int minute: 0
-                property real rotM: (wallClock.time.getMinutes() - 15) / 60
-                property real centerX: parent.width / 2
-                property real centerY: parent.height / 2
-                property real minuteX: centerX+Math.cos(rotM * 2 * Math.PI) * width / 2.75
-                property real minuteY: centerY+Math.sin(rotM * 2 * Math.PI) * height / 2.75
-
-                anchors.fill: parent
-                renderStrategy: Canvas.Cooperative
-                onPaint: {
-                    var ctx = getContext("2d")
-                    var rot1 = (0 -15 ) * 6 * .01745
-                    var rot2 = (60 -15 ) * 6 * .01745
-                    ctx.reset()
-                    ctx.lineWidth = 3
-                    ctx.fillStyle = Qt.rgba(.184, .184, .184, .95)
-                    ctx.beginPath()
-                    ctx.moveTo(minuteX, minuteY)
-                    ctx.arc(minuteX, minuteY, width / 8.6, rot1, rot2, false);
-                    ctx.lineTo(minuteX, minuteY);
-                    ctx.fill();
-                }
+                width: parent.width / 8.6 * 2
+                height: width
+                radius: width / 2
+                color: Qt.rgba(.184, .184, .184, .95)
             }
 
             Text {
                 id: minuteDisplay
 
-                property real rotM: (wallClock.time.getMinutes() - 15) / 60
-                property real centerX: parent.width / 2 - width / 2
-                property real centerY: parent.height / 2 - height / 2
-
+                color: "white"
                 font {
                     pixelSize: parent.height / 5.24
                     family: "BebasKai"
-                    styleName:'Condensed'
+                    styleName: "Condensed"
                 }
-                color: "white"
-                opacity: 1.00
-                x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .364
-                y: centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * .364
-                text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
         }
 
@@ -156,27 +113,20 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .04
                 property real scalefactor: .49 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -185,7 +135,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -208,26 +158,42 @@ Item {
     Connections {
         target: wallClock
         function onTimeChanged() {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
+            var min = wallClock.time.getMinutes()
+            var rotM = (min - 15) / 60
+            var cx = scaleContent.width / 2
+            var cy = scaleContent.height / 2
+            var dotR = scaleContent.width / 8.6
 
-            if(minuteCircle.minute !== minute) {
-                minuteCircle.minute = minute
-                minuteCircle.requestPaint()
-                minuteArc.requestPaint()
-            }
+            minuteArc.minute = min
+            minuteArc.requestPaint()
+
+            minuteCircle.x = cx + Math.cos(rotM * 2 * Math.PI) * scaleContent.width / 2.75 - dotR
+            minuteCircle.y = cy + Math.sin(rotM * 2 * Math.PI) * scaleContent.height / 2.75 - dotR
+
+            minuteDisplay.x = cx - minuteDisplay.width / 2 + Math.cos(rotM * 2 * Math.PI) * scaleContent.width * .364
+            minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(rotM * 2 * Math.PI) * scaleContent.width * .364
+            minuteDisplay.text = wallClock.time.toLocaleString(Qt.locale(), "mm")
         }
     }
 
     Component.onCompleted: {
-        var hour = wallClock.time.getHours()
-        var minute = wallClock.time.getMinutes()
+        var min = wallClock.time.getMinutes()
+        var rotM = (min - 15) / 60
+        var cx = scaleContent.width / 2
+        var cy = scaleContent.height / 2
+        var dotR = scaleContent.width / 8.6
 
-        minuteCircle.minute = minute
-        minuteCircle.requestPaint()
+        minuteArc.minute = min
         minuteArc.requestPaint()
 
-        burnInProtectionManager.widthOffset = Qt.binding(function() { return width * .3})
-        burnInProtectionManager.heightOffset = Qt.binding(function() { return height * .3})
+        minuteCircle.x = cx + Math.cos(rotM * 2 * Math.PI) * scaleContent.width / 2.75 - dotR
+        minuteCircle.y = cy + Math.sin(rotM * 2 * Math.PI) * scaleContent.height / 2.75 - dotR
+
+        minuteDisplay.x = cx - minuteDisplay.width / 2 + Math.cos(rotM * 2 * Math.PI) * scaleContent.width * .364
+        minuteDisplay.y = cy - minuteDisplay.height / 2 + Math.sin(rotM * 2 * Math.PI) * scaleContent.width * .364
+        minuteDisplay.text = wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+        burnInProtectionManager.widthOffset = Qt.binding(function() { return width * .3 })
+        burnInProtectionManager.heightOffset = Qt.binding(function() { return height * .3 })
     }
 }

--- a/src/watchfaces/012-analog-words.qml
+++ b/src/watchfaces/012-analog-words.qml
@@ -1,22 +1,6 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2021 - Ed Beroset <github.com/beroset>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2021 Ed Beroset <github.com/beroset>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -30,7 +14,7 @@ Item {
 
     property string currentColor: ""
     property string userColor: ""
-    property int hour: wallClock.time.toLocaleString(Qt.locale(), "h ap").slice(0, 2) === "12" ? 0 : wallClock.time.toLocaleString(Qt.locale(), "h ap").slice(0, 2)
+    property int hour: 0
     property var colorOffset: ["#ff0000", "#ff8000", "#ffff00", "#80ff00", "#00ff00", "#00ff80", "#00ffff", "#0080ff", "#0000ff", "#8000ff", "#ff00ff", "#ff0080"]
     property var wordsDE: ["zwölf", "eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn", "elf"]
     property var wordsEN: ["twelve", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven"]
@@ -49,10 +33,9 @@ Item {
     Item {
         id: root
 
+        anchors.centerIn: parent
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
-
-        anchors.centerIn: parent
 
         Item {
             id: nightstandMode
@@ -60,13 +43,8 @@ Item {
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
 
             Repeater {
@@ -80,15 +58,15 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .02
                 property real scalefactor: .48 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -97,7 +75,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startY: parent.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: parent.width / 2
@@ -118,14 +96,17 @@ Item {
             id: batteryChargePercentage
         }
 
+        // z: 2 retained — circleBack must always paint above Repeater delegates
+        // whose z is dynamic (hour == index ? 1 : 0); declaration order cannot satisfy this
         Rectangle {
             id: circleBack
             z: 2
 
-            property var toggle: 1
-            antialiasing : true
-            x: parent.width / 2 - width / 2
-            y: parent.height / 2 - height / 2
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                verticalCenter: parent.verticalCenter
+            }
+            antialiasing: true
             color: "white"
             width: parent.width * 0.3
             height: parent.height * 0.3
@@ -134,12 +115,14 @@ Item {
             Text {
                 id: minuteDisplay
 
-                font.pixelSize: parent.height * 0.549
-                font.family: "Montserrat"
-                font.styleName: "Regular"
+                anchors.centerIn: parent
                 color: "black"
                 opacity: 1
-                anchors.centerIn: parent
+                font {
+                    pixelSize: parent.height * 0.549
+                    family: "Montserrat"
+                    styleName: "Regular"
+                }
                 text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
         }
@@ -157,11 +140,12 @@ Item {
                 color: hour == index ? "white" : colorOffset[index]
                 opacity: 1
                 radius: width * 0.5
+
                 transform: [
                     Rotation {
-                        origin.x: backRectangles.height / 2;
-                        origin.y: backRectangles.height / 2;
-                        angle: ((index) * 30) - 90
+                        origin.x: backRectangles.height / 2
+                        origin.y: backRectangles.height / 2
+                        angle: (index * 30) - 90
                     },
                     Translate {
                         x: (parent.width - backRectangles.height) / 2
@@ -169,13 +153,24 @@ Item {
                     }
                 ]
                 state: currentColor
-                states: State { name: "black";
-                    PropertyChanges { target: backRectangles;
-                        color: hour == index ? "white" : "black" }
+
+                states: State {
+                    name: "black"
+                    PropertyChanges { target: backRectangles; color: hour == index ? "white" : "black" }
                 }
                 transitions: Transition {
                     from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 500 }
+                    ColorAnimation { duration: 500 }
+                }
+
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 3
+                    verticalOffset: 3
+                    radius: 12.0
+                    samples: 9
+                    color: "#50000000"
                 }
 
                 Text {
@@ -183,71 +178,75 @@ Item {
 
                     property var heightFontOffest: (index > 0 && index < 7) ? -parent.height * 0.05 : parent.height * 0.05
 
-                    font.pixelSize: parent.height * (hour == index ? 0.70 : 0.56)
-                    font.family: "SourceSansPro"
-                    font.styleName: hour == index ? "Semibold" : "Light"
-                    font.letterSpacing: hour == index ? -parent.height * 0.02 : parent.height * 0.001
-                    color: "black"
                     x: hour == index ? parent.height * 1.58 : parent.height * 1.94
                     y: ((parent.height - hourText.height) / 2) + heightFontOffest
-                    text: Qt.locale().name.substring(0,2) === "de" ? wordsDE[index]:
-                          Qt.locale().name.substring(0,2) === "fr" ? wordsFR[index]:
-                          Qt.locale().name.substring(0,2) === "es" ? wordsES[index]:
-                          Qt.locale().name.substring(0,2) === "it" ? wordsIT[index]:
-                          Qt.locale().name.substring(0,2) === "nl" ? wordsNL[index]:
-                          Qt.locale().name.substring(0,2) === "el" ? wordsGR[index]:
-                          Qt.locale().name.substring(0,2) === "sv" ? wordsSV[index]:
-                          Qt.locale().name.substring(0,2) === "sk" ? wordsSK[index]:
-                          Qt.locale().name.substring(0,2) === "da" ? wordsDA[index]:
-                          Qt.locale().name.substring(0,2) === "pt" ? wordsPT[index]:
-                          Qt.locale().name.substring(0,2) === "tr" ? wordsTR[index]:
-                          Qt.locale().name.substring(0,2) === "nb" ? wordsNB[index]:
+                    color: "black"
+                    font {
+                        pixelSize: parent.height * (hour == index ? 0.70 : 0.56)
+                        family: "SourceSansPro"
+                        styleName: hour == index ? "Semibold" : "Light"
+                        letterSpacing: hour == index ? -parent.height * 0.02 : parent.height * 0.001
+                    }
+                    text: Qt.locale().name.substring(0,2) === "de" ? wordsDE[index] :
+                          Qt.locale().name.substring(0,2) === "fr" ? wordsFR[index] :
+                          Qt.locale().name.substring(0,2) === "es" ? wordsES[index] :
+                          Qt.locale().name.substring(0,2) === "it" ? wordsIT[index] :
+                          Qt.locale().name.substring(0,2) === "nl" ? wordsNL[index] :
+                          Qt.locale().name.substring(0,2) === "el" ? wordsGR[index] :
+                          Qt.locale().name.substring(0,2) === "sv" ? wordsSV[index] :
+                          Qt.locale().name.substring(0,2) === "sk" ? wordsSK[index] :
+                          Qt.locale().name.substring(0,2) === "da" ? wordsDA[index] :
+                          Qt.locale().name.substring(0,2) === "pt" ? wordsPT[index] :
+                          Qt.locale().name.substring(0,2) === "tr" ? wordsTR[index] :
+                          Qt.locale().name.substring(0,2) === "nb" ? wordsNB[index] :
                                                                      wordsEN[index]
+
                     transform: Rotation {
-                        origin.x: hourText.width / 2;
-                        origin.y: hourText.height / 2;
+                        origin.x: hourText.width / 2
+                        origin.y: hourText.height / 2
                         /* flip text for readability for hours 1 through 6 */
                         angle: (index > 0 && index < 7) ? 0 : 180
                     }
                     state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: hourText;
-                            color: hour == index ? "black" : "white" }
+
+                    states: State {
+                        name: "black"
+                        PropertyChanges { target: hourText; color: hour == index ? "black" : "white" }
                     }
                     transitions: Transition {
                         from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 500 }
+                        ColorAnimation { duration: 500 }
                     }
-                }
-                layer.enabled: true
-                layer.effect: DropShadow {
-                    transparentBorder: true
-                    horizontalOffset: 3
-                    verticalOffset: 3
-                    radius: 12.0
-                    samples: 17
-                    color: "#50000000"
                 }
             }
         }
 
         Connections {
             target: compositor
-
             function onDisplayAmbientEntered() {
-                if (currentColor == "") {
+                if (currentColor === "") {
                     currentColor = "black"
                     userColor = ""
-                }
-                else
+                } else {
                     userColor = "black"
+                }
             }
-
             function onDisplayAmbientLeft() {
-                if (userColor == "") {
+                if (userColor === "") {
                     currentColor = ""
                 }
             }
         }
+    }
+
+    Connections {
+        target: wallClock
+        function onTimeChanged() {
+            hour = wallClock.time.getHours() % 12
+        }
+    }
+
+    Component.onCompleted: {
+        hour = wallClock.time.getHours() % 12
     }
 }

--- a/src/watchfaces/013-analog-nordic.qml
+++ b/src/watchfaces/013-analog-nordic.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -34,13 +19,10 @@ import Nemo.Mce 1.0
 Item {
     anchors.fill: parent
 
-    property real radian: .01745
-
     Item {
         id: rootitem
 
         anchors.centerIn: parent
-
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
@@ -51,27 +33,20 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .02
                 property real scalefactor: .471 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -80,7 +55,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -97,7 +72,6 @@ Item {
             Icon {
                 id: batteryIcon
 
-                name: "ios-battery-charging"
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: -parent.width * .16
@@ -105,6 +79,7 @@ Item {
                 visible: nightstandMode.active
                 width: parent.width * .13
                 height: parent.height * .13
+                name: "ios-battery-charging"
             }
 
             ColorOverlay {
@@ -120,14 +95,15 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: parent.width * .155
                 }
+                visible: nightstandMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
+                style: Text.Outline
+                styleColor: "#80000000"
                 font {
                     pixelSize: parent.width * .12
                     family: "Noto Sans"
                     styleName: "ExtraCondensed"
                 }
-                visible: nightstandMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
                 text: batteryChargePercentage.percent
             }
         }
@@ -140,20 +116,19 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width
             height: width
 
+            // Hour strokes — static, paints once only
             Canvas {
                 id: hourStrokes
 
                 anchors.fill: parent
-                smooth: true
                 renderStrategy: Canvas.Cooperative
+
                 onPaint: {
                     var ctx = getContext("2d")
-
-                    ctx.lineWidth = parent.width*.0093
+                    ctx.lineWidth = parent.width * .0093
                     ctx.strokeStyle = Qt.rgba(1, 1, 1, 1)
                     ctx.shadowColor = Qt.rgba(0, 0, 0, .7)
                     ctx.shadowOffsetX = 0
@@ -161,7 +136,7 @@ Item {
                     ctx.shadowBlur = 2
                     ctx.translate(parent.width / 2, parent.height / 2)
                     for (var i = 0; i < 12; i++) {
-                        if ( i % 3 != 0) {
+                        if (i % 3 !== 0) {
                             ctx.beginPath()
                             ctx.moveTo(0, parent.height * .3)
                             ctx.lineTo(0, parent.height * .42)
@@ -172,12 +147,13 @@ Item {
                 }
             }
 
+            // Minute strokes — static, paints once only
             Canvas {
                 id: minuteStrokes
 
                 anchors.fill: parent
-                smooth: true
                 renderStrategy: Canvas.Cooperative
+
                 onPaint: {
                     var ctx = getContext("2d")
                     ctx.lineWidth = parent.width * .014
@@ -198,6 +174,7 @@ Item {
                 }
             }
 
+            // Hour numerals — static, paints once only
             Canvas {
                 id: numberStrokes
 
@@ -205,8 +182,6 @@ Item {
                 property real hoffset: parent.height * 0
 
                 anchors.fill: parent
-                antialiasing: true
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
@@ -215,17 +190,17 @@ Item {
                     ctx.lineWidth = parent.height * .0124
                     ctx.font = "0 " + parent.height * .18 + "px FatCow"
                     ctx.textAlign = "center"
-                    ctx.textBaseline = 'middle';
+                    ctx.textBaseline = "middle"
                     ctx.strokeStyle = Qt.rgba(0, 0, 0, .3)
                     ctx.translate(parent.width / 2, parent.height / 2)
                     for (var i = 0; i < 12; i = i + 3) {
                         ctx.beginPath()
-                        ctx.strokeText(i != 0 ? i: 12,
-                                                Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * .346 - hoffset,
-                                                Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * .346 - voffset)
-                        ctx.fillText(i != 0 ? i: 12,
-                                              Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * .34 - hoffset,
-                                              Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * .34 - voffset)
+                        ctx.strokeText(i !== 0 ? i : 12,
+                                       Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * .346 - hoffset,
+                                       Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * .346 - voffset)
+                        ctx.fillText(i !== 0 ? i : 12,
+                                     Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * .34 - hoffset,
+                                     Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * .34 - voffset)
                         ctx.closePath()
                     }
                 }
@@ -235,9 +210,9 @@ Item {
                 id: hourHand
 
                 property int hour: 0
+                property int minute: 0
 
                 anchors.fill: parent
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
@@ -248,40 +223,37 @@ Item {
                     ctx.shadowOffsetY = 3
                     ctx.shadowBlur = 4
                     ctx.beginPath()
-                    ctx.lineWidth = parent.height*.004
-                    var gradient = ctx.createRadialGradient (parent.width / 2,
-                                                             parent.height / 2,
-                                                             0,
-                                                             parent.width / 2,
-                                                             parent.height / 2,
-                                                             parent.width * .285)
-                    gradient.addColorStop(.1, Qt.rgba(.2, .2, .2, 1)) // darker shaft
-                    gradient.addColorStop(.4, Qt.rgba(.4, .4, .4, 1)) // light gold center
-                    gradient.addColorStop(.6, Qt.rgba(.3, .3, .3, 1)) // dark gold tip
-
+                    ctx.lineWidth = parent.height * .004
+                    var gradient = ctx.createRadialGradient(parent.width / 2,
+                                                            parent.height / 2,
+                                                            0,
+                                                            parent.width / 2,
+                                                            parent.height / 2,
+                                                            parent.width * .285)
+                    gradient.addColorStop(.1, Qt.rgba(.2, .2, .2, 1))
+                    gradient.addColorStop(.4, Qt.rgba(.4, .4, .4, 1))
+                    gradient.addColorStop(.6, Qt.rgba(.3, .3, .3, 1))
                     ctx.strokeStyle = gradient
-
-                    var gradient2 = ctx.createLinearGradient (parent.width / 2 + Math.cos(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                                                              parent.height / 2 + Math.sin(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                                                              parent.width / 2 + Math.cos(((hour+0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                                                              parent.height / 2 + Math.sin(((hour+0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033)
-                    gradient2.addColorStop(.35, Qt.rgba(1, 1, 1, 1)) // darker gold
-                    gradient2.addColorStop(.5, Qt.rgba(.7, .7, .7, 1)) // light gold center
-                    gradient2.addColorStop(.65, Qt.rgba(1, 1, 1, 1)) // dark gold tip
+                    var gradient2 = ctx.createLinearGradient(parent.width / 2 + Math.cos(((hour - 6 + minute / 60) / 12) * 2 * Math.PI) * width * .033,
+                                                             parent.height / 2 + Math.sin(((hour - 6 + minute / 60) / 12) * 2 * Math.PI) * width * .033,
+                                                             parent.width / 2 + Math.cos(((hour + 0 + minute / 60) / 12) * 2 * Math.PI) * width * .033,
+                                                             parent.height / 2 + Math.sin(((hour + 0 + minute / 60) / 12) * 2 * Math.PI) * width * .033)
+                    gradient2.addColorStop(.35, Qt.rgba(1, 1, 1, 1))
+                    gradient2.addColorStop(.5, Qt.rgba(.7, .7, .7, 1))
+                    gradient2.addColorStop(.65, Qt.rgba(1, 1, 1, 1))
                     ctx.fillStyle = gradient2
-                    ctx.moveTo(parent.width/2+Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285,
-                               parent.height/2+Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 3.12 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                               parent.height/2+Math.sin(((hour - 3.12 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                               parent.height/2+Math.sin(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                               parent.height/2+Math.sin(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033)
-
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 2.88 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                               parent.height/2+Math.sin(((hour - 2.88 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285,
-                               parent.height/2+Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285)
+                    ctx.moveTo(parent.width / 2 + Math.cos(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .285,
+                               parent.height / 2 + Math.sin(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .285)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3.12 + minute / 60) / 12) * 2 * Math.PI) * width * .275,
+                               parent.height / 2 + Math.sin(((hour - 3.12 + minute / 60) / 12) * 2 * Math.PI) * width * .275)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 6 + minute / 60) / 12) * 2 * Math.PI) * width * .033,
+                               parent.height / 2 + Math.sin(((hour - 6 + minute / 60) / 12) * 2 * Math.PI) * width * .033)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour + 0 + minute / 60) / 12) * 2 * Math.PI) * width * .033,
+                               parent.height / 2 + Math.sin(((hour + 0 + minute / 60) / 12) * 2 * Math.PI) * width * .033)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 2.88 + minute / 60) / 12) * 2 * Math.PI) * width * .275,
+                               parent.height / 2 + Math.sin(((hour - 2.88 + minute / 60) / 12) * 2 * Math.PI) * width * .275)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .285,
+                               parent.height / 2 + Math.sin(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .285)
                     ctx.fill()
                     ctx.shadowColor = Qt.rgba(0, 0, 0, .0)
                     ctx.stroke()
@@ -291,8 +263,8 @@ Item {
                     ctx.lineWidth = parent.height * .003
                     ctx.moveTo(parent.width / 2,
                                parent.height / 2)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((hour-3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .284,
-                               parent.height / 2 + Math.sin(((hour-3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .284)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .284,
+                               parent.height / 2 + Math.sin(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .284)
                     ctx.stroke()
                     ctx.closePath()
                 }
@@ -304,7 +276,6 @@ Item {
                 property int minute: 0
 
                 anchors.fill: parent
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
@@ -315,26 +286,24 @@ Item {
                     ctx.shadowOffsetY = 3
                     ctx.shadowBlur = 4
                     ctx.beginPath()
-                    ctx.lineWidth = parent.height*.004
-                    var gradient = ctx.createRadialGradient (parent.width / 2,
-                                                             parent.height / 2,
-                                                             0,
-                                                             parent.width / 2,
-                                                             parent.height / 2,
-                                                             parent.width * .45)
-                    gradient.addColorStop(.1, Qt.rgba(.2, .2, .2, 1)) // darker shaft
-                    gradient.addColorStop(.4, Qt.rgba(.4, .4, .4, 1)) // light gold center
-                    gradient.addColorStop(.6, Qt.rgba(.3, .3, .3, 1)) // dark gold tip
-
+                    ctx.lineWidth = parent.height * .004
+                    var gradient = ctx.createRadialGradient(parent.width / 2,
+                                                            parent.height / 2,
+                                                            0,
+                                                            parent.width / 2,
+                                                            parent.height / 2,
+                                                            parent.width * .45)
+                    gradient.addColorStop(.1, Qt.rgba(.2, .2, .2, 1))
+                    gradient.addColorStop(.4, Qt.rgba(.4, .4, .4, 1))
+                    gradient.addColorStop(.6, Qt.rgba(.3, .3, .3, 1))
                     ctx.strokeStyle = gradient
-                    var gradient2 = ctx.createLinearGradient (parent.width / 2 + Math.cos(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
-                                                              parent.height / 2 + Math.sin(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
-                                                              parent.width / 2 + Math.cos(((minute + 0) / 60) * 2 * Math.PI) * width * .03,
-                                                              parent.height / 2 + Math.sin(((minute + 0) / 60) * 2 * Math.PI) * width * .03)
-                    gradient2.addColorStop(.35, Qt.rgba(1, 1, 1, 1)) // darker gold
-                    gradient2.addColorStop(.5, Qt.rgba(.7, .7, .7, 1)) // light gold center
-                    gradient2.addColorStop(.65, Qt.rgba(1, 1, 1, 1)) // dark gold tip
-
+                    var gradient2 = ctx.createLinearGradient(parent.width / 2 + Math.cos(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
+                                                             parent.height / 2 + Math.sin(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
+                                                             parent.width / 2 + Math.cos(((minute + 0) / 60) * 2 * Math.PI) * width * .03,
+                                                             parent.height / 2 + Math.sin(((minute + 0) / 60) * 2 * Math.PI) * width * .03)
+                    gradient2.addColorStop(.35, Qt.rgba(1, 1, 1, 1))
+                    gradient2.addColorStop(.5, Qt.rgba(.7, .7, .7, 1))
+                    gradient2.addColorStop(.65, Qt.rgba(1, 1, 1, 1))
                     ctx.fillStyle = gradient2
                     ctx.moveTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * .45,
                                parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * .45)
@@ -355,8 +324,8 @@ Item {
                     ctx.strokeStyle = Qt.rgba(0, 0, 0, .4)
                     ctx.moveTo(parent.width / 2,
                                parent.height / 2)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15)/60) * 2 * Math.PI) * width * .448,
-                               parent.height / 2 + Math.sin(((minute - 15)/60) * 2 * Math.PI) * width * .448)
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * .448,
+                               parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * .448)
                     ctx.stroke()
                     ctx.closePath()
                 }
@@ -368,7 +337,6 @@ Item {
                 property int second: 0
 
                 anchors.fill: parent
-                smooth: true
                 renderStrategy: Canvas.Cooperative
                 visible: !displayAmbient && !nightstandMode.active
 
@@ -396,15 +364,14 @@ Item {
                                parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .45)
                     ctx.stroke()
                     ctx.closePath()
-
                 }
             }
 
+            // Static center nail dot — paints once only
             Canvas {
                 id: nailDot
 
                 anchors.fill: parent
-                smooth: true
                 renderStrategy: Canvas.Cooperative
 
                 onPaint: {
@@ -426,13 +393,16 @@ Item {
                 var hour = wallClock.time.getHours()
                 var minute = wallClock.time.getMinutes()
                 var second = wallClock.time.getSeconds()
-                if(secondHand.second !== second) {
+                if (secondHand.second !== second) {
                     secondHand.second = second
                     secondHand.requestPaint()
-                }if(hourHand.hour !== hour) {
+                }
+                if (hourHand.hour !== hour) {
                     hourHand.hour = hour
-                }if(minuteHand.minute !== minute) {
+                }
+                if (minuteHand.minute !== minute) {
                     minuteHand.minute = minute
+                    hourHand.minute = minute
                     minuteHand.requestPaint()
                     hourHand.requestPaint()
                 }
@@ -448,12 +418,14 @@ Item {
             minuteHand.minute = minute
             minuteHand.requestPaint()
             hourHand.hour = hour
+            hourHand.minute = minute
             hourHand.requestPaint()
             hourStrokes.requestPaint()
             minuteStrokes.requestPaint()
             numberStrokes.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .11 : .06)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .11 : .06)})
+            nailDot.requestPaint()
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .11 : .06) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .11 : .06) })
         }
     }
 }

--- a/src/watchfaces/014-analog-50s-americana.qml
+++ b/src/watchfaces/014-analog-50s-americana.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -34,33 +19,21 @@ import Nemo.Mce 1.0
 Item {
     anchors.fill: parent
 
-    property real radian: .01745
-
     Item {
         id: rootitem
 
         anchors.centerIn: parent
-
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
-        Canvas {
-            id: backCircle
-
-            anchors.fill: parent
-            antialiasing: true
-            smooth: true
-            renderStrategy: Canvas.Cooperative
+        // Static background circle — plain Rectangle replaces Canvas
+        Rectangle {
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.height
+            radius: width / 2
+            color: Qt.rgba(1, 1, 1, .20)
             visible: !displayAmbient
-            onPaint: {
-                var ctx = getContext("2d")
-                ctx.reset()
-                ctx.fillStyle = Qt.rgba(1, 1, 1, .20)
-                ctx.beginPath()
-                ctx.arc(parent.height / 2, parent.width / 2, parent.width * .5, 0*radian, 360 * radian, false);
-                ctx.fill()
-                ctx.closePath()
-            }
         }
 
         Item {
@@ -70,27 +43,20 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .04
                 property real scalefactor: .482 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -99,7 +65,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -120,13 +86,14 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: -parent.width * .17
                 }
+                visible: nightstandMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
+                style: Text.Outline
+                styleColor: "#80000000"
                 font {
                     pixelSize: parent.width * .14
                     family: "Fyodor"
                 }
-                visible: nightstandMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
                 text: batteryChargePercentage.percent
             }
         }
@@ -135,6 +102,7 @@ Item {
             id: batteryChargePercentage
         }
 
+        // Hour numerals — static, paints once only
         Canvas {
             id: numberStrokes
 
@@ -142,8 +110,6 @@ Item {
             property real hoffset: -parent.height * .007
 
             anchors.fill: parent
-            antialiasing: true
-            smooth: true
             renderStrategy: Canvas.Cooperative
 
             onPaint: {
@@ -153,7 +119,7 @@ Item {
                 ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, .7) : Qt.rgba(.1, .1, .1, 1)
                 ctx.strokeStyle = displayAmbient ? Qt.rgba(1, 1, 1, .3) : Qt.rgba(1, 1, 1, .4)
                 ctx.textAlign = "center"
-                ctx.textBaseline = 'middle'
+                ctx.textBaseline = "middle"
                 ctx.translate(parent.width / 2, parent.height / 2)
                 for (var i = 1; i < 13; i++) {
                     ctx.beginPath()
@@ -162,22 +128,22 @@ Item {
                                  Math.cos((i - 3) / 12 * 2 * Math.PI) * height * .375 - hoffset,
                                  (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * .375) - voffset)
                     ctx.strokeText(i,
-                                 Math.cos((i - 3) / 12 * 2 * Math.PI) * height * .375 - hoffset,
-                                 (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * .375) - voffset)
+                                   Math.cos((i - 3) / 12 * 2 * Math.PI) * height * .375 - hoffset,
+                                   (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * .375) - voffset)
                     ctx.closePath()
                 }
             }
         }
 
+        // Hour strokes — static, paints once only
         Canvas {
             id: hourStrokes
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
-
                 ctx.lineWidth = parent.width * .015
                 ctx.strokeStyle = Qt.rgba(.1, .1, .1, .9)
                 ctx.translate(parent.width / 2, parent.height / 2)
@@ -191,20 +157,20 @@ Item {
             }
         }
 
+        // Minute strokes — static, paints once only
         Canvas {
             id: minuteStrokes
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.lineWidth = parent.width * .007
                 ctx.strokeStyle = Qt.rgba(.1, .1, .1, .9)
                 ctx.translate(parent.width / 2, parent.height / 2)
                 for (var i = 0; i < 60; i++) {
-                    // do not paint a minute stroke when there is an hour stroke
-                    if ((i % 5) != 0) {
+                    if ((i % 5) !== 0) {
                         ctx.beginPath()
                         ctx.moveTo(0, height * .45)
                         ctx.lineTo(0, height * .47)
@@ -220,17 +186,17 @@ Item {
 
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: parent.width*.015
+                horizontalCenterOffset: parent.width * .015
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: parent.height*.195
-            }
-            font {
-                pixelSize: parent.height * .08
-                family: "Fyodor"
+                verticalCenterOffset: parent.height * .195
             }
             renderType: Text.NativeRendering
             color: displayAmbient ? Qt.rgba(1, 1, 1, .7) : "black"
             horizontalAlignment: Text.AlignHCenter
+            font {
+                pixelSize: parent.height * .08
+                family: "Fyodor"
+            }
             text: Qt.formatDate(wallClock.time, "MMM dd")
         }
 
@@ -238,10 +204,11 @@ Item {
             id: hourHand
 
             property int hour: 0
+            property int minute: 0
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
@@ -253,18 +220,18 @@ Item {
                 ctx.lineWidth = parent.height * .0031
                 ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, .9) : Qt.rgba(0, 0, 0, 1)
                 ctx.strokeStyle = Qt.rgba(1, 1, 1, .4)
-                ctx.moveTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                           parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3.11 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26,
-                           parent.height / 2 + Math.sin(((hour - 3.11 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 8.68 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14,
-                           parent.height / 2 + Math.sin(((hour - 8.68 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 9.32 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14,
-                           parent.height / 2 + Math.sin(((hour - 9.32 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 2.89 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26,
-                           parent.height / 2 + Math.sin(((hour - 2.89 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                           parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
+                ctx.moveTo(parent.width / 2 + Math.cos(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .275,
+                           parent.height / 2 + Math.sin(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .275)
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3.11 + minute / 60) / 12) * 2 * Math.PI) * width * .26,
+                           parent.height / 2 + Math.sin(((hour - 3.11 + minute / 60) / 12) * 2 * Math.PI) * width * .26)
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 8.68 + minute / 60) / 12) * 2 * Math.PI) * width * .14,
+                           parent.height / 2 + Math.sin(((hour - 8.68 + minute / 60) / 12) * 2 * Math.PI) * width * .14)
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 9.32 + minute / 60) / 12) * 2 * Math.PI) * width * .14,
+                           parent.height / 2 + Math.sin(((hour - 9.32 + minute / 60) / 12) * 2 * Math.PI) * width * .14)
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 2.89 + minute / 60) / 12) * 2 * Math.PI) * width * .26,
+                           parent.height / 2 + Math.sin(((hour - 2.89 + minute / 60) / 12) * 2 * Math.PI) * width * .26)
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .275,
+                           parent.height / 2 + Math.sin(((hour - 3 + minute / 60) / 12) * 2 * Math.PI) * width * .275)
                 ctx.fill()
                 ctx.stroke()
                 ctx.closePath()
@@ -277,8 +244,8 @@ Item {
             property int minute: 0
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
@@ -314,9 +281,9 @@ Item {
             property int second: 0
 
             anchors.fill: parent
-            smooth: true
             renderStrategy: Canvas.Cooperative
             visible: !displayAmbient
+
             onPaint: {
                 var ctx = getContext("2d")
                 ctx.reset()
@@ -329,7 +296,7 @@ Item {
                 ctx.beginPath()
                 ctx.moveTo(parent.width / 2, parent.height / 2)
                 ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .07,
-                        parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .07)
+                           parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .07)
                 ctx.stroke()
                 ctx.closePath()
                 ctx.beginPath()
@@ -337,7 +304,7 @@ Item {
                 ctx.moveTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .07,
                            parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .07)
                 ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .16,
-                        parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .16)
+                           parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .16)
                 ctx.stroke()
                 ctx.closePath()
                 ctx.beginPath()
@@ -347,7 +314,7 @@ Item {
                 ctx.fill()
                 ctx.moveTo(parent.width / 2, parent.height / 2)
                 ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * .32,
-                        parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .32)
+                           parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .32)
                 ctx.stroke()
                 ctx.closePath()
             }
@@ -368,20 +335,23 @@ Item {
                 var hour = wallClock.time.getHours()
                 var minute = wallClock.time.getMinutes()
                 var second = wallClock.time.getSeconds()
-                if(secondHand.second !== second) {
+                if (secondHand.second !== second) {
                     secondHand.second = second
                     secondHand.requestPaint()
-                }if(hourHand.hour !== hour) {
+                }
+                if (hourHand.hour !== hour) {
                     hourHand.hour = hour
-                }if(minuteHand.minute !== minute) {
+                }
+                if (minuteHand.minute !== minute) {
                     minuteHand.minute = minute
+                    hourHand.minute = minute
                     minuteHand.requestPaint()
                     hourHand.requestPaint()
                 }
             }
-         }
+        }
 
-         Component.onCompleted: {
+        Component.onCompleted: {
             var hour = wallClock.time.getHours()
             var minute = wallClock.time.getMinutes()
             var second = wallClock.time.getSeconds()
@@ -389,8 +359,9 @@ Item {
             secondHand.requestPaint()
             minuteHand.minute = minute
             minuteHand.requestPaint()
-            hourHand.hour = hournightstandMode
+            hourHand.hour = hour
+            hourHand.minute = minute
             hourHand.requestPaint()
-         }
+        }
     }
 }

--- a/src/watchfaces/015-funky-town-words.qml
+++ b/src/watchfaces/015-funky-town-words.qml
@@ -1,36 +1,10 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2014 - Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick 2.15
 import QtQuick.Shapes 1.15
@@ -46,30 +20,45 @@ Item {
 
     Item {
         anchors.centerIn: parent
-
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
-        Image {
-            anchors.centerIn: parent
-            source: imgPath +
-                    wallClock.time.toLocaleString(Qt.locale(), "hh am").slice(0, 2) +
-                    (nightstandMode.active || displayAmbient ? "-bw.svg" : ".svg")
-            sourceSize.width: parent.width
-            sourceSize.height: parent.height
-            width: parent.width
-            height: parent.height
-        }
+        // OpacityMask clips square SVGs to circle on round screens — layer disabled on square screens for zero cost
+        Item {
+            id: imageWrapper
 
-        Image {
-            anchors.centerIn: parent
-            source: imgPath +
-                    wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase().slice(0, 2) + ".svg"
-            visible: use12H.value
-            sourceSize.width: parent.width
-            sourceSize.height: parent.height
-            width: parent.width
-            height: parent.height
+            anchors.fill: parent
+            layer.enabled: DeviceSpecs.hasRoundScreen
+            layer.effect: OpacityMask {
+                maskSource: Rectangle {
+                    width: imageWrapper.width
+                    height: imageWrapper.height
+                    radius: width / 2
+                    visible: false
+                }
+            }
+
+            Image {
+                anchors.centerIn: parent
+                width: parent.width
+                height: parent.height
+                source: imgPath +
+                        wallClock.time.toLocaleString(Qt.locale(), "hh am").slice(0, 2) +
+                        (nightstandMode.active || displayAmbient ? "-bw.svg" : ".svg")
+                sourceSize.width: parent.width
+                sourceSize.height: parent.height
+            }
+
+            Image {
+                anchors.centerIn: parent
+                width: parent.width
+                height: parent.height
+                visible: use12H.value
+                source: imgPath +
+                        wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase().slice(0, 2) + ".svg"
+                sourceSize.width: parent.width
+                sourceSize.height: parent.height
+            }
         }
 
         Text {
@@ -79,14 +68,14 @@ Item {
                 bottom: parent.bottom
                 bottomMargin: parent.height * .15
                 horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: parent.width*.2
+                horizontalCenterOffset: parent.width * .2
             }
+            color: nightstandMode.active || displayAmbient ? "#000" : "#fff"
             font {
                 pixelSize: parent.height * .22
                 family: "Source Sans Pro"
                 styleName: "Light"
             }
-            color: nightstandMode.active || displayAmbient ? "#000" : "#fff"
             text: wallClock.time.toLocaleString(Qt.locale(), "mm")
 
             Behavior on text {
@@ -107,27 +96,20 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .016
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -136,7 +118,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -157,14 +139,13 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: -parent.width * .28
                 }
-
+                visible: nightstandMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
                 font {
                     pixelSize: parent.width * .13
                     family: "Source Sans Pro"
                     styleName: "Light"
                 }
-                visible: nightstandMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
                 text: batteryChargePercentage.percent
             }
         }
@@ -173,19 +154,11 @@ Item {
             id: batteryChargePercentage
         }
 
-        MceBatteryState {
-            id: batteryChargeState
-        }
-
-        MceCableState {
-            id: mceCableState
-        }
-
         Component.onCompleted: {
-            burnInProtectionManager.leftOffset = Qt.binding(function() { return width * nightstandMode.active ? .05 : .4})
-            burnInProtectionManager.rightOffset = Qt.binding(function() { return width * .05})
-            burnInProtectionManager.topOffset = Qt.binding(function() { return height * nightstandMode.active ? .05 : .4})
-            burnInProtectionManager.bottomOffset = Qt.binding(function() { return height * .05})
+            burnInProtectionManager.leftOffset = Qt.binding(function() { return width * (nightstandMode.active ? .05 : .4) })
+            burnInProtectionManager.rightOffset = Qt.binding(function() { return width * .05 })
+            burnInProtectionManager.topOffset = Qt.binding(function() { return height * (nightstandMode.active ? .05 : .4) })
+            burnInProtectionManager.bottomOffset = Qt.binding(function() { return height * .05 })
         }
     }
 }

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -1,27 +1,12 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*
  * Based on a fragmentShader example from doc.qt.io. Design is heavily
@@ -36,69 +21,68 @@ import org.asteroid.utils 1.0
 import Nemo.Mce 1.0
 
 Item {
+    id: root
+
     anchors.fill: parent
 
-    property string imgPath: "../watchfaces-img/funky-town-words-"
+    // sq is the largest square that fits on any screen — text and mask geometry reference this
+    property real sq: Math.min(width, height)
 
-    Item {
-        anchors.centerIn: parent
+    // ShaderEffect stencil — numerals are cut from the wallpaper color.
+    // This watchface requires a non-black wallpaper to be visible.
+    Rectangle {
+        id: layer2mask
 
-        height: parent.width > parent.height ? parent.height : parent.width
-        width: height
+        anchors.fill: parent
+        color: displayAmbient ? Qt.rgba(1, 1, 1, .8) : Qt.rgba(0, 0, 0, .8)
+        opacity: .0
+        layer.enabled: true
+        // nightstand shrinks the visible circle; round screens clip to sq circle; square screens use no radius
+        radius: nightstand ? root.sq * .86 : DeviceSpecs.hasRoundScreen ? root.sq : 0
+    }
 
-        Rectangle {
-            id: layer2mask
+    Rectangle {
+        id: _mask
+
+        anchors.fill: parent
+        color: Qt.rgba(0, 1, 0, 0)
+
+        // textRoot preserves the square geometry all text items were authored against
+        Item {
+            id: textRoot
 
             anchors.centerIn: parent
-            width: parent.width * (nightstand ? .86 : 1)
+            width: nightstand ? root.sq * .86 : root.sq
             height: width
-            color: displayAmbient ? Qt.rgba(1, 1, 1, .8) : Qt.rgba(0, 0, 0, .8)
-            visible: true
-            opacity: .0
-            layer.enabled: true
-            layer.smooth: true
-            radius: DeviceSpecs.hasRoundScreen || nightstand ? width : 0
-        }
-
-        Rectangle {
-            id: _mask
-
-            anchors.fill: layer2mask
-            color: Qt.rgba(0, 1, 0, 0)
-            visible: true
 
             Text {
                 property real voffset: parent.height * .01
 
                 renderType: Text.NativeRendering
+                color: Qt.rgba(1, 1, 1, 1)
+                y: parent.height / 3 - height / 2 + voffset
+                x: -parent.width * .055
                 font {
                     pixelSize: parent.height * .58
                     letterSpacing: -parent.width * .08
                     family: "League Spartan"
                 }
-                color: Qt.rgba(1, 1, 1, 1)
-                y: parent.height / 3 - height / 2 + voffset
-                x: -parent.width * .055
-                text: if (use12H.value) {
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2).replace(/1/g," 1 ") }
-                      else
-                          wallClock.time.toLocaleString(Qt.locale(), "HH").replace(/1/g," 1 ")
-
-
+                text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2).replace(/1/g," 1 ") :
+                                     wallClock.time.toLocaleString(Qt.locale(), "HH").replace(/1/g," 1 ")
             }
 
             Text {
                 property real voffset: parent.height * .075
 
                 renderType: Text.NativeRendering
+                color: Qt.rgba(1, 1, 1, 1)
+                y: parent.height / 1.3 - height / 2 + voffset
+                x: parent.width * .25
                 font {
                     pixelSize: parent.height * .58
                     letterSpacing: -parent.width * .06
                     family: "League Spartan"
                 }
-                color: Qt.rgba(1, 1, 1, 1)
-                y: parent.height / 1.3 - height / 2 + voffset
-                x: parent.width*.25
                 text: wallClock.time.toLocaleString(Qt.locale(), "<b>mm</b>").replace(/1/g,"&nbsp;1")
             }
 
@@ -110,13 +94,13 @@ Item {
                     left: parent.horizontalCenter
                     leftMargin: parent.height * .19
                 }
+                visible: !displayAmbient
+                color: Qt.rgba(1, 1, 1, 1)
                 font {
                     pixelSize: parent.height * .24
                     letterSpacing: -parent.width * .025
                     family: "League Spartan"
                 }
-                color: Qt.rgba(1, 1, 1, 1)
-                visible: !displayAmbient
                 text: wallClock.time.toLocaleString(Qt.locale(), "<b>ss</b>").replace(/1/g,"&nbsp;1")
             }
 
@@ -128,15 +112,15 @@ Item {
                     left: parent.horizontalCenter
                     leftMargin: parent.height * .222
                 }
+                visible: use12H.value
+                lineHeight: .9
+                color: Qt.rgba(1, 1, 1, 1)
+                horizontalAlignment: Text.AlignRight
                 font {
                     pixelSize: parent.height * .1
                     letterSpacing: -parent.width * .01
                     family: "League Spartan"
                 }
-                visible: use12H.value
-                lineHeight: .9
-                color: Qt.rgba(1, 1, 1, 1)
-                horizontalAlignment: Text.AlignRight
                 text: wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase()
             }
 
@@ -148,14 +132,14 @@ Item {
                     right: parent.horizontalCenter
                     rightMargin: parent.height * .24
                 }
-                font{
+                lineHeight: .7
+                color: Qt.rgba(1, 1, 1, 1)
+                horizontalAlignment: Text.AlignRight
+                font {
                     pixelSize: parent.height * .24
                     letterSpacing: -parent.width * .025
                     family: "League Spartan"
                 }
-                lineHeight: .7
-                color: Qt.rgba(1, 1, 1, 1)
-                horizontalAlignment: Text.AlignRight
                 text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b>").toLowerCase()
             }
 
@@ -167,92 +151,85 @@ Item {
                     right: parent.horizontalCenter
                     rightMargin: parent.height * .23
                 }
-                font {
-                    pixelSize: parent.height*.1
-                    letterSpacing: -parent.width * .01
-                    family: "League Spartan"
-                }
                 lineHeight: .7
                 color: Qt.rgba(1, 1, 1, 1)
                 horizontalAlignment: Text.AlignRight
+                font {
+                    pixelSize: parent.height * .1
+                    letterSpacing: -parent.width * .01
+                    family: "League Spartan"
+                }
                 text: wallClock.time.toLocaleString(Qt.locale(), "MMM").toLowerCase()
-            }
-
-            layer.enabled: true
-            layer.samplerName: "maskSource"
-            layer.effect: ShaderEffect {
-                property variant source: layer2mask
-                property bool keepInner: displayAmbient
-                fragmentShader: "
-                        varying highp vec2 qt_TexCoord0;
-                        uniform highp float qt_Opacity;
-                        uniform lowp sampler2D source;
-                        uniform lowp sampler2D maskSource;
-                        uniform bool keepInner;
-                        void main(void) {
-                            if (keepInner) {
-                                gl_FragColor = texture2D(source, qt_TexCoord0.st) * (texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
-                            } else {
-                                gl_FragColor = texture2D(source, qt_TexCoord0.st) * (1.0-texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
-                            }
-                        }
-                    "
             }
         }
 
-        Item {
-            id: nightstandMode
+        layer.enabled: !displayAmbient
+        layer.samplerName: "maskSource"
+        layer.effect: ShaderEffect {
+            property variant source: layer2mask
+            property bool keepInner: displayAmbient
+            fragmentShader: "
+                    varying highp vec2 qt_TexCoord0;
+                    uniform highp float qt_Opacity;
+                    uniform lowp sampler2D source;
+                    uniform lowp sampler2D maskSource;
+                    uniform bool keepInner;
+                    void main(void) {
+                        if (keepInner) {
+                            gl_FragColor = texture2D(source, qt_TexCoord0.st) * (texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+                        } else {
+                            gl_FragColor = texture2D(source, qt_TexCoord0.st) * (1.0-texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+                        }
+                    }
+                "
+        }
+    }
 
-            readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
+    Item {
+        id: nightstandMode
+
+        readonly property bool active: nightstand
+        property int batteryPercentChanged: batteryChargePercentage.percent
+
+        anchors.fill: parent
+        layer.enabled: true
+        layer.samples: 4
+        visible: nightstandMode.active
+
+        Shape {
+            id: chargeArc
+
+            property real angle: batteryChargePercentage.percent * 360 / 100
+            property real arcStrokeWidth: .022
+            property real scalefactor: .45 - (arcStrokeWidth / 2)
+            property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+            readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
             anchors.fill: parent
-            visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
-            Shape {
-                id: chargeArc
+            ShapePath {
+                fillColor: "transparent"
+                strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
+                strokeWidth: parent.height * chargeArc.arcStrokeWidth
+                capStyle: ShapePath.FlatCap
+                joinStyle: ShapePath.MiterJoin
+                startX: chargeArc.width / 2
+                startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
-                property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
-                property real arcStrokeWidth: .022
-                property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
-
-                anchors.fill: parent
-                smooth: true
-                antialiasing: true
-
-                ShapePath {
-                    fillColor: "transparent"
-                    strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
-                    strokeWidth: parent.height * chargeArc.arcStrokeWidth
-                    capStyle: ShapePath.FlatCap
-                    joinStyle: ShapePath.MiterJoin
-                    startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
-
-                    PathAngleArc {
-                        centerX: chargeArc.width / 2
-                        centerY: chargeArc.height / 2
-                        radiusX: chargeArc.scalefactor * chargeArc.width
-                        radiusY: chargeArc.scalefactor * chargeArc.height
-                        startAngle: -90
-                        sweepAngle: chargeArc.angle
-                        moveToStart: false
-                    }
+                PathAngleArc {
+                    centerX: chargeArc.width / 2
+                    centerY: chargeArc.height / 2
+                    radiusX: chargeArc.scalefactor * chargeArc.width
+                    radiusY: chargeArc.scalefactor * chargeArc.height
+                    startAngle: -90
+                    sweepAngle: chargeArc.angle
+                    moveToStart: false
                 }
             }
         }
+    }
 
-        MceBatteryLevel {
-            id: batteryChargePercentage
-        }
+    MceBatteryLevel {
+        id: batteryChargePercentage
     }
 }

--- a/src/watchfaces/017-contemporary-digital-rings.qml
+++ b/src/watchfaces/017-contemporary-digital-rings.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/eLtMosen>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*
  * Based on analog-precison by Mario Kicherer. Remodeled the arms to arcs
@@ -39,94 +24,96 @@ import Nemo.Mce 1.0
 Item {
     anchors.fill: parent
 
-    property real radian: .01745
-
-    function prepareContext(ctx) {
-        ctx.reset()
-        ctx.shadowColor = (0, 0, 0, .25)
-        ctx.shadowOffsetX = 0
-        ctx.shadowOffsetY = 0
-        ctx.shadowBlur = parent.height * .00625
-        ctx.lineCap= "round"
-    }
-
     Item {
-        anchors.centerIn: parent
+        id: root
 
+        anchors.centerIn: parent
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
         Rectangle {
-            x: parent.width / 2-width / 2
-            y: parent.height / 2-width / 2
-            color: Qt.rgba(0, 0, 0, .2)
+            anchors.centerIn: parent
             width: parent.width / 1.3
-            height: parent.height / 1.3
+            height: width
             radius: width * .5
+            color: Qt.rgba(0, 0, 0, .2)
         }
 
-        Canvas {
-            id: secondCanvas
-
-            property int second: 0
+        // Second arc — outermost ring, red, declarative sweep from wallClock binding
+        Shape {
+            id: secondArc
 
             anchors.fill: parent
-            smooth: true
-            renderStrategy: Canvas.Cooperative
             visible: !displayAmbient && !nightstandMode.active
-            onPaint: {
-                var ctx = getContext("2d")
-                var rot = (wallClock.time.getSeconds() - 15) * 6
-                var rot_half = (wallClock.time.getSeconds() - 22) * 6
-                prepareContext(ctx)
-                ctx.beginPath()
-                ctx.arc(parent.width / 2, parent.height / 2, width / 2.2, -89.5 * radian, rot* radian, false);
-                ctx.lineWidth = parent.width * .009375
-                ctx.strokeStyle = Qt.rgba(.871, .165, .102, .95)
-                ctx.stroke()
+
+            property real secondAngle: 0
+
+            ShapePath {
+                strokeColor: Qt.rgba(.871, .165, .102, .95)
+                strokeWidth: root.width * .009375
+                fillColor: "transparent"
+                capStyle: ShapePath.RoundCap
+
+                PathAngleArc {
+                    centerX: root.width / 2
+                    centerY: root.height / 2
+                    radiusX: root.width / 2.2
+                    radiusY: root.height / 2.2
+                    startAngle: -89.5
+                    sweepAngle: secondArc.secondAngle
+                }
             }
         }
 
-        Canvas {
-            id: minuteCanvas
-
-            property int minute: 0
+        // Minute arc — middle ring, orange, declarative sweep from wallClock binding
+        Shape {
+            id: minuteArc
 
             anchors.fill: parent
-            smooth: true
-            renderStrategy: Canvas.Cooperative
             visible: !displayAmbient && !nightstandMode.active
-            onPaint: {
-                var ctx = getContext("2d")
-                var rot = (minute -15 ) * 6
-                prepareContext(ctx)
-                ctx.beginPath()
-                ctx.arc(parent.width / 2, parent.height / 2, width / 2.33, -88.8 * radian, rot * radian, false);
-                ctx.lineWidth = parent.width * .01875
-                ctx.strokeStyle = Qt.rgba(1, .549, .149, .95)
-                ctx.stroke()
+
+            property real minuteAngle: 0
+
+            ShapePath {
+                strokeColor: Qt.rgba(1, .549, .149, .95)
+                strokeWidth: root.width * .01875
+                fillColor: "transparent"
+                capStyle: ShapePath.RoundCap
+
+                PathAngleArc {
+                    centerX: root.width / 2
+                    centerY: root.height / 2
+                    radiusX: root.width / 2.33
+                    radiusY: root.height / 2.33
+                    startAngle: -88.8
+                    sweepAngle: minuteArc.minuteAngle
+                }
             }
         }
 
-        Canvas {
-            id: hourCanvas
-
-            property int hour: 0
+        // Hour arc — inner ring, gold, start offset at 273.5° aligns arc origin just past 12 o'clock
+        Shape {
+            id: hourArc
 
             anchors.fill: parent
-            smooth: true
-            renderStrategy: Canvas.Cooperative
             visible: !displayAmbient && !nightstandMode.active
-            onPaint: {
-                var ctx = getContext("2d")
-                var rot = .5 * (60 * (hour - 3) + wallClock.time.getMinutes())
-                prepareContext(ctx)
-                ctx.beginPath()
-                ctx.arc(parent.width / 2, parent.height / 2, width / 2.6,  273.5 * radian, rot * radian, false);
-                ctx.lineWidth = parent.width * .05
-                ctx.strokeStyle = Qt.rgba(.945, .769, .059, .95)
-                ctx.stroke()
-                ctx.beginPath()
+
+            property real hourAngle: 0
+
+            ShapePath {
+                strokeColor: Qt.rgba(.945, .769, .059, .95)
+                strokeWidth: root.width * .05
+                fillColor: "transparent"
+                capStyle: ShapePath.RoundCap
+
+                PathAngleArc {
+                    centerX: root.width / 2
+                    centerY: root.height / 2
+                    radiusX: root.width / 2.6
+                    radiusY: root.height / 2.6
+                    startAngle: 273.5
+                    sweepAngle: hourArc.hourAngle
+                }
             }
         }
 
@@ -139,40 +126,36 @@ Item {
                 verticalCenter: parent.verticalCenter
                 verticalCenterOffset: parent.height * .0281
             }
-            font {
-                pixelSize: parent.height * .375
-                family: "Titillium"
-                styleName: 'Bold'
-                letterSpacing: -3
-            }
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
-            text: if (use12H.value) {
-                      wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) }
-                  else
-                      wallClock.time.toLocaleString(Qt.locale(), "HH")
+            font {
+                pixelSize: parent.height * .375
+                family: "Titillium"
+                styleName: "Bold"
+                letterSpacing: -3
+            }
+            text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
+                                 wallClock.time.toLocaleString(Qt.locale(), "HH")
         }
 
         Text {
             id: minuteDisplay
 
-            property real rotM: (wallClock.time.getMinutes() - 12.1) / 60
-
             anchors {
-                top: hourDisplay.top;
+                top: hourDisplay.top
                 topMargin: -parent.height * .015625
+                left: hourDisplay.right
                 leftMargin: parent.width * .025
-                left: hourDisplay.right;
-            }
-            font {
-                pixelSize: parent.height * .1375
-                styleName: 'Semibold'
-                letterSpacing: -1
             }
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
+            font {
+                pixelSize: parent.height * .1375
+                styleName: "Semibold"
+                letterSpacing: -1
+            }
             text: wallClock.time.toLocaleString(Qt.locale(), "mm")
         }
 
@@ -180,23 +163,23 @@ Item {
             id: secondDisplay
 
             anchors {
-                bottom: hourDisplay.bottom;
+                bottom: hourDisplay.bottom
                 bottomMargin: parent.height * .059375
+                left: hourDisplay.right
                 leftMargin: parent.width * .025
-                left: hourDisplay.right;
             }
+            visible: !displayAmbient
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignHCenter
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .5)
             font {
                 pixelSize: parent.height * .1375
                 family: "Titillium"
-                styleName: 'Thin'
+                styleName: "Thin"
                 letterSpacing: -1
             }
-            color: Qt.rgba(1, 1, 1, 1)
-            style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
-            horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "ss")
-            visible: !displayAmbient
         }
 
         Text {
@@ -207,15 +190,15 @@ Item {
                 left: parent.left
                 right: parent.right
             }
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignHCenter
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .5)
             font {
                 pixelSize: parent.height * .084375
                 family: "Titillium"
-                styleName: 'Thin'
+                styleName: "Thin"
             }
-            color: Qt.rgba(1, 1, 1, 1)
-            style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
-            horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
         }
 
@@ -223,20 +206,20 @@ Item {
             id: dateDisplay
 
             anchors {
-                topMargin: -parent.height * .05
                 top: hourDisplay.bottom
+                topMargin: -parent.height * .05
                 left: parent.left
                 right: parent.right
             }
-            font {
-                pixelSize: parent.height*.084375
-                family: "Titillium"
-                styleName:'Thin'
-            }
             color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignHCenter
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
-            horizontalAlignment: Text.AlignHCenter
+            font {
+                pixelSize: parent.height * .084375
+                family: "Titillium"
+                styleName: "Thin"
+            }
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b> MMMM")
         }
 
@@ -244,21 +227,21 @@ Item {
             id: pmDisplay
 
             anchors {
-                bottomMargin: +parent.height * .018
                 bottom: dowDisplay.top
+                bottomMargin: parent.height * .018
                 left: parent.left
                 right: parent.right
             }
+            visible: use12H.value
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignHCenter
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, .5)
             font {
                 pixelSize: parent.height * .05
                 family: "Titillium"
-                styleName: 'Semibold'
+                styleName: "Semibold"
             }
-            color: Qt.rgba(1, 1, 1, 1)
-            style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
-            horizontalAlignment: Text.AlignHCenter
-            visible: use12H.value
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>ap</b>")
         }
 
@@ -269,27 +252,20 @@ Item {
             property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
+            layer.enabled: true
+            layer.samples: 4
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .03
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -298,7 +274,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -315,7 +291,6 @@ Item {
             Icon {
                 id: batteryIcon
 
-                name: "ios-battery-charging"
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: -parent.width * .316
@@ -323,6 +298,7 @@ Item {
                 visible: nightstandMode.active
                 width: parent.width * .14
                 height: parent.height * .14
+                name: "ios-battery-charging"
             }
 
             ColorOverlay {
@@ -338,15 +314,15 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: parent.width * .324
                 }
-
+                visible: nightstandMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
+                style: Text.Outline
+                styleColor: "#80000000"
                 font {
                     pixelSize: parent.width * .09
                     family: "Titillium"
                     styleName: "ExtraCondensed"
                 }
-                visible: nightstandMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
                 text: batteryChargePercentage.percent + "%"
             }
         }
@@ -358,36 +334,24 @@ Item {
         Connections {
             target: wallClock
             function onTimeChanged() {
-                if (displayAmbient) return
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var second = wallClock.time.getSeconds()
-                if(secondCanvas.second !== second) {
-                    secondCanvas.second = second
-                    secondCanvas.requestPaint()
-                } if(hourCanvas.hour !== hour) {
-                    hourCanvas.hour = hour
-                }if(minuteCanvas.minute !== minute) {
-                    minuteCanvas.minute = minute
-                    minuteCanvas.requestPaint()
-                    hourCanvas.requestPaint()
-                }
+                var h = wallClock.time.getHours()
+                var min = wallClock.time.getMinutes()
+                var sec = wallClock.time.getSeconds()
+                secondArc.secondAngle = Math.max(0, sec * 6 - 0.5)
+                minuteArc.minuteAngle = Math.max(0, min * 6 - 1.2)
+                hourArc.hourAngle = ((h * 30 + min * 0.5 - 3.5) % 360 + 360) % 360
             }
         }
 
         Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var second = wallClock.time.getSeconds()
-            secondCanvas.second = second
-            secondCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * nightstandMode.active ? .08 : .3})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * nightstandMode.active ? .08 : .3})
+            var h = wallClock.time.getHours()
+            var min = wallClock.time.getMinutes()
+            var sec = wallClock.time.getSeconds()
+            secondArc.secondAngle = Math.max(0, sec * 6 - 0.5)
+            minuteArc.minuteAngle = Math.max(0, min * 6 - 1.2)
+            hourArc.hourAngle = ((h * 30 + min * 0.5 - 3.5) % 360 + 360) % 360
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .3) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .3) })
         }
     }
 }


### PR DESCRIPTION
Updated 2026-04-21

## Overview

The `WallClock.enabled` fix that motivated this PR has already merged separately:
binding `enabled: desktop.visible` in MainScreen.qml stops the clock ticking behind
active apps. Verified with dodoradio via console log: `desktop.visible` is `false`
when an app is foregrounded and `true` during peek-to-homescreen and whenever the
launcher surface is active. The redundant `if (!visible) return` guards that
pre-existed in several watchfaces have been removed as part of this PR.

This PR refactors all 18 numbered watchfaces (000–017) for performance, correctness,
and code quality. All license headers are converted from LGPL/BSD prose blocks to
SPDX identifiers.

## SPDX license header conversion

All 18 watchfaces converted from multi-line prose license blocks to compact SPDX
identifiers. Duplicate copyright entries for the same author consolidated to the
oldest year. The 2012 triple-author line expanded to three individual
`SPDX-FileCopyrightText` lines throughout.

## Performance

**Canvas arcs replaced with declarative Shape+PathAngleArc** in
analog-scientific-v2, analog-weather-satellite, and contemporary-digital-rings.
Static full-circle backgrounds and battery/progress arcs are now declarative
`PathAngleArc` bindings. Eliminates `requestPaint` callbacks, stored arc
properties, and JS execution that previously ran every second.

**DropShadow samples reduced to 9** across all watchfaces. Previous values ranged
from 12 to 41. At watch screen resolution 9 samples are indistinguishable from
higher counts and the shader cost scales linearly with sample count.

**`smooth: true` and `antialiasing: true` removed** from all Canvas items where
present. `smooth` has no effect on Canvas elements. `antialiasing` on a Canvas
forces unnecessary compositor work. Both were removed from hourCanvas, minuteCanvas,
secondCanvas, and static stroke canvases throughout.

**`textureSize: Qt.size(width*2, height*2)` removed from all nightstandMode layer
blocks**. Double-resolution offscreen texture upload caused visible stutter on
nightstand mode activation. Removed from all affected watchfaces.

**DropShadow layer removed from continuously animating second hands** in
analog-circle-shades, analog-scientific-v2, and analog-aviator. A layer with a
DropShadow effect on a 16ms-updating Image forces a full 60fps shader recomposite
on every frame. Second hand Images now have no layer.

**16ms sweep Timer added** to analog-circle-shades, analog-scientific-v2, and
analog-weather-satellite, replacing `Behavior on angle`. Uses `new Date()` for
millisecond precision, eliminating the catch-up animation that played on watchface
return after visiting an app.

**Live `wallClock.time` reads moved out of Canvas `onPaint` handlers** throughout.
All Canvas `onPaint` bodies now read only from stored properties (`property int
hour`, `property string ap`, `property string dateText` etc.) that are assigned and
change-gated in the `Connections` block. Prevents redundant clock method calls
during repaint cycles.

**Orbiting text trig bindings moved from property declarations to Connections** in
analog-circle-shades and bold-hour-bebas. `Math.cos/sin` expressions in property
bindings re-evaluated every second; moved to imperative assignments in `Connections`
and `Component.onCompleted`.

**`currentMonth` and `currentDayName` lifted to root scope** in analog-scientific-v2,
eliminating 31 per-second `wallClock.time` reads across all day and month delegate
items.

## Correctness fixes

**`monthBox.month` format string bug fixed** in analog-scientific-v2. `"mm"` (minutes)
was used instead of `"MM"` (month), causing the monthly progress arc to repaint
every minute instead of every month.

**`hourHand.hour = hournightstandMode` typo fixed** in analog-50s-americana. The
concatenated identifier evaluated to `undefined` in JS, which coerced to `0` on a
QML `int` property, leaving the hour hand permanently at midnight. Present since
the watchface was added.

**Identical-branch source ternary fixed** in analog-aviator. Both branches of the
hour and minute SVG source expressions resolved to the ambient variant, meaning the
colored hands never displayed.

**`ctx.shadowColor = (0,0,0,.25)` JS comma-operator bug fixed** in
contemporary-digital-rings. The comma operator discards all but the last operand,
so `shadowColor` was assigned `0.25` — a number — which the Canvas API silently
ignores. Canvas shadows have never worked on this watchface.

**Missing `readonly property var colorArray` added to chargeArc** in
masked-spartan. The `ShapePath.strokeColor` binding referenced `chargeArc.colorArray`
which was never declared, causing a silent crash in nightstand mode.

**Operator precedence bug fixed** in funky-town-words, contemporary-digital-rings,
and analog-words `burnInProtectionManager` bindings. `width * condition ? a : b`
evaluates as `(width * condition) ? a : b` not `width * (condition ? a : b)`.
Parentheses added throughout.

**Beluga full-screen layout fixed** in masked-spartan and contemporary-digital-rings.
The square root Item constraint left 20px strips at top and bottom on Beluga
(320×360). masked-spartan restructured with `anchors.fill: parent` root and a
`Math.min(width, height)` square reference for text geometry.
contemporary-digital-rings arc `PathAngleArc` radius references corrected from
unresolvable `parent.width/height` inside `ShapePath` to the named root Item id.

**AoD compositor glitch fixed in masked-spartan**. The ShaderEffect layer is
disabled when `displayAmbient` is true, rendering plain white numerals on the dark
ambient background instead of running the stencil shader against an absent wallpaper.

**Redundant `if (!visible) return` wallClock guards removed** from all watchfaces
where present. These were made redundant by the `WallClock.enabled: desktop.visible`
fix in MainScreen.qml that has already merged.

## Code quality

All `Connections` blocks updated to Qt 5.15 `function onSignalName()` syntax,
replacing the deprecated Qt 5.14 `onSignalName: { }` slot form which generates
build warnings.

`layer { enabled: true; samples: 4 }` sub-object blocks flattened to
`layer.enabled: true` / `layer.samples: 4` dot-notation throughout. Sub-blocks
are appropriate only when nesting more than two properties.

`property var` changed to `property int` on all `chargecolor` properties across all
segmentedArc Repeaters, and on `hour`, `minute`, `second` stored properties on
Canvas items throughout.

`if`/`else` expressions in property bindings converted to ternary operators across
all watchfaces. Multi-line ternary continuations aligned consistently.

`==` and `!=` replaced with `===` and `!==` strict equality in all `Connections`
handlers and `for` loop conditions throughout.

`Text` items with two-property `anchors {}` blocks converted to inline
`anchors.centerIn` or expanded `anchors { }` per the number of properties.
Property ordering normalised: `anchors`, `visible`, `color`, `opacity`, then
`font {}`, then `text` throughout.

Trailing whitespace removed from all 18 files. Kate editor auto-indent had
introduced whitespace-only lines throughout previous commits.

UTF-8 BOM removed from analog-weather-satellite.

Unused `property real radian` removed from watchfaces where Canvas arcs were
eliminated. Unused Mce imports (`MceBatteryState`, `MceCableState`) removed from
funky-town-words.

`z: 0` default-value declarations removed from numerals-duo-synth-neon-green.
The deliberate `z: 2` on analog-words `circleBack` is retained and documented
with a comment, as it is a legitimate use of z-ordering for dynamic layer
management that declaration order alone cannot satisfy.

Design comment added to masked-spartan noting that the ShaderEffect stencil
requires a non-black wallpaper to be visible, as the numeral shapes are cut from
the wallpaper color.