### PR TITLE
compositor: Turn off display in non-ambient mode when display goes Off (fixes #198)

### DIFF
--- a/src/qml/compositor/compositor.qml
+++ b/src/qml/compositor/compositor.qml
@@ -212,8 +212,18 @@ Item {
             }
         }
 
-        onDisplayOff: delayTimer.start()
-        onDisplayAboutToBeOn: delayTimer.stop()
+        onDisplayOff: {
+            if (Lipstick.compositor.ambientEnabled) {
+                delayTimer.start()
+            }
+        }
+        onDisplayAboutToBeOn: {
+            delayTimer.stop()
+            if (ambientAppWindow && !Lipstick.compositor.displayAmbient) {
+                setCurrentWindow(ambientAppWindow, true)
+                ambientAppWindow = null
+            }
+        }
 
         onWindowAdded: (window) => {
             var isHomeWindow = window.isInProcess && comp.homeWindow == null && window.title === "Home"


### PR DESCRIPTION
When ambient/AOD is disabled and the display goes Off (power button press while an app is open), the compositor window was never hidden because the ambient-only code path never triggered.

## Root cause

In `LipstickCompositor::reactOnDisplayStateChanges`, when display goes Off and ambient is disabled, only `displayOff()` was emitted. The window stayed visible indefinitely — `delayTimer` fired after 5 seconds but `setAmbientUpdatesEnabled(true)` returned immediately because `!ambientEnabled()`.

## Changes

- **lipstick core**: Immediately call `setUpdatesEnabled(false)` when display goes Off in non-ambient mode. On wake-up, call `setUpdatesEnabled(true)` for proper restoration (DisplayOn, displayAboutToBeOn).
- **asteroid-launcher QML**: Only start `delayTimer` when ambient is enabled. Non-ambient display-off is now handled in C++.

Fixes #198