### PR TITLE
Refactor 004-alternative-scifi watchface for Qt6

### DIFF
--- a/src/watchfaces/004-alternative-scifi.qml
+++ b/src/watchfaces/004-alternative-scifi.qml
@@ -207,12 +207,6 @@ Item {
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
@@ -221,17 +215,15 @@ Item {
                 // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .024
                 property real scalefactor: .42 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
                 readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
                     strokeColor: chargeArc.colorArray[chargeArc.chargecolor]
-                    strokeWidth: parent.height * chargeArc.arcStrokeWidth
+                    strokeWidth: chargeArc.height * chargeArc.arcStrokeWidth
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2

--- a/src/watchfaces/004-alternative-scifi.qml
+++ b/src/watchfaces/004-alternative-scifi.qml
@@ -4,9 +4,9 @@
 // SPDX-FileCopyrightText: 2016 Florent Revest <revestflo@gmail.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
 import org.asteroid.controls
 import org.asteroid.utils
 import Nemo.Mce
@@ -18,7 +18,7 @@ Item {
         id: root
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Item {
@@ -119,7 +119,6 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
@@ -128,7 +127,6 @@ Item {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .024
                 property real scalefactor: .42 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
@@ -143,7 +141,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -164,14 +162,16 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: -parent.width * .3
                 }
+                visible: nightstandMode.active
+                color: chargeArc.colorArray[chargeArc.chargecolor]
+                style: Text.Outline
+                styleColor: "#80000000"
+                renderType: Text.NativeRendering
                 font {
                     pixelSize: parent.width / 20
                     family: "Xolonium"
-                    styleName: "Bold"
+                    weight: Font.Bold
                 }
-                visible: nightstandMode.active
-                color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
                 text: batteryChargePercentage.percent + "%"
             }
         }

--- a/src/watchfaces/004-alternative-scifi.qml
+++ b/src/watchfaces/004-alternative-scifi.qml
@@ -14,20 +14,6 @@ import Nemo.Mce
 Item {
     anchors.fill: parent
 
-    function twoDigits(x) {
-        if (x<10) return "0"+x;
-        else      return x;
-    }
-
-    function prepareContext(ctx) {
-        ctx.reset()
-        ctx.fillStyle = "white"
-        ctx.shadowColor = Qt.rgba(0, 0, 0, .80)
-        ctx.shadowOffsetX = parent.height * .00625
-        ctx.shadowOffsetY = parent.height * .00625
-        ctx.shadowBlur = parent.height * .0156
-    }
-
     Item {
         id: root
 
@@ -39,163 +25,93 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width * (nightstandMode.active ? .8 : 1)
             height: width
+            layer.enabled: true
+            layer.effect: DropShadow {
+                horizontalOffset: root.height * .0062
+                verticalOffset: root.height * .0062
+                radius: root.height * .0166
+                samples: 12
+                color: Qt.rgba(0, 0, 0, .84)
+            }
+            
 
-            Canvas {
-                id: dowCanvas
+            Text {
+                id: dowText
 
-                anchors.fill: parent
-                renderStrategy: Canvas.Cooperative
+                x: parent.width * .373 - width / 2
+                y: parent.height * .324 - height / 2
+                visible: !nightstandMode.active
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .051
+                    family: "Xolonium"
+                }
+                text: Qt.formatDate(wallClock.time, "dddd").toUpperCase()
+            }
 
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height * .00625
-                    ctx.textAlign = "center"
-                    ctx.textBaseline = "middle"
+            Text {
+                id: hourText
 
-                    var bold = "0 "
-                    var px = "px "
-
-                    var centerX = width * .373
-                    var centerY = height / 2 * .57
-                    var verticalOffset = height * .05
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
-
-                    var fontSize = height * .051
-                    var fontFamily = "Xolonium"
-                    ctx.font = bold + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                x: parent.width * .625 - width
+                y: parent.height * .61 - height * .75
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .36
+                    family: "Xolonium"
+                }
+                text: {
+                    var h = wallClock.time.getHours()
+                    if (use12H.value) { h = h % 12; if (h === 0) h = 12 }
+                    return h < 10 ? "0" + h : "" + h
                 }
             }
 
-            Canvas {
-                id: hourCanvas
+            Text {
+                id: minuteText
 
-                property int hour: 0
-
-                anchors.fill: parent
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.textAlign = "right"
-                    ctx.textBaseline = "right"
-
-                    var bold = "60 "
-                    var px = "px "
-
-                    var centerX = width / 2 * 1.25
-                    var centerY = height / 2
-                    var verticalOffset = height * .12
-
-                    var text;
-                    text = twoDigits(hour)
-
-                    var fontSize = height * .36
-                    var fontFamily = "Xolonium"
-                    ctx.font = bold + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                x: parent.width * .64
+                y: parent.height * .611 - height * .75
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .17
+                    family: "Xolonium"
                 }
+                text: Qt.formatTime(wallClock.time, "mm")
             }
 
-            Canvas {
-                id: minuteCanvas
+            Text {
+                id: amPmText
 
-                property int minute: 0
-
-                anchors.fill: parent
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = 3
-                    ctx.textAlign = "left"
-                    ctx.textBaseline = "left"
-
-                    var thin = "0 "
-                    var px = "px "
-
-                    var centerX = width / 2 * 1.268
-                    var centerY = height / 2
-                    var verticalOffset = height * .112
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale(), "mm")
-
-                    var fontSize = height * .17
-                    var fontFamily = "Xolonium"
-                    ctx.font = thin + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
+                x: parent.width * .645
+                y: parent.height * .465 - height * .75
+                visible: use12H.value && !nightstandMode.active
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .057
+                    family: "Xolonium"
                 }
+                text: wallClock.time.toLocaleString(Qt.locale("en_EN"), "AP")
             }
 
-            Canvas {
-                id: amPmCanvas
+            Text {
+                id: dateText
 
-                property bool am: false
-
-                anchors.fill: parent
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height*.00625 //2 px on 320x320
-                    ctx.textAlign = "left"
-                    ctx.textBaseline = "left"
-
-                    var bold = "64 "
-                    var px = "px "
-
-                    var centerX = width / 2 * 1.29
-                    var centerY = height / 2 * .83
-                    var verticalOffset = height * .05
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toUpperCase()
-
-                    var fontSize = height * .057
-                    var fontFamily = "Xolonium"
-                    ctx.font = bold + fontSize + px + fontFamily;
-                    if(use12H.value) ctx.fillText(text, centerX, centerY + verticalOffset);
+                x: parent.width * .626 - width / 2
+                y: parent.height * .675 - height / 2
+                visible: !nightstandMode.active
+                color: "white"
+                renderType: Text.NativeRendering
+                font {
+                    pixelSize: parent.height * .051
+                    family: "Xolonium"
                 }
-            }
-
-            Canvas {
-                id: dateCanvas
-
-                anchors.fill: parent
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    prepareContext(ctx)
-                    ctx.shadowBlur = parent.height*.00625
-                    ctx.textAlign = "center"
-                    ctx.textBaseline = "middle"
-
-                    var thin = "0 "
-                    var px = "px "
-
-                    var centerX = width * .626
-                    var centerY = height / 2 * 1.27
-                    var verticalOffset = height * .05
-
-                    var text;
-                    text = wallClock.time.toLocaleString(Qt.locale(), "dd MMMM").toUpperCase()
-
-                    var fontSize = height * .051
-                    var fontFamily = "Xolonium"
-                    ctx.font = thin + fontSize + px + fontFamily;
-                    ctx.fillText(text, centerX, centerY + verticalOffset);
-                }
+                text: Qt.formatDate(wallClock.time, "dd MMMM").toUpperCase()
             }
         }
 
@@ -265,60 +181,8 @@ Item {
         }
 
         Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var am = hour < 12
-            if(use12H.value) {
-                hour = hour % 12
-                if (hour === 0) hour = 12
-            }
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            dateCanvas.requestPaint()
-            dowCanvas.requestPaint()
-            amPmCanvas.am = am
-            amPmCanvas.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .12 : .2)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .12 : .2)})
-        }
-
-        Connections {
-            target: wallClock
-            function onTimeChanged() {
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var date = wallClock.time.getDate()
-                var am = hour < 12
-                if(use12H.value) {
-                    hour = hour % 12
-                    if (hour === 0) hour = 12;
-                }
-                if(hourCanvas.hour !== hour) {
-                    hourCanvas.hour = hour
-                    hourCanvas.requestPaint()
-                } if(minuteCanvas.minute !== minute) {
-                    minuteCanvas.minute = minute
-                    minuteCanvas.requestPaint()
-                    dateCanvas.requestPaint()
-                    dowCanvas.requestPaint()
-                } if(amPmCanvas.am != am) {
-                    amPmCanvas.am = am
-                    amPmCanvas.requestPaint()
-                }
-            }
-        }
-
-        Connections {
-            target: localeManager
-            function onChangesObserverChanged() {
-                hourCanvas.requestPaint()
-                minuteCanvas.requestPaint()
-                dateCanvas.requestPaint()
-                dowCanvas.requestPaint()
-                amPmCanvas.requestPaint()
-            }
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .12 : .2) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .12 : .2) })
         }
     }
 }

--- a/src/watchfaces/004-alternative-scifi.qml
+++ b/src/watchfaces/004-alternative-scifi.qml
@@ -1,34 +1,8 @@
-/*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Florent Revest <revestflo@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Florent Revest <revestflo@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick
 import QtQuick.Shapes


### PR DESCRIPTION
Qt6 refactor of the 004-alternative-scifi watchface. Converts the license header to SPDX format, removes the broken nightstand layer block and corrects arc geometry, replaces all five Canvas text items with QML Text items resolving the Qt6 font weight regression and an AM/PM display bug, and applies a conventions pass.

### Commits

1. **Convert license header to SPDX format** — replaces the legacy BSD block comment with `SPDX-FileCopyrightText` and `SPDX-License-Identifier: BSD-3-Clause` lines.
2. **Fix Qt6 nightstand correctness** — removes the `layer` block from `nightstandMode`, removes `smooth: true` and `antialiasing: true` from `chargeArc`, fixes the one `parent.height` reference inside `ShapePath` to use `chargeArc.height`, and casts `chargecolor` to `int` with an explicit `| 0`. No sweepAngle ternary collapse was needed and no `PathAngleArc` parent references required fixing — the vanilla already referenced `chargeArc` geometry by id throughout.
3. **Convert Canvas text items to QML Text** — replaces all five Canvas items with QML Text items binding directly to `wallClock.time`. Resolves the Qt6 font weight regression where non-standard CSS weight tokens below 100 were previously clamped to Thin. Removes `prepareContext()` and `twoDigits()` helper functions; shadow is replaced by a single `layer.effect: DropShadow` on `watchfaceRoot`. Fixes the AM/PM display not responding to 12h/24h setting changes — the Canvas implementation gated rendering with `if (use12H.value)` inside `onPaint` but never triggered `requestPaint` on setting change; `amPmText.visible` and `hourText.text` now bind directly to `use12H.value` and re-evaluate immediately. Both `Connections` blocks removed. `Component.onCompleted` retains only the `burnInProtectionManager` offset bindings. All five text items confirmed at `Font.Normal` on hardware — Xolonium Regular is the correct weight throughout. Position values tuned against Qt5 vanilla reference.
4. **Conventions and cleanup** — imports sorted alphabetically with `Qt5Compat.GraphicalEffects` before `QtQuick` per qmlformat convention, `Math.min` square sizing on `root`, dead `batteryPercentChanged` removed, stale `chargeArc` comment removed, `colorArray` bracket spacing and `startY` parenthesis spacing normalised, `batteryPercent` converted from `font.styleName` to `font.weight: Font.Bold` with `style`/`styleColor` split and `renderType: Text.NativeRendering` added, property ordering corrected to anchors-first, qmlformat pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: visual match confirmed for layout, font weights, and shadow rendering.
- 12h mode: `amPmText` visible and correctly positioned; hour display shows 12h format. Setting change responds immediately.
- 24h mode: `amPmText` hidden; hour display shows 24h format. Setting change responds immediately.
- Nightstand mode: battery arc and percentage render correctly, no multisample renderbuffer journal warning.
- AoD: `secondText` is not present in this watchface; ambient mode tested implicitly.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- No separate visual tuning commit — font weights and position values were dialled in during commit 3.
- The nightstand arc in this watchface is a single continuous `Shape`, not a segmented `Repeater`. Most `PathAngleArc` geometry already referenced `chargeArc` by id in the vanilla; only `strokeWidth` required correction.
- Import alphabetical ordering fix (`Qt5Compat.GraphicalEffects` before `QtQuick`) also applies to the already-open 003 branch if it has not yet merged.