### PR TITLE
Fix Qt6 compositor regressions: null guards, signal syntax and binding initialization

### DIFF
--- a/src/qml/compositor/WindowWrapperBase.qml
+++ b/src/qml/compositor/WindowWrapperBase.qml
@@ -53,7 +53,11 @@ Item {
     }
     function animateIn() { fadeInAnimation.start(); }
 
-    Component.onCompleted: window.parent = wrapper
+    Component.onCompleted: {
+        window.parent = wrapper
+        window.x = 0
+        window.y = 0
+    }
 
     layer.enabled: smoothBorders && DeviceSpecs.hasRoundScreen
     layer.effect: CircleMaskShader { }

--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -53,7 +53,7 @@ Item {
     Item {
         property bool ready: false
         id: appLayer
-        visible: comp.appActive
+        visible: comp ? comp.appActive : false
         z: 2
 
         opacity: (width-2*gestureArea.value)/width
@@ -81,15 +81,15 @@ Item {
 
     BorderGestureArea {
         id: gestureArea
-        enabled: comp.appActive
+        enabled: comp ? comp.appActive : false
         z: 5
         anchors.fill: parent
         acceptsDown: true
-        acceptsRight: !comp.topmostWindowRequestsGesturesDisabled
+        acceptsRight: comp != null && comp.topmostWindow != null && !comp.topmostWindowRequestsGesturesDisabled
 
         property real swipeThreshold: 0.15
 
-        onGestureStarted: {
+        onGestureStarted: (gesture) => {
             swipeAnimation.stop()
             if (gesture == "down") {
                 Desktop.desktop.aboutToClose = true
@@ -98,7 +98,7 @@ Item {
             }
         }
 
-        onGestureFinished: {
+        onGestureFinished: (gesture) => {
             if ((gesture == "down" || gesture == "right")) {
                 if (gestureArea.progress >= swipeThreshold) {
                     swipeAnimation.valueTo = inverted ? -max : max
@@ -168,7 +168,13 @@ Item {
 
         // Only used to change blank timeout when on watchface or elsewhere
         property bool longTimeout: homeActive
-        Component.onCompleted: longTimeout = Qt.binding(function() { return homeActive && (Desktop.panelsGrid.currentVerticalPos == 0 && Desktop.panelsGrid.currentHorizontalPos == 0) })
+        Component.onCompleted: {
+            longTimeout = Qt.binding(function() {
+                return homeActive && Desktop.panelsGrid != null
+                    && Desktop.panelsGrid.currentVerticalPos == 0
+                    && Desktop.panelsGrid.currentHorizontalPos == 0
+            })
+        }
         onLongTimeoutChanged: lipstickSettings.lockscreenVisible = longTimeout
 
         // True if the home window is the topmost window
@@ -209,7 +215,7 @@ Item {
         onDisplayOff: delayTimer.start()
         onDisplayAboutToBeOn: delayTimer.stop()
 
-        onWindowAdded: {
+        onWindowAdded: (window) => {
             var isHomeWindow = window.isInProcess && comp.homeWindow == null && window.title === "Home"
             var isDialogWindow = window.category === "dialog"
             var isNotificationWindow = window.category == "notification"
@@ -229,7 +235,7 @@ Item {
             window.userData = w
 
             if (isHomeWindow) {
-                parent.z = Qt.binding(function() { return w.window.rootItem.z })
+                parent.z = Qt.binding(function() { return w.window.rootItem ? w.window.rootItem.z : 0 })
                 Desktop.desktop.aboutToOpen = Qt.binding(function() {return !homeActive && !appLayer.ready })
                 comp.homeWindow = w
                 setCurrentWindow(homeWindow)
@@ -246,9 +252,9 @@ Item {
             }
         }
 
-        onWindowRaised:  windowToFront(window.windowId)
+        onWindowRaised: (window) => windowToFront(window.windowId)
 
-        onWindowRemoved: {
+        onWindowRemoved: (window) => {
             var w = window.userData;
             if (comp.topmostWindow == w)
                 setCurrentWindow(comp.homeWindow);


### PR DESCRIPTION
Qt6 introduced several breaking changes in QML binding evaluation order and signal handler syntax that cause TypeErrors and deprecation warnings at runtime.
This PR addresses all of them in compositor.qml.

**Null guards on comp-referencing bindings (lines 58, 86, 90)**

In Qt5, all items within a QML component were guaranteed to be instantiated before any property bindings were evaluated. Qt6 changed this: the binding engine can evaluate bindings eagerly during component construction, before sibling items with declared ids exist. The Compositor item (id: comp) is declared after appLayer and BorderGestureArea in the file, so when those items' bindings first evaluate, comp is null. The result is a TypeError on every cold start. Adding comp != null guards lets these bindings degrade gracefully during the initialization window.

**Null guard on w.window.rootItem (line 241)**

In Qt5 lipstick, window.rootItem was always available when onWindowAdded fired for the in-process home window. In Qt6, the QWaylandQuickItem backing the home window does not expose rootItem until after the surface is fully mapped. Without the guard the homeLayer z binding throws TypeError and the z-ordering of the home window layer is left in an undefined state.

**Null guard on Desktop.panelsGrid in longTimeout binding (line 175)**

The Compositor item's Component.onCompleted runs before desktop.js has finished setting up its exported references. Desktop.panelsGrid is null at that point, causing TypeError when the longTimeout binding tries to read currentVerticalPos. The guard keeps the binding safe until panelsGrid exists.

**Arrow function syntax for signal handlers (lines 94, 103, 221, 258, 260)**

Qt6 deprecated implicit injection of signal parameters into handler bodies.
In Qt5, a signal handler like onWindowAdded: { ... } could freely use the window parameter without declaring it. Qt6 requires explicit declaration via arrow function syntax: onWindowAdded: (window) => { ... }. Without this change Qt6 logs a deprecation warning for every signal invocation and future Qt versions will treat it as an error.