### PR TITLE
Qt6 injection fixes

### DIFF
--- a/src/applauncher/004-three-by-three.qml
+++ b/src/applauncher/004-three-by-three.qml
@@ -268,11 +268,11 @@ Item {
             clickY = Math.round(mouse.y)
             mouse.accepted = false
         }
-        onClicked: mouse.accepted = false
-        onReleased: mouse.accepted = false
-        onDoubleClicked: mouse.accepted = false
-        onPositionChanged: mouse.accepted = false
-        onPressAndHold: mouse.accepted = false
+        onClicked: (mouse) => mouse.accepted = false
+        onReleased: (mouse) => mouse.accepted = false
+        onDoubleClicked: (mouse) => mouse.accepted = false
+        onPositionChanged: (mouse) => mouse.accepted = false
+        onPressAndHold: (mouse) => mouse.accepted = false
     }
 
     Rectangle {

--- a/src/qml/notifications/NotificationView.qml
+++ b/src/qml/notifications/NotificationView.qml
@@ -80,9 +80,9 @@ MouseArea {
         }
     }
 
-    onPressed: prevY = mouse.y
+    onPressed: (mouse) => prevY = mouse.y
 
-    onPositionChanged: {
+    onPositionChanged: (mouse) => {
         var newY = column.y + mouse.y-prevY
         newY = Math.max(newY, -column.height+view.height)
         newY = Math.min(newY, 0)


### PR DESCRIPTION
Fixes Qt6 signal parameter injection deprecation warnings in NotificationView.qml and 004-three-by-three.qml.

Qt6 deprecated implicit injection of signal parameters into handler bodies. Handlers referencing signal-provided objects must use arrow function syntax with explicit parameter declarations.

NotificationView.qml: onPressed and onPositionChanged use mouse.y for notification scroll tracking.

004-three-by-three.qml: onPressed uses mouse.y and mouse.accepted, five additional single-line handlers use mouse.accepted to pass events through to underlying items.

Tested on sparrow and beluga without regressions.