### PR TITLE
Refactor 000-default-digital watchface for Qt6 and remove Canvas

### DIFF
--- a/src/watchfaces/000-default-digital.qml
+++ b/src/watchfaces/000-default-digital.qml
@@ -12,24 +12,15 @@ import QtQuick.Shapes
 Item {
     anchors.fill: parent
 
-    function twoDigits(x) {
-        if (x<10) return "0" + x;
-        else      return x;
-    }
-
-    function prepareContext(ctx) {
-        ctx.reset()
-        ctx.fillStyle = "white"
-        ctx.textAlign = "center"
-        ctx.textBaseline = 'middle';
-        ctx.shadowColor = "black"
-        ctx.shadowOffsetX = 0
-        ctx.shadowOffsetY = 0
-        ctx.shadowBlur = root.height * .0125
-    }
-
     Item {
         id: root
+
+        // Time values, declarative bindings on the launcher wallClock.
+        property int hour24: wallClock.time.getHours()
+        property int displayHour: use12H.value ? (hour24 % 12 === 0 ? 12 : hour24 % 12) : hour24
+        property int minutes: wallClock.time.getMinutes()
+        property string apText: wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP")
+        property string dateText: wallClock.time.toLocaleString(Qt.locale(), "d MMM")
 
         anchors.centerIn: parent
         height: Math.min(parent.width, parent.height)
@@ -42,81 +33,86 @@ Item {
             width: parent.width * (nightstandMode.active ? .86 : 1)
             height: width
 
-            Canvas {
-                id: hourCanvas
-
-                property int hour: 0
-
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-
-                    ctx.font = "57 " + height * .36 + "px Roboto"
-                    ctx.fillText(twoDigits(hour), width * .378, height * .537);
-                }
+            layer.enabled: true
+            layer.effect: DropShadow {
+                color: "black"
+                horizontalOffset: 0
+                verticalOffset: 0
+                radius: root.height * .0235
+                samples: 17
             }
 
-            Canvas {
-                id: minuteCanvas
+            Text {
+                id: hourLabel
 
-                property int minute: 0
-
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-
-                    ctx.font = "30 " + height * .18 + "px Roboto"
-                    ctx.fillText(twoDigits(minute), width * .717, height * .473);
+                anchors {
+                    centerIn: parent
+                    horizontalCenterOffset: parent.width * (.379 - .5)
+                    verticalCenterOffset: parent.height * (.487 - .5)
                 }
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    family: "Roboto"
+                    pixelSize: parent.height * .36
+                    weight: Font.Medium
+                }
+                text: root.displayHour < 10 ? "0" + root.displayHour : "" + root.displayHour
             }
 
-            Canvas {
-                id: amPmCanvas
+            Text {
+                id: minuteLabel
 
-                property bool am: false
+                anchors {
+                    centerIn: parent
+                    horizontalCenterOffset: parent.width * (.717 - .5)
+                    verticalCenterOffset: parent.height * (.45 - .5)
+                }
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    family: "Roboto"
+                    pixelSize: parent.height * .18
+                    weight: Font.Light
+                }
+                text: root.minutes < 10 ? "0" + root.minutes : "" + root.minutes
+            }
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
+            Text {
+                id: apLabel
+
+                anchors {
+                    centerIn: parent
+                    horizontalCenterOffset: parent.width * (.898 - .5)
+                    verticalCenterOffset: parent.height * (.368 - .5)
+                }
                 visible: use12H.value
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-
-                    ctx.font = "25 " + height / 15 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP"), width * .894, height * .371);
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    family: "Raleway"
+                    pixelSize: parent.height * .065
+                    weight: Font.Light
                 }
+                text: root.apText
             }
 
-            Canvas {
-                id: dateCanvas
+            Text {
+                id: dateLabel
 
-                property int date: 0
-                property int month: 0
-
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.font = "25 " + height / 13 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "d MMM"), width * .719, height * .595);
+                anchors {
+                    centerIn: parent
+                    horizontalCenterOffset: parent.width * (.719 - .5)
+                    verticalCenterOffset: parent.height * (.587 - .5)
                 }
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    family: "Raleway"
+                    pixelSize: parent.height * .076
+                    weight: Font.Light
+                }
+                text: root.dateText
             }
         }
 
@@ -140,14 +136,14 @@ Item {
                 property real arcStrokeWidth: .055
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -176,57 +172,9 @@ Item {
             id: batteryChargePercentage
         }
 
-        Connections {
-            target: wallClock
-            function onTimeChanged() {
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var month = wallClock.time.getMonth()
-                var date = wallClock.time.getDate()
-                var am = hour < 12
-                if(use12H.value) {
-                    hour = hour % 12
-                    if (hour === 0) hour = 12;
-                }
-                if(hourCanvas.hour !== hour) {
-                    hourCanvas.hour = hour
-                    hourCanvas.requestPaint()
-                } if(minuteCanvas.minute !== minute) {
-                    minuteCanvas.minute = minute
-                    minuteCanvas.requestPaint()
-                } if(dateCanvas.date !== date || dateCanvas.month !== month) {
-                    dateCanvas.date = date
-                    dateCanvas.month = month
-                    dateCanvas.requestPaint()
-                } if(amPmCanvas.am != am) {
-                    amPmCanvas.am = am
-                    amPmCanvas.requestPaint()
-                }
-            }
-        }
-
         Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var month = wallClock.time.getMonth()
-            var date = wallClock.time.getDate()
-            var am = hour < 12
-            if(use12H.value) {
-                hour = hour % 12
-                if (hour === 0) hour = 12
-            }
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            dateCanvas.month = month
-            dateCanvas.date = date
-            dateCanvas.requestPaint()
-            amPmCanvas.am = am
-            amPmCanvas.requestPaint()
-
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .1 : .32)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .1 : .7)})
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return root.width * (nightstandMode.active ? .1 : .32) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return root.height * (nightstandMode.active ? .1 : .7) })
         }
     }
 }

--- a/src/watchfaces/000-default-digital.qml
+++ b/src/watchfaces/000-default-digital.qml
@@ -4,12 +4,10 @@
 // SPDX-FileCopyrightText: 2017 Florent Revest <revestflo@gmail.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
     anchors.fill: parent
@@ -34,7 +32,7 @@ Item {
         id: root
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Item {
@@ -128,12 +126,6 @@ Item {
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-            }
             visible: nightstandMode.active
 
             Repeater {
@@ -147,7 +139,7 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .055
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
                 readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
@@ -164,7 +156,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * ( .5 - segmentedArc.scalefactor)
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2
@@ -172,8 +164,7 @@ Item {
                             radiusX: segmentedArc.scalefactor * root.width
                             radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }

--- a/src/watchfaces/000-default-digital.qml
+++ b/src/watchfaces/000-default-digital.qml
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/000-default-digital.qml
+++ b/src/watchfaces/000-default-digital.qml
@@ -133,7 +133,6 @@ Item {
                 enabled: true
                 samples: 4
                 smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
             }
             visible: nightstandMode.active
 
@@ -161,17 +160,17 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * ( .5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
                             sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
                                                                  -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap


### PR DESCRIPTION
## Summary

Refactors the `000-default-digital` stock watchface to a fully declarative, Qt6-compatible state. All Canvas usage is replaced with QML `Text` and `Shape` items, the Qt6 thin-numeral regression is fixed, and the file is brought in line with current conventions.

This is the `000-default-digital` slice of splitting #214 into one PR per watchface so each can be reviewed on its own. The four commits are ordered so every one builds and runs independently.

## Commits

1. **Convert default-digital license header to SPDX format.** Mechanical replacement of the BSD-3-Clause prose header with SPDX tags. No code change.
2. **Clean up nightstand arc geometry references for Qt6.** Binds the battery arc geometry to the square `root` Item instead of `parent`, since `parent` inside a `ShapePath` resolves to the geometry-less path container. Also drops the double-resolution `textureSize` override that caused a stutter on nightstand activation. Rendering is unchanged.
3. **Clean up default-digital conventions and drop the unsupported nightstand layer.** Removes the unused `org.asteroid.controls` and `org.asteroid.utils` imports, normalises the square sizing to `Math.min`, collapses the multi-line `sweepAngle` ternary, and types the charge colour index as `int`. Removes the `nightstandMode` layer block entirely: this hardware has no multisample renderbuffers, so the requested samples were silently ignored and only produced a journal warning, while the `Shape` renderer antialiases the arc on its own.
4. **Replace default-digital Canvas text with declarative Text items.** Converts the four Canvas text drawers (hour, minute, AM/PM, date) to declarative `Text` items. Canvas text was the last Qt5-era pattern here and the source of the thin-numeral regression on Qt6, where the stricter Canvas font parser read the previously ignored weight tokens, so the Text items carry explicit font weights instead. Time values become direct declarative bindings on `wallClock`, replacing the imperative `Connections` and `Component.onCompleted` repaint dispatch, and the two Canvas helper functions and the `Connections` block are removed. The soft Canvas shadow is recreated with a single `DropShadow` over the text container.

## Testing

Built on the locally compiled 2.2 nightly (Qt 6.11) and deployed to sturgeon, compared side by side against the 1.1 nightly (Qt 5.15) vanilla render on tunny.

- Normal mode matches the Qt5 reference for numeral weight, positions and the soft shadow.
- Nightstand mode renders the battery arc with correct colour and geometry, and the journal no longer logs the multisample warning.
- 12h and 24h toggle: AM/PM appears and hides, the hour switches range correctly.

## Notes

- The outer screen-filling `Item` is kept on purpose. It is the watchface root the launcher sizes to the screen, while the inner square `root` keeps the layout from squishing on non-square panels.
- Glyph sizes, positions and weights were tuned on hardware against the Qt5 vanilla render.
- On Qt6 the text is marginally softer than the Qt5 Canvas because the shadow routes the glyphs through a compositing layer. Supersampling and texture-size adjustments did not change it meaningfully, and the match is judged perfectly acceptable.

Qt6 adapted state:
<img width="400" height="400" alt="000-qt6-state-try001" src="https://github.com/user-attachments/assets/cab837cb-09d6-44cf-bc3c-1e2c080617f0" />

Vanilla Qt5 state:
<img width="400" height="400" alt="000-vanilla" src="https://github.com/user-attachments/assets/4ed73a9d-d357-426f-8afc-a37dc072052c" />
