### PR TITLE
Refactor 001-words-worte-palabras-mots watchface for Qt6

### DIFF
--- a/src/watchfaces/001-words-worte-palabras-mots.qml
+++ b/src/watchfaces/001-words-worte-palabras-mots.qml
@@ -7,12 +7,11 @@
 // SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
 import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
     anchors.fill: parent
@@ -23,35 +22,42 @@ Item {
         property string localeName: Qt.locale().name
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
 
+            layer.enabled: true
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: root.height * .01
+                verticalOffset: root.height * .01
+                radius: root.height * .014
+                samples: 9
+                color: "#60000000"
+            }
+
             Text {
+                id: timeDisplay
+
                 function generateTimeEn(time) {
                     var minutesList = ["'o clock", "five<br>past", "ten<br>past", "quarter<br>past", "twenty", "twenty<br>five", "thirty", "thirty<br>five", "forty", "quarter<br>to", "ten to", "five to", "'o clock"]
                     var hoursList = ["<b>twelve</b>", "<b>one</b>", "<b>two</b>", "<b>three</b>", "<b>four</b>", "<b>five</b>", "<b>six</b>", "<b>seven</b>", "<b>eight</b>", "<b>nine</b>", "<b>ten</b>", "<b>eleven</b>"]
                     var minutesFirst = [false, true, true, true, false, false, false, false, false, true, true, true, false]
                     var nextHour = [false, false, false, false, false, false, false, false, false, true, true, true, true]
-
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
-
                     var newline = "<br>"
-
                     if (minutesFirst[minutes]) {
                         var generatedString = minutesList[minutes] + newline + hoursList[hours]
                     } else {
                         var generatedString = hoursList[hours] + newline + minutesList[minutes]
                     }
-
                     return generatedString
                 }
 
@@ -64,13 +70,10 @@ Item {
                     var enPunto = [true, false, false, false, false, false, false, false, false, false, false, false, true]
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
-
                     var newline = "<br>"
-
                     if (enPunto[minutes]) {
                         var generatedString = hoursList[hours] + newline + minutesList[minutes]
                     } else {
-                        //also use next hour to decide between y or menos
                         if (nextHour[minutes]) {
                             var generatedString = hoursListmenos[hours] + newline + minutesList[minutes]
                         } else {
@@ -81,30 +84,17 @@ Item {
                 }
 
                 function generateTimeDe(time) {
-                    var nextHour   = [false, false, false, false, false, true, true, true, true, true, true, true, true]
+                    var nextHour = [false, false, false, false, false, true, true, true, true, true, true, true, true]
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
-
                     var minutesList = ["uhr", "fünf<br>nach", "zehn<br>nach", "viertel<br>nach", "zwanzig<br>nach", "fünf<br>vor halb", "halb", "fünf<br>nach halb", "zwanzig<br>vor", "viertel<br>vor", "zehn<br>vor", "fünf<br>vor", "uhr"]
                     var hoursList = ["<b>zwölf</b>", minutesList[minutes] === "uhr" ? "<b>ein</b>" : "<b>eins</b>", "<b>zwei</b>", "<b>drei</b>", "<b>vier</b>", "<b>fünf</b>", "<b>sechs</b>", "<b>sieben</b>", "<b>acht</b>", "<b>neun</b>", "<b>zehn</b>", "<b>elf</b>"]
                     var minutesFirst = [false, true, true, true, true, true, true, true, true, true, true, true, false]
-                    var hourSuffix = [false, false, false, false ,false, false, false, false, false, false, false, false, false]
-
                     var newline = "<br>"
-
-                    if (hourSuffix[minutes]) {
-                        if (minutesFirst[minutes]) {
-                            var generatedString = minutesList[minutes] + newline + hoursList[hours] +" uhr"
-                        } else {
-                            var generatedString = hoursList[hours]+ newline + " uhr" + newline + minutesList[minutes]}
+                    if (minutesFirst[minutes]) {
+                        var generatedString = minutesList[minutes] + newline + hoursList[hours]
                     } else {
-
-                            if (minutesFirst[minutes]) {
-                                var generatedString = minutesList[minutes] + newline + hoursList[hours]
-                            } else {
-                                var generatedString = hoursList[hours] + newline + minutesList[minutes]
-                            }
-
+                        var generatedString = hoursList[hours] + newline + minutesList[minutes]
                     }
                     return generatedString
                 }
@@ -114,18 +104,14 @@ Item {
                     var hoursList = ["<b>douze</b>", "<b>une</b>", "<b>deux</b>", "<b>trois</b>", "<b>quatre</b>", "<b>cinq</b>", "<b>six</b>", "<b>sept</b>", "<b>huit</b>", "<b>neuf</b>", "<b>dix</b>", "<b>onze</b>"]
                     var minutesFirst = [false, false, false, false, false, false, false, false, false, false, false, false, false]
                     var nextHour = [false, false, false, false, false, false, false, true, true, true, true, true, true]
-
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
-
                     var newline = "<br>"
-
                     if (minutesFirst[minutes]) {
                         var generatedString = minutesList[minutes] + newline + hoursList[hours]
                     } else {
                         var generatedString = hoursList[hours] + newline + minutesList[minutes]
                     }
-
                     return generatedString
                 }
 
@@ -134,26 +120,20 @@ Item {
                     var hoursList = ["<b>tolv</b>", "<b>et</b>", "<b>to</b>", "<b>tre</b>", "<b>fire</b>", "<b>fem</b>", "<b>seks</b>", "<b>syv</b>", "<b>otte</b>", "<b>ni</b>", "<b>ti</b>", "<b>elleve</b>"]
                     var minutesFirst = [false, true, true, true, true, false, true, false, false, true, true, true, false]
                     var nextHour = [false, false, false, false, false, false, true, false, false, true, true, true, false]
-
                     var minutes = Math.round(time.getMinutes() / 5)
                     var hours = (time.getHours() + (nextHour[minutes] ? 1 : 0)) % 12
-
                     var newline = "<br>"
-
                     if (minutesFirst[minutes]) {
                         var generatedString = minutesList[minutes] + newline + hoursList[hours]
                     } else {
                         var generatedString = hoursList[hours] + newline + minutesList[minutes]
                     }
-
                     return generatedString
                 }
 
-                id: timeDisplay
-
                 anchors {
                     verticalCenter: parent.verticalCenter
-                    verticalCenterOffset: -parent.height * .085
+                    verticalCenterOffset: -parent.height * .029
                     left: parent.left
                     right: parent.right
                 }
@@ -161,49 +141,28 @@ Item {
                 lineHeight: .64
                 color: "white"
                 textFormat: Text.StyledText
+                renderType: Text.NativeRendering
                 font {
-                    pixelSize: text.includes('veinticinco') || text.includes('moins') || text.includes('demie') || text.includes('vingt-cinq') ?
-                                       parent.height * .185 :
-                                   text.includes('nach halb') || text.includes('zwanzig') ?
-                                           parent.height * .22 :
-                                           parent.height * .24
-                    weight: Font.Light
                     family: "SourceSansPro"
+                    pixelSize: text.includes("veinticinco") || text.includes("moins") || text.includes("demie") || text.includes("vingt-cinq") ? parent.height * .185 : text.includes("nach halb") || text.includes("zwanzig") ? parent.height * .22 : parent.height * .24
+                    weight: Font.Light
                 }
-                text: root.localeName.substring(0,2) === "de" ?
-                          generateTimeDe(wallClock.time) :
-                          root.localeName.substring(0,2) === "es" ?
-                              generateTimeEs(wallClock.time) :
-                              root.localeName.substring(0,2) === "fr" ?
-                                  generateTimeFr(wallClock.time) :
-                                  root.localeName.substring(0,2) === "da" ?
-                                      generateTimeDa(wallClock.time) :
-                                      generateTimeEn(wallClock.time)
-
-
-            }
-
-            layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 4
-                verticalOffset: 4
-                radius: 8.0
-                samples: 17
-                color: "#60000000"
+                text: root.localeName.substring(0,2) === "de" ? generateTimeDe(wallClock.time) : root.localeName.substring(0,2) === "es" ? generateTimeEs(wallClock.time) : root.localeName.substring(0,2) === "fr" ? generateTimeFr(wallClock.time) : root.localeName.substring(0,2) === "da" ? generateTimeDa(wallClock.time) : generateTimeEn(wallClock.time)
             }
 
             Text {
                 id: dateDisplay
 
                 anchors {
-                    topMargin: parent.width * .09
+                    topMargin: -parent.width * .019
                     top: timeDisplay.bottom
                     left: parent.left
                     right: parent.right
                 }
                 horizontalAlignment: Text.AlignHCenter
                 color: "white"
+                textFormat: Text.StyledText
+                renderType: Text.NativeRendering
                 font.pixelSize: parent.height * .07
                 text: wallClock.time.toLocaleString(Qt.locale(root.localeName), "<b>ddd</b> d MMM")
             }
@@ -221,15 +180,14 @@ Item {
                 Icon {
                     id: batteryIcon
 
-                    name: "ios-battery-charging"
                     anchors {
                         right: parent.horizontalCenter
                         rightMargin: watchfaceRoot.height * .004
-                        topMargin: watchfaceRoot.height * .005
                     }
-                    visible: nightstandMode.active
                     width: watchfaceRoot.width * .1
                     height: watchfaceRoot.height * .1
+                    visible: nightstandMode.active
+                    name: "ios-battery-charging"
                 }
 
                 Text {
@@ -239,14 +197,16 @@ Item {
                         left: parent.horizontalCenter
                         leftMargin: watchfaceRoot.height * .004
                     }
+                    visible: nightstandMode.active
+                    color: "white"
+                    style: Text.Outline
+                    styleColor: "#80000000"
+                    renderType: Text.NativeRendering
                     font {
-                        pixelSize: watchfaceRoot.width * .07
                         family: "Roboto"
+                        pixelSize: watchfaceRoot.width * .07
                         styleName: "Regular"
                     }
-                    visible: nightstandMode.active
-                    color: "#ffffffff"
-                    style: Text.Outline; styleColor: "#80000000"
                     text: batteryChargePercentage.percent + "%"
                 }
             }
@@ -272,14 +232,14 @@ Item {
                 property real arcStrokeWidth: .024
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -288,7 +248,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * ( .5 - segmentedArc.scalefactor)
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2
@@ -316,8 +276,8 @@ Item {
         }
 
         Component.onCompleted: {
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .2)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .2)})
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return root.width * (nightstandMode.active ? .08 : .2) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return root.height * (nightstandMode.active ? .08 : .2) })
         }
     }
 }

--- a/src/watchfaces/001-words-worte-palabras-mots.qml
+++ b/src/watchfaces/001-words-worte-palabras-mots.qml
@@ -20,6 +20,8 @@ Item {
     Item {
         id: root
 
+        property string localeName: Qt.locale().name
+
         anchors.centerIn: parent
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
@@ -158,6 +160,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 lineHeight: .64
                 color: "white"
+                textFormat: Text.StyledText
                 font {
                     pixelSize: text.includes('veinticinco') || text.includes('moins') || text.includes('demie') || text.includes('vingt-cinq') ?
                                        parent.height * .185 :
@@ -167,13 +170,13 @@ Item {
                     weight: Font.Light
                     family: "SourceSansPro"
                 }
-                text: Qt.locale().name.substring(0,2) === "de" ?
+                text: root.localeName.substring(0,2) === "de" ?
                           generateTimeDe(wallClock.time) :
-                          Qt.locale().name.substring(0,2) === "es" ?
+                          root.localeName.substring(0,2) === "es" ?
                               generateTimeEs(wallClock.time) :
-                              Qt.locale().name.substring(0,2) === "fr" ?
+                              root.localeName.substring(0,2) === "fr" ?
                                   generateTimeFr(wallClock.time) :
-                                  Qt.locale().name.substring(0,2) === "da" ?
+                                  root.localeName.substring(0,2) === "da" ?
                                       generateTimeDa(wallClock.time) :
                                       generateTimeEn(wallClock.time)
 
@@ -202,7 +205,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 color: "white"
                 font.pixelSize: parent.height * .07
-                text: wallClock.time.toLocaleString(Qt.locale(), "<b>ddd</b> d MMM")
+                text: wallClock.time.toLocaleString(Qt.locale(root.localeName), "<b>ddd</b> d MMM")
             }
 
             Item {
@@ -253,15 +256,8 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
             visible: nightstandMode.active
 
             Repeater {
@@ -275,7 +271,7 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .024
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
                 readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
@@ -288,20 +284,19 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * ( .5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }
@@ -314,11 +309,10 @@ Item {
         }
 
         Connections {
-            target: localeManager
             function onChangesObserverChanged() {
-                timeDisplay.text = Qt.binding(function() { return generateTime(wallClock.time) })
-                dateDisplay.text = Qt.binding(function() { return wallClock.time.toLocaleString(Qt.locale(), "<b>ddd</b> d MMM") })
+                root.localeName = Qt.locale().name
             }
+            target: localeManager
         }
 
         Component.onCompleted: {

--- a/src/watchfaces/001-words-worte-palabras-mots.qml
+++ b/src/watchfaces/001-words-worte-palabras-mots.qml
@@ -1,37 +1,11 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2021 - Oliver Geneser <olivergeneser@gmail.com>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2014 - Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2021 Oliver Geneser <olivergeneser@gmail.com>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick
 import QtQuick.Shapes


### PR DESCRIPTION
## Summary

Refactors the `001-words-worte-palabras-mots` stock watchface to a Qt6-compatible, convention-clean state. This is the 001 slice of splitting #214 into one PR per watchface. The three commits are ordered so every one builds and runs independently.

## Commits

1. **Convert 001-words-worte-palabras-mots license header to SPDX format.** Mechanical replacement of the BSD-3-Clause prose header with SPDX tags across all seven copyright holders. No code change. 
**Apply Qt6 nightstand and arc fixes to 001-words-worte-palabras-mots.** Remove the nightstandMode layer block entirely: the hardware has no multisample renderbuffers, so the requested samples logged a warning and did nothing, and the Shape renderer provides its own antialiasing. Bind the battery arc ShapePath and PathAngleArc geometry to the square root Item rather than parent. Type the charge colour index as int with bitwise truncation, collapse the multi-line sweepAngle ternary to one line, and remove the unused batteryPercentChanged property.
2. **Repair the locale-change handler in 001-words-worte-palabras-mots.** The original Connections block called an undefined generateTime function and would also have replaced the per-language ternary with a broken binding, so locale changes silently failed. Store the system locale name as a property on root, initialised at startup and updated by the Connections handler. The timeDisplay and dateDisplay bindings reference this stored property so the QML engine re-evaluates them immediately on locale change without waiting for the next minute tick.
3. **Apply conventions and formatting to 001-words-worte-palabras-mots.** Drop the unused org.asteroid.utils import and sort imports alphabetically. Normalise square sizing to Math.min. Move the DropShadow block to the top of watchfaceRoot above the children, convert radius and offsets to root-height fractions, and reduce samples to 9. Move id to the first line of the timeDisplay Text before its function declarations, collapse both multi-line ternaries to single lines, and convert single-quoted string literals to double quotes. Remove the always-false hourSuffix dead-code branch from generateTimeDe and clean its indentation. Add textFormat: Text.StyledText and renderType: Text.NativeRendering to all three visible Text items. Split batteryPercent style and styleColor to separate lines and simplify its colour to white. Make the Component.onCompleted burn-in bindings reference root explicitly. Tune verticalCenterOffset and topMargin on hardware against the Qt5 vanilla render to correct the Qt6 font-metrics layout shift.

## Testing

Built on the locally compiled 2.2 nightly (Qt 6.11) and deployed to sturgeon, compared against the 1.1 nightly (Qt 5.15) vanilla render on tunny.

- Normal mode matches the Qt5 reference for text position, date gap and shadow.
- Nightstand mode renders the battery arc with correct geometry and colour, and the journal no longer logs the multisample warning.
- Locale change: switching the system language immediately updates the word clock and date without waiting for the next minute tick.

## Notes

- The outer screen-filling Item is kept on purpose. It is the watchface root the launcher sizes to the screen, while the inner square root keeps the layout from squishing on non-square panels.
- Qt6 allocates more vertical space below the visible glyphs in a Text bounding box than Qt5. Because dateDisplay anchors to timeDisplay.bottom, a negative topMargin is needed to pull it back up to match the vanilla date position. verticalCenterOffset is reduced from the original .085 to .029 for the same reason.
- The locale handler now stores the locale name as a root property used as a binding dependency. The per-language word-generation logic is otherwise unchanged.