### PR TITLE
Refactor 003-alternative-digital-2 watchface for Qt6

### DIFF
--- a/src/watchfaces/003-alternative-digital-2.qml
+++ b/src/watchfaces/003-alternative-digital-2.qml
@@ -191,12 +191,6 @@ Item {
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Repeater {
                 id: segmentedArc
@@ -209,7 +203,7 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .05
                 property real scalefactor: .46 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
                 readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
@@ -222,20 +216,19 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * ( .5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }

--- a/src/watchfaces/003-alternative-digital-2.qml
+++ b/src/watchfaces/003-alternative-digital-2.qml
@@ -18,7 +18,7 @@ Item {
         id: root
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Item {
@@ -28,7 +28,6 @@ Item {
 
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
-            
             layer.enabled: true
             layer.effect: DropShadow {
                 color: Qt.rgba(0, 0, 0, .80)
@@ -160,7 +159,6 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
@@ -177,14 +175,14 @@ Item {
                 property real arcStrokeWidth: .05
                 property real scalefactor: .46 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -193,7 +191,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * ( .5 - segmentedArc.scalefactor)
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2

--- a/src/watchfaces/003-alternative-digital-2.qml
+++ b/src/watchfaces/003-alternative-digital-2.qml
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/003-alternative-digital-2.qml
+++ b/src/watchfaces/003-alternative-digital-2.qml
@@ -14,22 +14,6 @@ import Nemo.Mce
 Item {
     anchors.fill: parent
 
-    function twoDigits(x) {
-        if (x < 10) return "0" + x;
-        else      return x;
-    }
-
-    function prepareContext(ctx) {
-        ctx.reset()
-        ctx.fillStyle = "white"
-        ctx.textAlign = "center"
-        ctx.textBaseline = 'middle';
-        ctx.shadowColor = Qt.rgba(0, 0, 0, .80)
-        ctx.shadowOffsetX = parent.height * .00625
-        ctx.shadowOffsetY = parent.height * .00625
-        ctx.shadowBlur = parent.height * .0156
-    }
-
     Item {
         id: root
 
@@ -44,142 +28,131 @@ Item {
 
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
+            
+            layer.enabled: true
+            layer.effect: DropShadow {
+                color: Qt.rgba(0, 0, 0, .80)
+                horizontalOffset: root.height * .00625
+                verticalOffset: root.height * .00625
+                radius: root.height * .0152
+                samples: 12
+            }
 
-            Canvas {
-                id: hourCanvas
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
+            Text {
+                id: hourText
 
-                property int hour: 0
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-
-                    ctx.font = "60 " + parent.height*.39 + "px Roboto"
-                    ctx.fillText(twoDigits(hour),
-                                 parent.width * .5,
-                                 parent.height * .34);
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    verticalCenter: parent.verticalCenter
+                    horizontalCenterOffset: parent.height * .003
+                    verticalCenterOffset: -parent.height * .212
+                }
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .39
+                    family: "Roboto"
+                    weight: Font.Medium
+                }
+                text: {
+                    var h = wallClock.time.getHours()
+                    if (use12H.value) { h = h % 12; if (h === 0) h = 12 }
+                    return h < 10 ? "0" + h : "" + h
                 }
             }
 
-            Canvas {
-                id: minuteCanvas
+            Text {
+                id: minuteText
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-
-                property int minute: 0
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-
-                    ctx.font = "26 " + parent.height * .38 + "px Roboto"
-                    ctx.fillText(twoDigits(minute),
-                                 parent.width * .5,
-                                 parent.height * .74);
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    verticalCenter: parent.verticalCenter
+                    verticalCenterOffset: parent.height * .19
                 }
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .38
+                    family: "Roboto"
+                    weight: Font.Light
+                }
+                text: Qt.formatTime(wallClock.time, "mm")
             }
 
-            Canvas {
-                id: dateCanvas
+            Text {
+                id: dateText
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
+                x: parent.width * .175
+                anchors {
+                    verticalCenter: parent.verticalCenter
+                    verticalCenterOffset: -parent.height * .002
+                }
                 visible: !nightstandMode.active
-
-                property int month: 0
-                property int date: 0
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625 //2 px on 320x320
-                    ctx.textAlign = "left"
-                    ctx.textBaseline = "left"
-                    ctx.font = "60 " + parent.height * .09 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "dd"),
-                                 parent.width / 10 * 1.75,
-                                 parent.height * .505);
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .09
+                    family: "Raleway"
+                    weight: Font.Medium
                 }
+                text: Qt.formatDate(wallClock.time, "dd")
             }
 
-            Canvas {
-                id: monthCanvas
+            Text {
+                id: monthText
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    verticalCenter: parent.verticalCenter
+                    verticalCenterOffset: parent.height * .006
+                }
                 visible: !nightstandMode.active
-
-                property int month: 0
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625 //2 px on 320x320
-                    ctx.textAlign = "center"
-                    ctx.font = "40 " +parent.height * .07 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale(), "MMMM").toUpperCase(),
-                                 parent.width / 2,
-                                 parent.height * .509);
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .07
+                    family: "Raleway"
+                    weight: Font.Normal
                 }
+                text: Qt.formatDate(wallClock.time, "MMMM").toUpperCase()
             }
 
-            Canvas {
-                id: amPmCanvas
+            Text {
+                id: amPmText
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
+                x: parent.width * .83 - width
+                anchors {
+                    verticalCenter: parent.verticalCenter
+                    verticalCenterOffset: parent.height * .006
+                }
                 visible: use12H.value && !nightstandMode.active
-
-                property bool am: false
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625
-                    ctx.textAlign = "right"
-                    ctx.textBaseline = "right"
-                    ctx.font = "72 " +parent.height * .072 + "px Raleway"
-                    ctx.fillText(wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP").slice(0, 2),
-                                 parent.width / 10 * 8.3,
-                                 parent.height * .509);
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .072
+                    family: "Raleway"
+                    weight: Font.Bold
                 }
+                text: wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP")
             }
 
-            Canvas {
-                id: secondCanvas
+            Text {
+                id: secondText
 
-                anchors.fill: parent
-                antialiasing: true
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-                visible: !use12H.value && !displayAmbient && !nightstandMode.active
-
-                property int second: 0
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625
-                    ctx.textAlign = "right"
-                    ctx.textBaseline = "right"
-                    ctx.font = "60 " +parent.height * .08 + "px Roboto"
-                    ctx.fillText(twoDigits(second),
-                                 parent.width / 10 * 8.1,
-                                 parent.height * .506);
+                x: parent.width * .81 - width
+                anchors {
+                    verticalCenter: parent.verticalCenter
+                    verticalCenterOffset: -parent.height * .002
                 }
+                visible: !use12H.value && !displayAmbient && !nightstandMode.active
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .09
+                    family: "Roboto"
+                    weight: Font.Medium
+                }
+                text: Qt.formatTime(wallClock.time, "ss")
             }
         }
 
@@ -238,82 +211,6 @@ Item {
 
         MceBatteryLevel {
             id: batteryChargePercentage
-        }
-
-        Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var second = wallClock.time.getSeconds()
-            var month = wallClock.time.getMonth()
-            var date = wallClock.time.getDate()
-            var am = hour < 12
-            if(use12H.value) {
-                hour = hour % 12
-                if (hour === 0) hour = 12
-            }
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            secondCanvas.second = second
-            secondCanvas.requestPaint()
-            dateCanvas.date = date
-            dateCanvas.month = month
-            dateCanvas.requestPaint()
-            monthCanvas.month = month
-            monthCanvas.requestPaint()
-            amPmCanvas.am = am
-            amPmCanvas.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .2)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .2)})
-        }
-
-        Connections {
-            target: wallClock
-            function onTimeChanged() {
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var second = wallClock.time.getSeconds()
-                var month = wallClock.time.getMonth()
-                var date = wallClock.time.getDate()
-                var am = hour < 12
-                if(use12H.value) {
-                    hour = hour % 12
-                    if (hour === 0) hour = 12;
-                }
-                if(hourCanvas.hour !== hour) {
-                    hourCanvas.hour = hour
-                    hourCanvas.requestPaint()
-                } if(minuteCanvas.minute !== minute) {
-                    minuteCanvas.minute = minute
-                    minuteCanvas.requestPaint()
-                } if(secondCanvas.second !== second) {
-                    secondCanvas.second = second
-                    secondCanvas.requestPaint()
-                } if(dateCanvas.date !== date || dateCanvas.month !== month) {
-                    dateCanvas.month = month
-                    dateCanvas.date = date
-                    dateCanvas.requestPaint()
-                } if(monthCanvas.month !== month) {
-                    monthCanvas.month = month
-                    monthCanvas.requestPaint()
-                } if(amPmCanvas.am != am) {
-                    amPmCanvas.am = am
-                    amPmCanvas.requestPaint()
-                }
-            }
-        }
-
-        Connections {
-            target: localeManager
-            function onChangesObserverChanged() {
-                hourCanvas.requestPaint()
-                minuteCanvas.requestPaint()
-                secondCanvas.requestPaint()
-                dateCanvas.requestPaint()
-                monthCanvas.requestPaint()
-                amPmCanvas.requestPaint()
-            }
         }
     }
 }


### PR DESCRIPTION
Qt6 refactor of the 003-alternative-digital-2 watchface. Converts the license header to SPDX format, removes the broken nightstand layer block and corrects arc geometry, replaces all six Canvas text items with QML Text items resolving the Qt6 font weight regression, and applies a conventions pass.

This watchface was entirely Canvas-based for text rendering. The conversion to QML Text is the structural core of the PR and required hardware-validated tuning of font weights and vertical offsets.

### Commits

1. **Convert license header to SPDX format** — replaces the legacy BSD block comment with `SPDX-FileCopyrightText` and `SPDX-License-Identifier: BSD-3-Clause` lines.
2. **Fix Qt6 nightstand and arc correctness** — removes the `layer` block from `nightstandMode`, replaces all seven `parent.width/height` references inside `ShapePath` and `PathAngleArc` with `root.width/root.height`, casts `chargecolor` to `int` with an explicit `| 0`, and collapses the multi-line `sweepAngle` ternary.
3. **Convert Canvas text items to QML Text** — replaces all six Canvas items (`hourCanvas`, `minuteCanvas`, `dateCanvas`, `monthCanvas`, `amPmCanvas`, `secondCanvas`) with QML Text items binding directly to `wallClock.time`. Removes `prepareContext()` and `twoDigits()` helper functions. Shadow is consolidated into a single `layer.effect: DropShadow` on `watchfaceRoot`, matching the original `prepareContext` offset and radius values. Both `Connections` blocks are removed. `Component.onCompleted` retains only the `burnInProtectionManager` offset bindings. Font weights and vertical offsets confirmed on hardware against the Qt5 vanilla screenshot: `hourText` `Font.Medium`, `minuteText` `Font.Light`, `dateText` `Font.Medium`, `monthText` `Font.Normal`, `amPmText` `Font.Bold`, `secondText` `Font.Medium`.
4. **Conventions and cleanup** — `Math.min` square sizing on `root`, dead `batteryPercentChanged` property removed from `nightstandMode`, stray blank line in `watchfaceRoot` property block removed, operator spacing normalised in `colorArray`, `startY`, and `segmentedArc` visible expression, qmlformat pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: visual match confirmed against Qt5 reference screenshot for layout, font weights, and shadow rendering.
- Nightstand mode: battery arc renders correctly, `watchfaceRoot` scales to 80% with text items following correctly, no multisample renderbuffer journal warning.
- 12h mode: `amPmText` visible and correctly positioned, `secondText` hidden.
- 24h mode: `secondText` visible and correctly positioned, `amPmText` hidden.
- AoD: `secondText` hidden on ambient entry via `displayAmbient` bare identifier.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- No separate visual tuning commit — font weights and `verticalCenterOffset` values were dialled in iteratively and locked as part of commit 3.
- The consolidated `layer.effect: DropShadow` on `watchfaceRoot` renders with minor glyph softening due to the FBO compositing pass. This is the accepted tradeoff of the architecture and matches the confirmed 000-default-digital shadow pattern.