### PR TITLE
compositor: use overridesSystemGestures Wayland property for back gesture guard

### DIFF
--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -185,7 +185,7 @@ Item {
         property Item topmostApplicationWindow
 
         readonly property bool topmostWindowRequestsGesturesDisabled: topmostWindow && topmostWindow.window
-                                                                      && (topmostWindow.window.windowFlags & 1)
+                                                                      && topmostWindow.window.overridesSystemGestures
 
         function windowToFront(winId) {
             var o = comp.windowForId(winId)


### PR DESCRIPTION
Replaces the legacy windowFlags bitfield check with the new overridesSystemGestures Q_PROPERTY on LipstickCompositorWindow, which is set by the zasteroid_gestures_manager_v1 Wayland protocol implemented in lipstick.

Full set of PRs for the back gesture fix:
https://github.com/AsteroidOS/qml-asteroid/pull/100
https://github.com/AsteroidOS/lipstick/pull/23
https://github.com/AsteroidOS/asteroid-launcher/pull/234