### PR TITLE
Fix Qt6 signal parameter injection deprecation in PanelsGrid.qml

### DIFF
--- a/src/qml/misc/PanelsGrid.qml
+++ b/src/qml/misc/PanelsGrid.qml
@@ -170,7 +170,7 @@ GestureFilterArea {
         if (panels[currentHorizontalPos + "x" + (currentVerticalPos+1)] !== undefined) panels[currentHorizontalPos + "x" + (currentVerticalPos+1)].visible = true
     }
 
-    onSwipeMoved: {
+    onSwipeMoved: (horizontal, delta) => {
         panelsHideTimeout.stop()
         if(horizontal) {
             contentX = content.x + delta
@@ -192,7 +192,7 @@ GestureFilterArea {
         bottomIndicator.animateFar()
     }
 
-    onSwipeReleased: {
+    onSwipeReleased: (horizontal, velocity, tracing) => {
         if(!tracing) {
             if(horizontal) {
                 var loc = contentX+currentHorizontalPos*panelWidth

--- a/src/qml/misc/PanelsGrid.qml
+++ b/src/qml/misc/PanelsGrid.qml
@@ -195,20 +195,20 @@ GestureFilterArea {
     onSwipeReleased: (horizontal, velocity, tracing) => {
         if(!tracing) {
             if(horizontal) {
-                var loc = contentX+currentHorizontalPos*panelWidth
-                if((loc > width/2) || velocity > 10 && toRightAllowed)
+                var locX = contentX + currentHorizontalPos * panelWidth
+                if((locX > width/2) || velocity > 10 && toRightAllowed)
                     currentHorizontalPos--
-                else if((loc < -width/2) || velocity < -10 && toLeftAllowed)
+                else if((locX < -width/2) || velocity < -10 && toLeftAllowed)
                     currentHorizontalPos++
 
                 contentAnim.property = "x"
                 contentAnim.to = -panelWidth*currentHorizontalPos
                 contentAnim.start()
             } else {
-                var loc = contentY+currentVerticalPos*panelHeight
-                if((loc > height/2 && velocity > 0) || velocity > 10 && toBottomAllowed)
+                var locY = contentY + currentVerticalPos * panelHeight
+                if((locY > height/2 && velocity > 0) || velocity > 10 && toBottomAllowed)
                     currentVerticalPos--
-                else if((loc < -height/2 && velocity < 0) || velocity < -10 && toTopAllowed)
+                else if((locY < -height/2 && velocity < 0) || velocity < -10 && toTopAllowed)
                     currentVerticalPos++
 
                 contentAnim.property = "y"


### PR DESCRIPTION
Fixes two Qt6 deprecation warnings fired on every swipe gesture in the main screen.

Qt6 deprecated implicit injection of signal parameters into handler bodies. The GestureFilterArea C++ component emits swipeMoved(bool horizontal, qreal delta) and swipeReleased(bool horizontal, qreal velocity, bool tracing). Both onSwipeMoved and onSwipeReleased in PanelsGrid.qml used these parameters without declaring them, causing Qt6 to log a deprecation warning on every gesture interaction.

Both handlers are converted to arrow function syntax with parameters declared in the order matching the C++ signal definitions. The parameter order for swipeReleased is horizontal, velocity, tracing — note that tracing is the last parameter, not the first, which is easy to get wrong when reading the handler body alone.

A cosmetic follow-up commit renames the duplicate var loc declarations inside onSwipeReleased to locX and locY to eliminate the same-scope shadowing and make the horizontal vs vertical branching intent explicit.