### PR TITLE
Fix Qt6 crash and type error in 003-turbo-list.qml

### DIFF
--- a/src/applauncher/003-turbo-list.qml
+++ b/src/applauncher/003-turbo-list.qml
@@ -91,7 +91,10 @@ ListView {
         // Finally we add a small padding (Dims.w(5)) so that the item is not touching the left 'bezel'.
         property var screenRadius: appsView.height/2
         property var itemLocationY: (launcherItem.height * (appsView.contentY/launcherItem.height - index) - launcherItem.height/2)
-        property var bezelOffset: screenRadius - Math.sqrt(Math.pow(screenRadius, 2) - Math.pow((screenRadius + itemLocationY),2))
+        property var bezelOffset: {
+            var d = Math.pow(screenRadius, 2) - Math.pow(screenRadius + itemLocationY, 2)
+            return d < 0 ? screenRadius : screenRadius - Math.sqrt(d)
+        }
         property var normalizedBezelOffset: 1.0 - (bezelOffset / screenRadius)
 
         id: launcherItem
@@ -155,9 +158,11 @@ ListView {
                 width: parent.width
                 anchors.leftMargin: parent.width * 0.04
                 anchors.verticalCenter: parent.verticalCenter
-                font.pixelSize: (Math.exp((normalizedBezelOffset)) - 1) * viewScale * Dims.l(6)
-                font.letterSpacing: Dims.l(0.2)
-                font.styleName: "Bold"
+                font {
+                    pixelSize: Math.max(1, (Math.exp(normalizedBezelOffset) - 1) * viewScale * Dims.l(6))
+                    letterSpacing: Dims.l(0.2)
+                    styleName: "Bold"
+                }
                 style: (normalizedBezelOffset >= 0.99) ? Text.Outline : Text.Normal
                 styleColor: alb.centerColor(launcherModel.get(index).filePath)
                 text: model.object.title + localeManager.changesObserver
@@ -181,6 +186,6 @@ ListView {
         var lowerStop = Math.floor(contentY/(appsView.height/6))
         var upperStop = lowerStop+1
         var ratio = (contentY%appsView.height)/(appsView.height/6)
-        currentPos = Math.round(lowerStop+ratio)
+        currentPos = Math.round(lowerStop + ratio) | 0
     }
 }


### PR DESCRIPTION
Three related Qt6 regressions in the turbo list applauncher.

currentPos is declared as int but onContentYChanged assigned the result of Math.round() which returns a JavaScript Number (double). Qt6 rejects the implicit coercion that Qt5 accepted silently. Fix: append | 0 to force integer truncation before assignment.

During scroll, items that move above the visible center produce a positive itemLocationY causing the bezelOffset discriminant to go negative. Math.sqrt of a negative number returns NaN, which propagates into font.pixelSize and crashes the QSGRenderThread with a null pointer dereference at offset 0x1c. Qt5 text rendering tolerated NaN silently. Fix: guard bezelOffset against a negative discriminant, returning screenRadius (normalizedBezelOffset = 0) for out-of-range items.

font.pixelSize evaluates to zero when normalizedBezelOffset is 0, which is also invalid for text rendering. Fix: wrap in Math.max(1, ...) to ensure a minimum valid size.