### PR TITLE
Switch to home screen immediately when entering AOD/ambient mode (fixes meta-asteroid#228)

### DIFF
--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -153,7 +153,10 @@ Item {
         interval: 5000
         repeat: false
         onTriggered: {
-            Lipstick.compositor.closeClientForWindowId(comp.topmostWindow.window.windowId)
+            if (comp.ambientAppWindow) {
+                Lipstick.compositor.closeClientForWindowId(comp.ambientAppWindow.window.windowId)
+                comp.ambientAppWindow = null
+            }
             Lipstick.compositor.setAmbientUpdatesEnabled(true)
         }
     }
@@ -177,6 +180,9 @@ Item {
 
         // The application window that was most recently topmost
         property Item topmostApplicationWindow
+
+        // The application window that was visible when ambient mode was entered
+        property Item ambientAppWindow
 
         readonly property bool topmostWindowRequestsGesturesDisabled: topmostWindow && topmostWindow.window
                                                                       && (topmostWindow.window.windowFlags & 1)
@@ -207,7 +213,20 @@ Item {
         }
 
         onDisplayOff: delayTimer.start()
-        onDisplayAboutToBeOn: delayTimer.stop()
+        onDisplayAboutToBeOn: {
+            delayTimer.stop()
+            if (ambientAppWindow && !Lipstick.compositor.displayAmbient) {
+                setCurrentWindow(ambientAppWindow, true)
+                ambientAppWindow = null
+            }
+        }
+
+        onDisplayAmbientEntered: {
+            if (!homeActive) {
+                ambientAppWindow = topmostWindow
+                setCurrentWindow(homeWindow)
+            }
+        }
 
         onWindowAdded: {
             var isHomeWindow = window.isInProcess && comp.homeWindow == null && window.title === "Home"
@@ -252,6 +271,8 @@ Item {
             var w = window.userData;
             if (comp.topmostWindow == w)
                 setCurrentWindow(comp.homeWindow);
+            if (comp.ambientAppWindow == w)
+                comp.ambientAppWindow = null;
 
             if (window.userData)
                 window.userData.destroy()


### PR DESCRIPTION
When AOD (Always-On Display) activates while an application is open, the
compositor previously kept showing the dimmed application for 5 seconds
until `delayTimer` fired, killed the app, and switched to the home screen.

During those 5 seconds the dimmed app was visible instead of the
AOD-optimized watchface. This was reported as
[AsteroidOS/meta-asteroid#228](https://github.com/AsteroidOS/meta-asteroid/issues/228).

## Changes

- Added `onDisplayAmbientEntered` handler: immediately switches to the home
  window when ambient mode activates, saving a reference to the app
- Modified `delayTimer`: kills the saved app reference instead of the
  current topmost window (which is now the home window)
- Updated `onDisplayAboutToBeOn`: restores the saved app if the display
  wakes before the 5-second cleanup timer fires (but not during periodic
  ambient minute updates)
- Added `onWindowRemoved` safety check: clears the saved app reference if
  the app is closed externally while in ambient mode

Fixes AsteroidOS/meta-asteroid#228