### PR TITLE
Fix memory leaks, uninitialized members, and shell escaping

### DIFF
--- a/src/firstrun.cpp
+++ b/src/firstrun.cpp
@@ -33,9 +33,9 @@
 #include <QDBusPendingCall>
 #include <QDBusVariant>
 
-FirstRun::FirstRun()
+FirstRun::FirstRun(QObject *parent) : QObject(parent)
 {
-    m_mceDbus = new QDBusInterface("com.nokia.mce", "/com/nokia/mce/request", "com.nokia.mce.request", QDBusConnection::systemBus());
+    m_mceDbus = new QDBusInterface("com.nokia.mce", "/com/nokia/mce/request", "com.nokia.mce.request", QDBusConnection::systemBus(), this);
     firstRunDone = new MGConfItem("/org/asteroidos/launcher/firstRunDone", this);
 }
 

--- a/src/firstrun.h
+++ b/src/firstrun.h
@@ -38,7 +38,7 @@ class FirstRun : public QObject
 {
     Q_OBJECT
 public:
-    FirstRun();
+    explicit FirstRun(QObject *parent = nullptr);
 
     Q_INVOKABLE bool isFirstRun();
     Q_INVOKABLE void startFirstRun();

--- a/src/gesturefilterarea.h
+++ b/src/gesturefilterarea.h
@@ -86,10 +86,14 @@ signals:
 private:
     bool m_toRightAllowed, m_toLeftAllowed, m_toBottomAllowed, m_toTopAllowed;
 
-    bool m_horizontal, m_pressed, m_tracing;
-    unsigned int m_counter;
+    bool m_horizontal = false;
+    bool m_pressed = false;
+    bool m_tracing = false;
+    unsigned int m_counter = 0;
     QPointF m_prevPos;
-    qreal m_velocityX, m_velocityY, m_threshold;
+    qreal m_velocityX = 0;
+    qreal m_velocityY = 0;
+    qreal m_threshold = 0;
 
 protected:
     virtual bool childMouseEventFilter(QQuickItem *, QEvent *);

--- a/src/notificationsnoozer.cpp
+++ b/src/notificationsnoozer.cpp
@@ -32,6 +32,16 @@
 #include <timed-qt5/event>
 #include <timed-qt5/interface>
 
+static QString shellEscape(const QString &s)
+{
+    QString escaped = s;
+    escaped.replace(QLatin1Char('\\'), QLatin1String("\\\\"));
+    escaped.replace(QLatin1Char('"'),  QLatin1String("\\\""));
+    escaped.replace(QLatin1Char('$'),  QLatin1String("\\$"));
+    escaped.replace(QLatin1Char('`'),  QLatin1String("\\`"));
+    return escaped;
+}
+
 bool NotificationSnoozer::snooze(LipstickNotification *notif, int minutes)
 {
     /* Build a notificationtool command to be triggered later */
@@ -43,13 +53,13 @@ bool NotificationSnoozer::snooze(LipstickNotification *notif, int minutes)
     const QVariantHash hints(notif->hints());
     QVariantHash::const_iterator hit = hints.constBegin(), hend = hints.constEnd();
     for( ; hit != hend; ++hit)
-        cmdStream << " --hint=\"" << hit.key() << " " << hit.value().toString() << "\"";
+        cmdStream << " --hint=\"" << shellEscape(hit.key()) << " " << shellEscape(hit.value().toString()) << "\"";
 
-    cmdStream << " --application=\"" << notif->appName() << "\"";
-    cmdStream << " --icon=\"" << notif->appIcon() << "\"";
+    cmdStream << " --application=\"" << shellEscape(notif->appName()) << "\"";
+    cmdStream << " --icon=\"" << shellEscape(notif->appIcon()) << "\"";
     cmdStream << " --timeout=\"" << notif->expireTimeout() << "\"";
-    cmdStream << " \"" << notif->summary() << "\"";
-    cmdStream << " \"" << notif->body() << "\"";
+    cmdStream << " \"" << shellEscape(notif->summary()) << "\"";
+    cmdStream << " \"" << shellEscape(notif->body()) << "\"";
 
     /* Build a timed countdown that will run the notificationtool command */
     Maemo::Timed::Interface interface;

--- a/src/qml/notifications/NotificationsPanel.qml
+++ b/src/qml/notifications/NotificationsPanel.qml
@@ -75,6 +75,8 @@ Item {
                 notifView.notification = item
                 notifView.panelsGrid = panelsGrid
             } else {
+                if (firstNotifView !== null)
+                    firstNotifView.destroy()
                 firstNotifView = notificationViewComp.createObject(notifPanel)
 
                 firstNotifView.x = 0
@@ -108,6 +110,8 @@ Item {
                     notifActions.notification = notifModel.get(0)
                     notifActions.notificationModel = notifModel
 
+                    if (firstNotifView !== null)
+                        firstNotifView.destroy()
                     firstNotifView = notificationViewComp.createObject(notifPanel)
                     firstNotifView.x = 0
                     firstNotifView.y = 0

--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -30,7 +30,7 @@
  */
 
 import QtQuick 2.9
-import QtGraphicalEffects 1.15
+import QtGraphicalEffects 1.0
 import QtMultimedia 5.8
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
@@ -345,6 +345,7 @@ Item {
         snapMode: ListView.SnapOneItem
         clip: true
         interactive: true
+        pressDelay: 200
         boundsBehavior: Flickable.StopAtBounds
         spacing: Dims.l(4)
 
@@ -531,6 +532,8 @@ Item {
         opacity: 0.5
     }
 
+    property var _remorseAction: null
+
     RemorseTimer {
         id: remorseTimer
         duration: 3000
@@ -539,6 +542,8 @@ Item {
         gaugeEndFromStartDegree: 265
         //% "Tap to cancel"
         cancelText: qsTrId("id-tap-to-cancel")
+        onTriggered: { if (_remorseAction) _remorseAction(); _remorseAction = null }
+        onCancelled: _remorseAction = null
     }
 
     Component {
@@ -812,9 +817,7 @@ Item {
             onClicked: {
                 //% "Powering off in"
                 remorseTimer.action = qsTrId("id-power-off");
-                remorseTimer.onTriggered.connect(function() {
-                    login1DBus.call("PowerOff", [false]);
-                });
+                _remorseAction = function() { login1DBus.call("PowerOff", [false]) };
                 remorseTimer.start();
             }
         }
@@ -827,10 +830,10 @@ Item {
             onClicked: {
                 //% "Rebooting in"
                 remorseTimer.action = qsTrId("id-reboot");
-                remorseTimer.onTriggered.connect(function() {
+                _remorseAction = function() {
                     login1DBus.call("SetRebootParameter", [""]);
                     login1DBus.call("Reboot", [false]);
-                });
+                };
                 remorseTimer.start();
             }
         }


### PR DESCRIPTION
Ran cppcheck and clang-tidy on the C++ sources and fixed the warnings:

- **firstrun**: \`m_mceDbus\` was allocated with \`new QDBusInterface(...)\` without a Qt parent, leaking it. Pass \`this\` as parent. Also accept an optional \`QObject *parent\` in the constructor.

- **gesturefilterarea**: POD members (\`m_horizontal\`, \`m_pressed\`, \`m_tracing\`, \`m_counter\`, \`m_velocityX\`, \`m_velocityY\`, \`m_threshold\`) were left uninitialized. Add in-class default initializers.

- **notificationsnoozer**: notification fields (appName, body, summary, hints) were interpolated directly into a shell command string. Escape \`\\\`, \`"\`, \`$\`, and \`\\`\` to prevent injection.

Also fixed two QML issues found during review:

- **QuickPanel**: power-off and reboot used \`remorseTimer.onTriggered.connect()\` which *accumulated* handlers on every click — tapping power-off three times then letting it expire called PowerOff three times. Replace with a property-based approach.

- **NotificationsPanel**: \`firstNotifView\` was reassigned via \`createObject()\` without destroying the previous instance, leaking the old view.