### PR TITLE
Fix quick panel swipe and button interaction

### DIFF
--- a/src/gesturefilterarea.cpp
+++ b/src/gesturefilterarea.cpp
@@ -159,6 +159,7 @@ void GestureFilterArea::mouseReleaseEvent(QMouseEvent *event) {
                 currVel = m_velocityY;
             emit swipeReleased(m_horizontal, currVel, m_tracing);
             m_pressed = false;
+            ungrabMouse();
         }
     }
 }

--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -345,6 +345,7 @@ Item {
         snapMode: ListView.SnapOneItem
         clip: true
         interactive: true
+        pressDelay: 200
         boundsBehavior: Flickable.StopAtBounds
         spacing: Dims.l(4)
 

--- a/src/qml/quickpanel/QuickPanelToggle.qml
+++ b/src/qml/quickpanel/QuickPanelToggle.qml
@@ -35,6 +35,7 @@ MouseArea {
 
     width: parent.width
     height: width
+    preventStealing: true
 
     property alias icon: ic.name
     property bool checkable: false


### PR DESCRIPTION
The content Item in PanelsGrid had no explicit size so hit-testing never reached child items (contains() returns false for a 0x0 item). Give it 3x3 panel dimensions and offset panel positions by +1 to keep local coords non-negative.

Release the mouse grab after swipeReleased so clicks arent swallowed by GestureFilterArea. Add preventStealing and pressDelay so toggle buttons actually work inside the flickable.

Also fix the QtGraphicalEffects import to 1.0 which matches the version that ships with the image.

Related PRs:
- https://github.com/AsteroidOS/meta-smartwatch/pull/299 (emulator machine config fix)
- https://github.com/AsteroidOS/asteroid/pull/337 (run-emulator.sh launch script)