### PR TITLE
QuickPanelToggle: handle press-and-hold stealing

### DIFF
--- a/src/qml/quickpanel/QuickPanelToggle.qml
+++ b/src/qml/quickpanel/QuickPanelToggle.qml
@@ -60,6 +60,11 @@ MouseArea {
         directionChangeTimer.stop()
     }
 
+    onCanceled: {
+        holdTimer.stop()
+        directionChangeTimer.stop()
+    }
+
     Timer {
         id: holdTimer
         interval: 300


### PR DESCRIPTION
the flickable of the listview steals gestures when it detects a swipe, which doesn't trigger onReleased. Add a handler for onCanceled to fix the issues this causes.