### PR TITLE
asteroid-launcher: stop wallClock ticking when launcher grid is not shown

### DIFF
--- a/src/qml/MainScreen.qml
+++ b/src/qml/MainScreen.qml
@@ -169,7 +169,7 @@ Item {
 
     WallClock {
         id: wallClock
-        enabled: true
+        enabled: desktop.visible
         updateFrequency: WallClock.Second
     }
 


### PR DESCRIPTION
Bind wallClock.enabled to desktop.visible instead of hardcoded true, clock now pauses when an app is shown and starts again on peek or when launcher gird is visible