### PR TITLE
Fix timezone DBus property type coercion for Qt6

### DIFF
--- a/src/qml/firstrun/FirstRunConfig.qml
+++ b/src/qml/firstrun/FirstRunConfig.qml
@@ -214,7 +214,8 @@ FlatMesh {
     ListModel {
         id: regionModel
         Component.onCompleted: {
-            config.currentTz = timedateDbus.getProperty("Timezone")
+            var tzRaw = timedateDbus.getProperty("Timezone")
+            config.currentTz = tzRaw ? tzRaw.toString() : ""
             timedateDbus.call("ListTimezones", undefined, function(m) {
                 config.timezoneList = m
             })


### PR DESCRIPTION
In Qt6, Nemo.DBus getProperty() returns a QDBusVariant instead of auto-coercing to the declared property type. Assigning the raw QDBusVariant to a property string fails with "Cannot assign QDBusVariant to QString" and aborts the Component.onCompleted handler before the ListTimezones call executes. This leaves timezoneList empty for the entire session, making the city spinner always empty and crashing on next button press in TIMEZONE_CITY state with TypeError on fullPath of undefined.

Fix: call .toString() on the getProperty result to unwrap the variant.