### PR TITLE
Refactor 006-analog-weather-satellite watchface for Qt6

### DIFF
--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -11,7 +11,7 @@
 import QtQuick
 import QtQuick.Shapes
 import QtSensors
-import Qt5compat.GraphicalEffects
+import Qt5Compat.GraphicalEffects
 import org.asteroid.controls
 import org.asteroid.utils
 import Nemo.Configuration
@@ -82,12 +82,6 @@ Item {
 
             anchors.fill: root
             visible: dockMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(dockMode.width * 2, dockMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
@@ -96,7 +90,7 @@ Item {
                 // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: 0.016
                 property real scalefactor: 0.39 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
                 readonly property var colorArray: [ "red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: dockMode
@@ -107,8 +101,8 @@ Item {
                     strokeWidth: dockMode.height * chargeArc.arcStrokeWidth
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
-                    startX: width / 2
-                    startY: height * ( 0.5 - chargeArc.scalefactor)
+                    startX: chargeArc.width / 2
+                    startY: chargeArc.height * ( 0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: dockMode.width / 2
@@ -631,31 +625,21 @@ Item {
                 width: handBox.width
                 height: handBox.height
                 source: imgPath + "hour-12h.svg"
-                antialiasing: true
-                smooth: true
 
                 transform: Rotation {
+                    id: hourRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: hourSVG.toggle24h ?
-                               (wallClock.time.getHours() * 15) + (wallClock.time.getMinutes() * .25) :
-                               (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * .5)
                 }
 
-                layer {
-                    enabled: true
-                    samples: 4
-                    smooth: true
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    // DropShadow depends on import Qt5Compat.GraphicalEffects
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 3
-                        verticalOffset: 3
-                        radius: 8.0
-                        samples: 17
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 3
+                    verticalOffset: 3
+                    radius: 8.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
@@ -666,71 +650,70 @@ Item {
                 width: handBox.width
                 height: handBox.height
                 source: imgPath + "minute.svg"
-                antialiasing: true
-                smooth: true
 
                 transform: Rotation {
+                    id: minuteRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
                 }
 
-                layer {
-                    enabled: true
-                    samples: 4
-                    smooth: true
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 5
-                        verticalOffset: 5
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: 5
+                    verticalOffset: 5
+                    radius: 10.0
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
+            // second hand has no layer — continuous 60fps rotation would force constant recomposite
             Image {
                 id: secondSVG
 
                 anchors.centerIn: handBox
                 width: handBox.width
                 height: handBox.height
-                source: imgPath + "second.svg"
-                antialiasing: true
-                smooth: true
                 visible: !displayAmbient && !dockMode.active
+                source: imgPath + "second.svg"
 
                 transform: Rotation {
+                    id: secondRot
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: wallClock.time.getSeconds() * 6
-
-                    Behavior on angle {
-                        enabled: !displayAmbient && !nightstand
-                        RotationAnimation {
-                            duration: 1000
-                            direction: RotationAnimation.Clockwise
-                        }
-                    }
-                }
-
-                layer {
-                    enabled: true
-                    samples: 4
-                    smooth: true
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 5
-                        verticalOffset: 5
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
                 }
             }
+        }
+        
+        Timer {
+            interval: 16
+            repeat: true
+            running: !displayAmbient && !dockMode.active && visible
+
+            onTriggered: {
+                var now = new Date();
+                secondRot.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000;
+            }
+        }
+        
+        Connections {
+            target: wallClock
+            function onTimeChanged() {
+                var h = wallClock.time.getHours();
+                var min = wallClock.time.getMinutes();
+                var sec = wallClock.time.getSeconds();
+                hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5;
+                minuteRot.angle = min * 6 + sec * 6 / 60;
+            }
+        }
+
+        Component.onCompleted: {
+            var h = wallClock.time.getHours();
+            var min = wallClock.time.getMinutes();
+            var sec = wallClock.time.getSeconds();
+            hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5;
+            minuteRot.angle = min * 6 + sec * 6 / 60;
         }
     }
 }

--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -8,14 +8,14 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
 import QtSensors
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
 import Nemo.Configuration
 import Nemo.Mce
+import org.asteroid.controls
+import org.asteroid.utils
 import 'weathericons.js' as WeatherIcons
 
 Item {
@@ -61,7 +61,7 @@ Item {
         id: root
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
 
@@ -78,7 +78,6 @@ Item {
             id: dockMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: root
             visible: dockMode.active
@@ -87,11 +86,10 @@ Item {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: 0.016
                 property real scalefactor: 0.39 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: dockMode
 
@@ -102,7 +100,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( 0.5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: dockMode.width / 2
@@ -130,7 +128,8 @@ Item {
                 }
                 visible: dockMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
+                style: Text.Outline
+                styleColor: "#80000000"
                 renderType: Text.NativeRendering
                 text: batteryChargePercentage.percent
             }
@@ -368,7 +367,6 @@ Item {
                 }
 
                 Icon {
-                    // WeatherIcons depends on import 'weathericons.js' as WeatherIcons
                     id: iconDisplay
 
                     anchors {

--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
 // SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
 // SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
 // SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
@@ -8,51 +8,55 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Configuration
+import Nemo.Mce
 import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
 import QtSensors
-import Nemo.Configuration
-import Nemo.Mce
 import org.asteroid.controls
 import org.asteroid.utils
-import 'weathericons.js' as WeatherIcons
+import "weathericons.js" as WeatherIcons
 
 Item {
-    anchors.fill: parent
+    // Uranian Blue
 
     property string imgPath: "../watchfaces-img/analog-weather-satellite-"
-
     // Element sizes, positioning, linewidth and opacity
-    property real switchSize: root.width * .1375
-    property real boxSize: root.width * .35
-    property real switchPosition: root.width * .26
-    property real boxPosition: root.width * .25
-    property real innerArcLineWidth: root.height * .008
-    property real outerArcLineWidth: root.height * .016
-    property real activeArcOpacity: !displayAmbient ? .7 : .4
-    property real inactiveArcOpacity: !displayAmbient ? .5 : .3
-    property real activeContentOpacity: !displayAmbient ? .95 : .6
-    property real inactiveContentOpacity: !displayAmbient ? .5 : .3
-
+    property real switchSize: root.width * 0.1375
+    property real boxSize: root.width * 0.35
+    property real switchPosition: root.width * 0.26
+    property real boxPosition: root.width * 0.25
+    property real innerArcLineWidth: root.height * 0.008
+    property real outerArcLineWidth: root.height * 0.016
+    property real activeArcOpacity: !displayAmbient ? 0.7 : 0.4
+    property real inactiveArcOpacity: !displayAmbient ? 0.5 : 0.3
+    property real activeContentOpacity: !displayAmbient ? 0.95 : 0.6
+    property real inactiveContentOpacity: !displayAmbient ? 0.5 : 0.3
     // Color definition
-    property string customRed: "#DB5461" // Indian Red
-    property string customBlue: "#1E96FC" // Dodger Blue
-    property string customGreen: "#26C485" // Ocean Green
-    property string customOrange: "#FFC600" // Mikado Yellow
-    property string boxColor: "#E8DCB9" // Dutch White
-    property string switchColor: "#A2D6F9" // Uranian Blue
-
+    property string customRed: "#DB5461"
+    // Indian Red
+    property string customBlue: "#1E96FC"
+    // Dodger Blue
+    property string customGreen: "#26C485"
+    // Ocean Green
+    property string customOrange: "#FFC600"
+    // Mikado Yellow
+    property string boxColor: "#E8DCB9"
+    // Dutch White
+    property string switchColor: "#A2D6F9"
     // Set day to use in the weatherBox to today.
     property int dayNb: 0
 
     function kelvinToTemperatureString(kelvin) {
         var celsius = (kelvin - 273);
-        if(!useFahrenheit.value)
+        if (!useFahrenheit.value)
             return celsius + "°";
         else
             return Math.round(((celsius) * 9 / 5) + 32) + "°";
     }
+
+    anchors.fill: parent
 
     Item {
         id: root
@@ -60,8 +64,13 @@ Item {
         anchors.centerIn: parent
         height: Math.min(parent.width, parent.height)
         width: height
-
-
+        Component.onCompleted: {
+            var h = wallClock.time.getHours();
+            var min = wallClock.time.getMinutes();
+            var sec = wallClock.time.getSeconds();
+            hourRot.angle = hourSVG.toggle24h ? h * 15 + min * 0.25 : h * 30 + min * 0.5;
+            minuteRot.angle = min * 6 + sec * 6 / 60;
+        }
 
         MceBatteryState {
             id: batteryChargeState
@@ -108,70 +117,70 @@ Item {
                         sweepAngle: chargeArc.angle
                         moveToStart: false
                     }
+
                 }
+
             }
 
             Text {
                 id: batteryDockPercent
 
-                anchors {
-                    centerIn: dockMode
-                    verticalCenterOffset: dockMode.width * 0.22
-                }
-                font {
-                    pixelSize: dockMode.width * .15
-                    family: "Noto Sans"
-                    styleName: "Condensed Light"
-                }
                 visible: dockMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 style: Text.Outline
                 styleColor: "#80000000"
                 renderType: Text.NativeRendering
                 text: batteryChargePercentage.percent
+
+                anchors {
+                    centerIn: dockMode
+                    verticalCenterOffset: dockMode.width * 0.22
+                }
+
+                font {
+                    pixelSize: dockMode.width * 0.15
+                    family: "Noto Sans"
+                    styleName: "Condensed Light"
+                }
+
             }
+
         }
 
         Item {
             id: dialBox
 
             anchors.fill: parent
-
             // Slight dropshadow under all Items.
             layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 1
-                verticalOffset: 1
-                radius: 6.0
-                samples: 13
-                color: Qt.rgba(0, 0, 0, .7)
-            }
 
             Repeater {
-                    model: 60
+                model: 60
 
-                    Rectangle {
-                        id: minuteStrokes
+                Rectangle {
+                    id: minuteStrokes
 
-                        property real rotM: (index - 15) / 60
-                        property real centerX: root.width / 2 - width / 2
-                        property real centerY: root.height / 2 - height / 2
+                    property real rotM: (index - 15) / 60
+                    property real centerX: root.width / 2 - width / 2
+                    property real centerY: root.height / 2 - height / 2
 
-                        x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
-                        y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
-                        visible: index % 5
-                        antialiasing: true
-                        color: "#55ffffff"
-                        width: root.width * .005
-                        height: root.height * .018
-                        transform: Rotation {
-                            origin.x: width / 2
-                            origin.y: height / 2
-                            angle: (index) * 6
-                        }
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.46
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.46
+                    visible: index % 5
+                    antialiasing: true
+                    color: "#55ffffff"
+                    width: root.width * 0.005
+                    height: root.height * 0.018
+
+                    transform: Rotation {
+                        origin.x: width / 2
+                        origin.y: height / 2
+                        angle: (index) * 6
                     }
+
                 }
+
+            }
 
             Repeater {
                 // Hour numerals. hourModeSwitch toggles the 12/24hour display.
@@ -184,103 +193,116 @@ Item {
                     property real centerX: root.width / 2 - width / 2
                     property real centerY: root.height / 2 - height / 2
 
-                    font {
-                        pixelSize: root.height * .06
-                        family: "Noto Sans"
-                        styleName: "Bold"
-                    }
-                    x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
-                    y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * 0.46
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * 0.46
                     antialiasing: true
                     color: hourSVG.toggle24h && index === 0 ? customGreen : "white"
                     opacity: inactiveContentOpacity
                     renderType: Text.NativeRendering
                     text: (index === 0 ? 12 : index)
 
+                    font {
+                        pixelSize: root.height * 0.06
+                        family: "Noto Sans"
+                        styleName: "Bold"
+                    }
+
                     transform: Rotation {
                         origin.x: width / 2
                         origin.y: height / 2
-                        angle: index === 6 ?
-                                   0 :
-                                   ([4, 5, 7, 8].includes(index)) ?
-                                       (index * 30) + 180 :
-                                       index * 30
+                        angle: index === 6 ? 0 : ([4, 5, 7, 8].includes(index)) ? (index * 30) + 180 : index * 30
                     }
+
                 }
+
             }
 
             Item {
                 // Wrapper for digital time related objects. Hour, minute and AP following units setting.
                 id: digitalBox
 
-                anchors {
-                    centerIn: dialBox
-                    verticalCenterOffset: dockMode.active ? -root.width * .21 : -root.width * .29
-                }
-                width: !dockMode.active ? boxSize : boxSize * .84
+                width: !dockMode.active ? boxSize : boxSize * 0.84
                 height: width
                 opacity: activeContentOpacity
+
+                anchors {
+                    centerIn: dialBox
+                    verticalCenterOffset: dockMode.active ? -root.width * 0.21 : -root.width * 0.29
+                }
 
                 Text {
                     id: digitalHour
 
-                    anchors {
-                        right: digitalBox.horizontalCenter
-                        rightMargin: digitalBox.width * .01
-                        verticalCenter: digitalBox.verticalCenter
-                    }
-                    font {
-                        pixelSize: digitalBox.width * .46
-                        family: "Noto Sans"
-                        styleName: "Regular"
-                        letterSpacing: -digitalBox.width * .001
-                    }
                     color: "#ccffffff"
                     renderType: Text.NativeRendering
-                    text: if (use12H.value) {
-                              wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2)}
-                          else
-                              wallClock.time.toLocaleString(Qt.locale(), "HH")
+                    text: {
+                        if (use12H.value) {
+                            wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
+                        } else {
+                            wallClock.time.toLocaleString(Qt.locale(), "HH");
+                        }
+                    }
+
+                    anchors {
+                        right: digitalBox.horizontalCenter
+                        rightMargin: digitalBox.width * 0.01
+                        verticalCenter: digitalBox.verticalCenter
+                    }
+
+                    font {
+                        pixelSize: digitalBox.width * 0.46
+                        family: "Noto Sans"
+                        styleName: "Regular"
+                        letterSpacing: -digitalBox.width * 0.001
+                    }
+
                 }
 
                 Text {
                     id: digitalMinutes
 
-                    anchors {
-                        left: digitalHour.right
-                        bottom: digitalHour.bottom
-                        leftMargin: digitalBox.width * .01
-                    }
-                    font {
-                        pixelSize: digitalBox.width * .46
-                        family: "Noto Sans"
-                        styleName: "Light"
-                        letterSpacing: -digitalBox.width * .001
-                    }
                     color: "#ddffffff"
                     renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+                    anchors {
+                        left: digitalHour.right
+                        bottom: digitalHour.bottom
+                        leftMargin: digitalBox.width * 0.01
+                    }
+
+                    font {
+                        pixelSize: digitalBox.width * 0.46
+                        family: "Noto Sans"
+                        styleName: "Light"
+                        letterSpacing: -digitalBox.width * 0.001
+                    }
+
                 }
 
                 Text {
                     id: apDisplay
 
+                    visible: use12H.value
+                    color: "#ddffffff"
+                    renderType: Text.NativeRendering
+                    text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
+
                     anchors {
                         left: digitalMinutes.right
-                        leftMargin: digitalBox.width * .09
+                        leftMargin: digitalBox.width * 0.09
                         bottom: digitalMinutes.verticalCenter
-                        bottomMargin: -digitalBox.width * .22
+                        bottomMargin: -digitalBox.width * 0.22
                     }
+
                     font {
                         pixelSize: digitalBox.width * 0.14
                         family: "Noto Sans"
                         styleName: "Condensed"
                     }
-                    visible: use12H.value
-                    color: "#ddffffff"
-                    renderType: Text.NativeRendering
-                    text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
+
                 }
+
             }
 
             Item {
@@ -289,12 +311,15 @@ Item {
                 // ConfigurationValue depends on Nemo.Configuration 1.0
                 id: weatherBox
 
-                anchors {
-                    centerIn: dialBox
-                    horizontalCenterOffset: !dockMode.active ? -boxPosition : -boxPosition * .78
-                }
+                property bool weatherSynced: maxTemp.value != 0
+
                 width: boxSize
                 height: width
+
+                anchors {
+                    centerIn: dialBox
+                    horizontalCenterOffset: !dockMode.active ? -boxPosition : -boxPosition * 0.78
+                }
 
                 ConfigurationValue {
                     id: timestampDay0
@@ -312,23 +337,23 @@ Item {
 
                 ConfigurationValue {
                     id: owmId
+
                     key: "/org/asteroidos/weather/day" + dayNb + "/id"
                     defaultValue: 0
                 }
 
                 ConfigurationValue {
                     id: maxTemp
+
                     key: "/org/asteroidos/weather/day" + dayNb + "/max-temp"
                     defaultValue: 0
                 }
-
-                property bool weatherSynced: maxTemp.value != 0
 
                 Rectangle {
                     id: weatherArc
 
                     anchors.centerIn: parent
-                    width: parent.width * .86
+                    width: parent.width * 0.86
                     height: width
                     radius: width / 2
                     color: "#22ffffff"
@@ -354,30 +379,28 @@ Item {
                         border.width: innerArcLineWidth
                         border.color: boxColor
                     }
+
                 }
 
                 Icon {
                     id: iconDisplay
 
-                    anchors {
-                        centerIn: weatherBox
-                        verticalCenterOffset: -parent.height * .155
-                    }
-                    width: weatherBox.width * .42
+                    width: weatherBox.width * 0.42
                     height: width
                     opacity: activeContentOpacity
                     visible: weatherBox.weatherSynced
                     name: WeatherIcons.getIconName(owmId.value)
+
+                    anchors {
+                        centerIn: weatherBox
+                        verticalCenterOffset: -parent.height * 0.155
+                    }
+
                 }
 
                 Label {
                     id: maxDisplay
 
-                    anchors {
-                        centerIn: weatherBox
-                        verticalCenterOffset: weatherBox.height * (weatherBox.weatherSynced ? .155 : 0)
-                        horizontalCenterOffset: weatherBox.height * (weatherBox.weatherSynced ? .05 : 0)
-                    }
                     width: weatherBox.width
                     height: width
                     horizontalAlignment: Text.AlignHCenter
@@ -385,31 +408,41 @@ Item {
                     opacity: activeContentOpacity
                     renderType: Text.NativeRendering
                     textFormat: Text.StyledText
+                    text: weatherBox.weatherSynced ? kelvinToTemperatureString(maxTemp.value) : "NO<br>WEATHER<br>DATA"
+
+                    anchors {
+                        centerIn: weatherBox
+                        verticalCenterOffset: weatherBox.height * (weatherBox.weatherSynced ? 0.155 : 0)
+                        horizontalCenterOffset: weatherBox.height * (weatherBox.weatherSynced ? 0.05 : 0)
+                    }
+
                     font {
                         family: "Barlow"
                         styleName: weatherBox.weatherSynced ? "Medium" : "Bold"
-                        pixelSize: weatherBox.width * (weatherBox.weatherSynced ? .30 : .14)
+                        pixelSize: weatherBox.width * (weatherBox.weatherSynced ? 0.3 : 0.14)
                     }
-                    text: weatherBox.weatherSynced ? kelvinToTemperatureString(maxTemp.value) : "NO<br>WEATHER<br>DATA"
+
                 }
+
             }
 
             Item {
                 // Wrapper for date related objects, day name, day number and month short code.
                 id: dayBox
 
-                anchors {
-                    centerIn: dialBox
-                    horizontalCenterOffset: !dockMode.active ? boxPosition : boxPosition * .78
-                }
                 width: boxSize
                 height: width
+
+                anchors {
+                    centerIn: dialBox
+                    horizontalCenterOffset: !dockMode.active ? boxPosition : boxPosition * 0.78
+                }
 
                 Rectangle {
                     id: dayArc
 
                     anchors.centerIn: parent
-                    width: parent.width * .86
+                    width: parent.width * 0.86
                     height: width
                     radius: width / 2
                     color: "#22ffffff"
@@ -435,59 +468,68 @@ Item {
                         border.width: innerArcLineWidth
                         border.color: boxColor
                     }
+
                 }
 
                 Text {
                     id: dayName
 
-                    anchors {
-                        centerIn: dayBox
-                        verticalCenterOffset: -dayBox.width * .25
-                    }
-                    font {
-                        pixelSize: dayBox.width * .14
-                        family: "Barlow"
-                        styleName: "Bold"
-                    }
                     color: "#ffffffff"
                     opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
                     renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 3).toUpperCase()
+
+                    anchors {
+                        centerIn: dayBox
+                        verticalCenterOffset: -dayBox.width * 0.25
+                    }
+
+                    font {
+                        pixelSize: dayBox.width * 0.14
+                        family: "Barlow"
+                        styleName: "Bold"
+                    }
+
                 }
 
                 Text {
                     id: dayNumber
 
                     anchors.centerIn: dayBox
-                    
-                    font {
-                        pixelSize: dayBox.width * .38
-                        family: "Noto Sans"
-                        styleName: "Condensed"
-                    }
                     color: "#ffffffff"
                     opacity: activeContentOpacity
                     renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
+
+                    font {
+                        pixelSize: dayBox.width * 0.38
+                        family: "Noto Sans"
+                        styleName: "Condensed"
+                    }
+
                 }
 
                 Text {
                     id: monthName
 
-                    anchors {
-                        centerIn: dayBox
-                        verticalCenterOffset: dayBox.width * .25
-                    }
-                    font {
-                        pixelSize: dayBox.width * .14
-                        family: "Barlow"
-                        styleName: "Bold"
-                    }
                     color: "#ffffffff"
                     opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
                     renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase()
+
+                    anchors {
+                        centerIn: dayBox
+                        verticalCenterOffset: dayBox.width * 0.25
+                    }
+
+                    font {
+                        pixelSize: dayBox.width * 0.14
+                        family: "Barlow"
+                        styleName: "Bold"
+                    }
+
                 }
+
             }
 
             Item {
@@ -497,17 +539,18 @@ Item {
 
                 property int value: batteryChargePercentage.percent
 
-                anchors {
-                    centerIn: dialBox
-                    verticalCenterOffset: boxPosition
-                }
                 width: boxSize
                 height: width
                 visible: !dockMode.active
 
+                anchors {
+                    centerIn: dialBox
+                    verticalCenterOffset: boxPosition
+                }
+
                 Rectangle {
                     anchors.centerIn: parent
-                    width: parent.width * .86
+                    width: parent.width * 0.86
                     height: width
                     radius: width / 2
                     color: "#22ffffff"
@@ -529,18 +572,20 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: batteryArc.width / 2
-                        startY: batteryArc.height * (.5 - .43)
+                        startY: batteryArc.height * (0.5 - 0.43)
 
                         PathAngleArc {
                             centerX: batteryBox.width / 2
                             centerY: batteryBox.height / 2
-                            radiusX: batteryBox.width * .43
-                            radiusY: batteryBox.height * .43
+                            radiusX: batteryBox.width * 0.43
+                            radiusY: batteryBox.height * 0.43
                             startAngle: -90
                             sweepAngle: batteryBox.value / 100 * 360
                             moveToStart: false
                         }
+
                     }
+
                 }
 
                 Icon {
@@ -548,50 +593,69 @@ Item {
 
                     name: "ios-flash"
                     visible: batteryChargeState.value === MceBatteryState.Charging
-                    anchors {
-                        centerIn: batteryBox
-                        verticalCenterOffset: -batteryBox.height * .26
-                    }
-                    width: batteryBox.width * .25
+                    width: batteryBox.width * 0.25
                     height: width
                     opacity: inactiveContentOpacity
+
+                    anchors {
+                        centerIn: batteryBox
+                        verticalCenterOffset: -batteryBox.height * 0.26
+                    }
+
                 }
 
                 Text {
                     id: batteryDisplay
 
-                    anchors {
-                        centerIn: batteryBox
-                    }
-                    font {
-                        pixelSize: batteryBox.width * .38
-                        family: "Noto Sans"
-                        styleName: "Condensed"
-                    }
                     color: "#ffffffff"
                     opacity: activeContentOpacity
                     renderType: Text.NativeRendering
                     text: batteryBox.value
+
+                    anchors {
+                        centerIn: batteryBox
+                    }
+
+                    font {
+                        pixelSize: batteryBox.width * 0.38
+                        family: "Noto Sans"
+                        styleName: "Condensed"
+                    }
+
                 }
 
                 Text {
                     id: chargeText
 
-                    anchors {
-                        centerIn: batteryBox
-                        verticalCenterOffset: batteryBox.width * .25
-                    }
-                    font {
-                        pixelSize: batteryBox.width * .14
-                        family: "Barlow"
-                        styleName: "Bold"
-                    }
                     color: "#ffffffff"
                     opacity: inactiveContentOpacity
                     renderType: Text.NativeRendering
                     text: "%"
+
+                    anchors {
+                        centerIn: batteryBox
+                        verticalCenterOffset: batteryBox.width * 0.25
+                    }
+
+                    font {
+                        pixelSize: batteryBox.width * 0.14
+                        family: "Barlow"
+                        styleName: "Bold"
+                    }
+
                 }
+
             }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: 1
+                verticalOffset: 1
+                radius: 6
+                samples: 13
+                color: Qt.rgba(0, 0, 0, 0.7)
+            }
+
         }
 
         Item {
@@ -610,22 +674,24 @@ Item {
                 width: handBox.width
                 height: handBox.height
                 source: imgPath + "hour-12h.svg"
+                layer.enabled: true
 
                 transform: Rotation {
                     id: hourRot
+
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
                 }
 
-                layer.enabled: true
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: 3
                     verticalOffset: 3
-                    radius: 8.0
+                    radius: 8
                     samples: 9
-                    color: Qt.rgba(0, 0, 0, .2)
+                    color: Qt.rgba(0, 0, 0, 0.2)
                 }
+
             }
 
             Image {
@@ -635,22 +701,24 @@ Item {
                 width: handBox.width
                 height: handBox.height
                 source: imgPath + "minute.svg"
+                layer.enabled: true
 
                 transform: Rotation {
                     id: minuteRot
+
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
                 }
 
-                layer.enabled: true
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: 5
                     verticalOffset: 5
-                    radius: 10.0
+                    radius: 10
                     samples: 9
-                    color: Qt.rgba(0, 0, 0, .2)
+                    color: Qt.rgba(0, 0, 0, 0.2)
                 }
+
             }
 
             // second hand has no layer — continuous 60fps rotation would force constant recomposite
@@ -665,40 +733,37 @@ Item {
 
                 transform: Rotation {
                     id: secondRot
+
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
                 }
+
             }
+
         }
-        
+
         Timer {
             interval: 16
             repeat: true
             running: !displayAmbient && !dockMode.active && visible
-
             onTriggered: {
                 var now = new Date();
                 secondRot.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000;
             }
         }
-        
+
         Connections {
-            target: wallClock
             function onTimeChanged() {
                 var h = wallClock.time.getHours();
                 var min = wallClock.time.getMinutes();
                 var sec = wallClock.time.getSeconds();
-                hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5;
+                hourRot.angle = hourSVG.toggle24h ? h * 15 + min * 0.25 : h * 30 + min * 0.5;
                 minuteRot.angle = min * 6 + sec * 6 / 60;
             }
+
+            target: wallClock
         }
 
-        Component.onCompleted: {
-            var h = wallClock.time.getHours();
-            var min = wallClock.time.getMinutes();
-            var sec = wallClock.time.getSeconds();
-            hourRot.angle = hourSVG.toggle24h ? h * 15 + min * .25 : h * 30 + min * .5;
-            minuteRot.angle = min * 6 + sec * 6 / 60;
-        }
     }
+
 }

--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -1,27 +1,12 @@
-﻿/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+﻿// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -131,6 +131,7 @@ Item {
                 visible: dockMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 style: Text.Outline; styleColor: "#80000000"
+                renderType: Text.NativeRendering
                 text: batteryChargePercentage.percent
             }
         }
@@ -187,7 +188,6 @@ Item {
                     property real centerX: root.width / 2 - width / 2
                     property real centerY: root.height / 2 - height / 2
 
-                    antialiasing : true
                     font {
                         pixelSize: root.height * .06
                         family: "Noto Sans"
@@ -195,8 +195,10 @@ Item {
                     }
                     x: centerX + Math.cos(rotM * 2 * Math.PI) * root.width * .46
                     y: centerY + Math.sin(rotM * 2 * Math.PI) * root.width * .46
+                    antialiasing: true
                     color: hourSVG.toggle24h && index === 0 ? customGreen : "white"
                     opacity: inactiveContentOpacity
+                    renderType: Text.NativeRendering
                     text: (index === 0 ? 12 : index)
 
                     transform: Rotation {
@@ -238,6 +240,7 @@ Item {
                         letterSpacing: -digitalBox.width * .001
                     }
                     color: "#ccffffff"
+                    renderType: Text.NativeRendering
                     text: if (use12H.value) {
                               wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2)}
                           else
@@ -259,6 +262,7 @@ Item {
                         letterSpacing: -digitalBox.width * .001
                     }
                     color: "#ddffffff"
+                    renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "mm")
                 }
 
@@ -278,6 +282,7 @@ Item {
                     }
                     visible: use12H.value
                     color: "#ddffffff"
+                    renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
                 }
             }
@@ -390,6 +395,8 @@ Item {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     opacity: activeContentOpacity
+                    renderType: Text.NativeRendering
+                    textFormat: Text.StyledText
                     font {
                         family: "Barlow"
                         styleName: weatherBox.weatherSynced ? "Medium" : "Bold"
@@ -463,15 +470,15 @@ Item {
                     }
                     color: "#ffffffff"
                     opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
+                    renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 3).toUpperCase()
                 }
 
                 Text {
                     id: dayNumber
 
-                    anchors {
-                        centerIn: dayBox
-                    }
+                    anchors.centerIn: dayBox
+                    
                     font {
                         pixelSize: dayBox.width * .38
                         family: "Noto Sans"
@@ -479,6 +486,7 @@ Item {
                     }
                     color: "#ffffffff"
                     opacity: activeContentOpacity
+                    renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
                 }
 
@@ -496,6 +504,7 @@ Item {
                     }
                     color: "#ffffffff"
                     opacity: displayAmbient ? inactiveArcOpacity : activeContentOpacity
+                    renderType: Text.NativeRendering
                     text: wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase()
                 }
             }
@@ -587,6 +596,7 @@ Item {
                     }
                     color: "#ffffffff"
                     opacity: activeContentOpacity
+                    renderType: Text.NativeRendering
                     text: batteryBox.value
                 }
 
@@ -604,6 +614,7 @@ Item {
                     }
                     color: "#ffffffff"
                     opacity: inactiveContentOpacity
+                    renderType: Text.NativeRendering
                     text: "%"
                 }
             }

--- a/src/watchfaces/006-analog-weather-satellite.qml
+++ b/src/watchfaces/006-analog-weather-satellite.qml
@@ -23,9 +23,6 @@ Item {
 
     property string imgPath: "../watchfaces-img/analog-weather-satellite-"
 
-    // Radian per degree used by all canvas arcs
-    property real rad: .01745
-
     // Element sizes, positioning, linewidth and opacity
     property real switchSize: root.width * .1375
     property real boxSize: root.width * .35
@@ -327,42 +324,35 @@ Item {
 
                 property bool weatherSynced: maxTemp.value != 0
 
-                Canvas {
+                Rectangle {
                     id: weatherArc
 
-                    anchors.fill: weatherBox
+                    anchors.centerIn: parent
+                    width: parent.width * .86
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
                     opacity: inactiveArcOpacity
-                    smooth: true
                     visible: !dockMode.active
-                    renderStrategy : Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.lineWidth = outerArcLineWidth
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#33ffffff"
-                        ctx.beginPath()
-                        ctx.arc(weatherBox.width / 2,
-                                weatherBox.height / 2,
-                                weatherBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(weatherBox.width / 2,
-                                weatherBox.height / 2,
-                                weatherBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = boxColor
-                        ctx.lineWidth = innerArcLineWidth
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: outerArcLineWidth
+                        border.color: "#33ffffff"
+                    }
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: innerArcLineWidth
+                        border.color: boxColor
                     }
                 }
 
@@ -415,42 +405,35 @@ Item {
                 width: boxSize
                 height: width
 
-                Canvas {
+                Rectangle {
                     id: dayArc
 
-                    anchors.fill: dayBox
+                    anchors.centerIn: parent
+                    width: parent.width * .86
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
                     opacity: inactiveArcOpacity
-                    smooth: true
                     visible: !dockMode.active
-                    renderStrategy : Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(dayBox.width / 2,
-                                dayBox.height / 2,
-                                dayBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = boxColor
-                        ctx.lineWidth = innerArcLineWidth
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = outerArcLineWidth
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#33ffffff"
-                        ctx.beginPath()
-                        ctx.arc(dayBox.width / 2,
-                                dayBox.height / 2,
-                                dayBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: outerArcLineWidth
+                        border.color: "#33ffffff"
+                    }
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: innerArcLineWidth
+                        border.color: boxColor
                     }
                 }
 
@@ -514,8 +497,6 @@ Item {
 
                 property int value: batteryChargePercentage.percent
 
-                onValueChanged: batteryArc.requestPaint()
-
                 anchors {
                     centerIn: dialBox
                     verticalCenterOffset: boxPosition
@@ -524,46 +505,41 @@ Item {
                 height: width
                 visible: !dockMode.active
 
-                Canvas {
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: parent.width * .86
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
+                    opacity: activeArcOpacity
+                    border.width: innerArcLineWidth
+                    border.color: "#77ffffff"
+                }
+
+                Shape {
                     id: batteryArc
 
-                    anchors.fill: batteryBox
+                    anchors.fill: parent
                     opacity: activeArcOpacity
-                    smooth: true
-                    renderStrategy : Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(batteryBox.width / 2,
-                                batteryBox.height / 2,
-                                batteryBox.width * .43,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = innerArcLineWidth
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = outerArcLineWidth
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = batteryBox.value < 30 ?
-                                    customRed :
-                                    batteryBox.value < 60 ?
-                                        customOrange :
-                                        customGreen
-                        ctx.beginPath()
-                        ctx.arc(batteryBox.width / 2,
-                                batteryBox.height / 2,
-                                batteryBox.width * .43,
-                                270 * rad,
-                                ((batteryBox.value/100*360)+270) * rad,
-                                false
-                                );
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    ShapePath {
+                        fillColor: "transparent"
+                        strokeColor: batteryBox.value < 30 ? customRed : batteryBox.value < 60 ? customOrange : customGreen
+                        strokeWidth: outerArcLineWidth
+                        capStyle: ShapePath.RoundCap
+                        joinStyle: ShapePath.MiterJoin
+                        startX: batteryArc.width / 2
+                        startY: batteryArc.height * (.5 - .43)
+
+                        PathAngleArc {
+                            centerX: batteryBox.width / 2
+                            centerY: batteryBox.height / 2
+                            radiusX: batteryBox.width * .43
+                            radiusY: batteryBox.height * .43
+                            startAngle: -90
+                            sweepAngle: batteryBox.value / 100 * 360
+                            moveToStart: false
+                        }
                     }
                 }
 


### PR DESCRIPTION
Qt6 refactor of the 006-analog-weather-satellite watchface — the most complex face in the stock set. Fixes a render crash, eliminates severe animation stutter, applies text rendering and conventions passes, replaces all remaining Canvas arcs with declarative Qt objects, and runs a qmlformat normalisation pass.

### Commits

1. **Convert license header to SPDX format** — replaces the legacy LGPL block comment with `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` lines. Removes the UTF-8 BOM present at the start of the file.
2. **Fix Qt6 correctness and animation system** — fixes the import capitalisation (`Qt5compat` → `Qt5Compat`), which was the sole reason the face did not render at all on Qt6. Removes the `layer` block from `dockMode`. Fixes `chargecolor` from `property var` to `property int` with `| 0` cast, and `startX`/`startY` in `chargeArc ShapePath` to use `chargeArc.width/height` explicitly. Removes `layer.samples`, `textureSize`, `smooth`, and `antialiasing` from `hourSVG` and `minuteSVG`; converts both layer blocks to inline `layer.effect: DropShadow` only; reduces DropShadow samples to 9. Removes `layer.effect: DropShadow` from `secondSVG` (60fps stutter), removes the `Behavior on angle RotationAnimation` (catch-up on wake), and removes `smooth`/`antialiasing` from the second hand Image. Replaces direct `wallClock.time` rotation bindings on `hourSVG` and `minuteSVG` with imperative `Connections` and `Component.onCompleted`. Fixes the vanilla `hourSVG` rotation ternary, which used a multi-line form that silently evaluated only the first branch in Qt 5.15, meaning the 24h/12h toggle was already broken in vanilla. Adds 16ms Timer for smooth second hand using `new Date()` millisecond precision.
3. **Add Qt6 text rendering properties** — adds `renderType: Text.NativeRendering` to all eleven Text and Label items. Adds `textFormat: Text.StyledText` to `maxDisplay`, which uses `<br>` in its no-weather-data fallback string.
4. **Conventions and cleanup** — imports sorted alphabetically with local JS import last, `Math.min` sizing, dead `batteryPercentChanged` removed, stale inline comments removed, `colorArray` bracket spacing and `startY` parenthesis spacing normalised, `style`/`styleColor` split on `batteryDockPercent`, all `font.styleName` values retained intact (compound variants such as `Condensed Light` are the correct addressing mechanism for Noto Sans width variants).
5. **Replace Canvas arcs with Qt objects** — converts `weatherArc` and `dayArc` from Canvas to nested Rectangles with `radius: width / 2`. Both Canvas items drew full static circles that are direct Rectangle equivalents with zero per-frame cost and no `onPaint` overhead. Converts `batteryArc` from Canvas to a static Rectangle background and a Shape with PathAngleArc progress arc; the declarative `sweepAngle: batteryBox.value / 100 * 360` binding updates automatically on battery change, making the `onValueChanged: batteryArc.requestPaint()` handler redundant — removed. `capStyle: ShapePath.RoundCap` replicates the original `lineCap round` setting. Removes the dead `rad` property.
6. **qmlformat pass** — full `-i` normalisation pass over the file following the Canvas removal.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Qt6 render crash resolved — face loads and displays correctly.
- Normal mode: major performance improvement; second hand animation is smooth without the previous stutter.
- Dock/nightstand mode: battery arc and percentage render correctly, no multisample renderbuffer journal warning.
- Weather sub-dial: displays weather icon and temperature when synced; no-weather fallback renders correctly with `<br>` line breaks.
- Day sub-dial: day name, date, and month name render correctly.
- Battery sub-dial: arc and percentage render correctly; progress arc updates on charge change; charging icon visible when charging.
- 12h/24h toggle: `apDisplay` visibility and `hourSVG` rotation both respond immediately. Toggle was silently broken in Qt5 vanilla due to multi-line ternary; this PR restores correct behaviour.
- AoD: second hand hidden, ambient opacity changes correct.
- No regressions found across all six commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- The `dialBox` layer carries a `layer.effect: DropShadow` applied to the full sub-dial assembly. Text items inside it bind directly to `wallClock.time`, marking the layer dirty every second. This is accepted technical debt for this PR — splitting the static tick ring from the dynamic text content into separate layers would require a larger architectural refactor.
- No visual tuning commit was needed — all text anchoring is item-relative and the face renders visually identically on Qt5 and Qt6.
- All `font.styleName` values are intentionally preserved. Compound variants (`Condensed Light`, `Condensed`) are the correct mechanism for addressing Noto Sans width variants and are visually verified on hardware.