### PR TITLE
Refactor 007-digital-outfit watchface for Qt6

### DIFF
--- a/src/watchfaces/007-digital-outfit.qml
+++ b/src/watchfaces/007-digital-outfit.qml
@@ -33,17 +33,17 @@ Item {
                 property int gap: 6
                 property int endFromStart: 360
                 property bool clockwise: true
-                property real arcStrokeWidth: .05
-                property real scalefactor: .46 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.05
+                property real scalefactor: 0.46 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -52,7 +52,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * (.5 - segmentedArc.scalefactor)
+                        startY: root.height * (0.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2
@@ -63,9 +63,13 @@ Item {
                             sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
+
                     }
+
                 }
+
             }
+
         }
 
         MceBatteryLevel {
@@ -76,94 +80,106 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: root
-            width: root.width * (nightstandMode.active ? .8 : 1)
+            width: root.width * (nightstandMode.active ? 0.8 : 1)
             height: width
             layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: watchfaceRoot.height * .01
-                verticalOffset: watchfaceRoot.height * .01
-                radius: watchfaceRoot.height * .018
-                samples: 9
-                color: "#99000000"
-            }
 
             Text {
                 id: hourDisplay
 
+                renderType: Text.NativeRendering
+                color: "#ffffff"
+                horizontalAlignment: Text.AlignHCenter
+                text: use12H.value ? wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) : wallClock.time.toLocaleString(Qt.locale(), "HH")
+
                 anchors {
                     centerIn: watchfaceRoot
-                    verticalCenterOffset: -watchfaceRoot.height * .218
+                    verticalCenterOffset: -watchfaceRoot.height * 0.218
                 }
-                renderType: Text.NativeRendering
+
                 font {
-                    pixelSize: watchfaceRoot.height * .4
-                    letterSpacing: watchfaceRoot.height * .006
+                    pixelSize: watchfaceRoot.height * 0.4
+                    letterSpacing: watchfaceRoot.height * 0.006
                     family: "Outfit"
                     weight: Font.Medium
                 }
-                color: "#ffffff"
-                horizontalAlignment: Text.AlignHCenter
-                text: use12H.value ?
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) :
-                          wallClock.time.toLocaleString(Qt.locale(), "HH")
+
             }
 
             Text {
                 id: apDisplay
 
-                anchors {
-                    left: hourDisplay.right
-                    leftMargin: watchfaceRoot.height * .01
-                    bottom: watchfaceRoot.verticalCenter
-                    bottomMargin: watchfaceRoot.height * .22
-                }
                 renderType: Text.NativeRendering
                 visible: use12H.value
                 color: "#ddffffff"
-                font {
-                    pixelSize: watchfaceRoot.height * .076
-                    family: "Outfit"
-                    letterSpacing: watchfaceRoot.height * .006
-                }
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
+
+                anchors {
+                    left: hourDisplay.right
+                    leftMargin: watchfaceRoot.height * 0.01
+                    bottom: watchfaceRoot.verticalCenter
+                    bottomMargin: watchfaceRoot.height * 0.22
+                }
+
+                font {
+                    pixelSize: watchfaceRoot.height * 0.076
+                    family: "Outfit"
+                    letterSpacing: watchfaceRoot.height * 0.006
+                }
+
             }
 
             Text {
                 id: monthDisplay
 
                 anchors.centerIn: watchfaceRoot
-
                 renderType: Text.NativeRendering
                 color: "#ddffffff"
                 horizontalAlignment: Text.AlignHCenter
+                text: wallClock.time.toLocaleString(Qt.locale(), "MMM dd").replace(".", "").toUpperCase()
+
                 font {
-                    pixelSize: watchfaceRoot.height * .1
-                    letterSpacing: watchfaceRoot.height * .006
+                    pixelSize: watchfaceRoot.height * 0.1
+                    letterSpacing: watchfaceRoot.height * 0.006
                     family: "Outfit"
                     weight: Font.Light
                 }
-                text: wallClock.time.toLocaleString(Qt.locale(), "MMM dd").replace(".","").toUpperCase()
+
             }
 
             Text {
                 id: minuteDisplay
 
-                anchors {
-                    centerIn: watchfaceRoot
-                    verticalCenterOffset: watchfaceRoot.height * .21
-                }
                 renderType: Text.NativeRendering
                 color: "#ffffff"
                 horizontalAlignment: Text.AlignHCenter
+                text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+                anchors {
+                    centerIn: watchfaceRoot
+                    verticalCenterOffset: watchfaceRoot.height * 0.21
+                }
+
                 font {
-                    pixelSize: watchfaceRoot.height * .4
-                    letterSpacing: watchfaceRoot.height * .006
+                    pixelSize: watchfaceRoot.height * 0.4
+                    letterSpacing: watchfaceRoot.height * 0.006
                     family: "Outfit"
                     weight: Font.Light
                 }
-                text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
             }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: watchfaceRoot.height * 0.01
+                verticalOffset: watchfaceRoot.height * 0.01
+                radius: watchfaceRoot.height * 0.018
+                samples: 9
+                color: "#99000000"
+            }
+
         }
+
     }
+
 }

--- a/src/watchfaces/007-digital-outfit.qml
+++ b/src/watchfaces/007-digital-outfit.qml
@@ -22,16 +22,9 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: root
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Repeater {
                 id: segmentedArc
@@ -44,8 +37,8 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .05
                 property real scalefactor: .46 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
@@ -57,20 +50,19 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }

--- a/src/watchfaces/007-digital-outfit.qml
+++ b/src/watchfaces/007-digital-outfit.qml
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
     anchors.fill: parent
@@ -15,7 +13,7 @@ Item {
         id: root
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Item {
@@ -80,6 +78,15 @@ Item {
             anchors.centerIn: root
             width: root.width * (nightstandMode.active ? .8 : 1)
             height: width
+            layer.enabled: true
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: watchfaceRoot.height * .01
+                verticalOffset: watchfaceRoot.height * .01
+                radius: watchfaceRoot.height * .018
+                samples: 9
+                color: "#99000000"
+            }
 
             Text {
                 id: hourDisplay
@@ -93,7 +100,7 @@ Item {
                     pixelSize: watchfaceRoot.height * .4
                     letterSpacing: watchfaceRoot.height * .006
                     family: "Outfit"
-                    styleName: "Medium"
+                    weight: Font.Medium
                 }
                 color: "#ffffff"
                 horizontalAlignment: Text.AlignHCenter
@@ -117,7 +124,6 @@ Item {
                 font {
                     pixelSize: watchfaceRoot.height * .076
                     family: "Outfit"
-                    styleName: "Regular"
                     letterSpacing: watchfaceRoot.height * .006
                 }
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
@@ -135,7 +141,7 @@ Item {
                     pixelSize: watchfaceRoot.height * .1
                     letterSpacing: watchfaceRoot.height * .006
                     family: "Outfit"
-                    styleName: "Light"
+                    weight: Font.Light
                 }
                 text: wallClock.time.toLocaleString(Qt.locale(), "MMM dd").replace(".","").toUpperCase()
             }
@@ -154,19 +160,9 @@ Item {
                     pixelSize: watchfaceRoot.height * .4
                     letterSpacing: watchfaceRoot.height * .006
                     family: "Outfit"
-                    styleName: "Light"
+                    weight: Font.Light
                 }
                 text: wallClock.time.toLocaleString(Qt.locale(), "mm")
-            }
-
-            layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 4
-                verticalOffset: 4
-                radius: 7.0
-                samples: 15
-                color: "#99000000"
             }
         }
     }

--- a/src/watchfaces/007-digital-outfit.qml
+++ b/src/watchfaces/007-digital-outfit.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes


### PR DESCRIPTION
Qt6 refactor of the 007-digital-outfit watchface — a clean pure-text digital face with no Canvas or animation system. Three focused commits covering SPDX header, Qt6 nightstand and arc correctness, and a conventions pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Updates contributor handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand and arc correctness** — removes the `layer` block from `nightstandMode`. The hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and the `textureSize` supersampling causes visible stutter. Shape antialiases natively without it. Removes the dead `batteryPercentChanged` property from `nightstandMode`; the `segmentedArc` bindings already read `batteryChargePercentage.percent` directly. Adds `| 0` bitwise cast to `chargecolor`; Qt6 rejects implicit double-to-int coercion on array index access. Replaces `parent` references in `ShapePath` and `PathAngleArc` with `root`; inside `ShapePath` and `PathAngleArc` the parent chain resolves to items with no geometry. Collapses the `sweepAngle` ternary to a single line and normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Conventions and formatting** — sorts imports alphabetically per qmlformat CI rule; removes `org.asteroid.controls` and `org.asteroid.utils` which have no references in this file. Replaces the root square sizing ternary with `Math.min`. Converts simple weight-only `font.styleName` values to `font.weight` enum constants; removes `styleName: "Regular"` from `apDisplay` as it is the default. Converts `DropShadow` offset, radius, and samples to screen-relative fractions of `watchfaceRoot.height` so the shadow scales correctly across all watch resolutions.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: hour, minute, date, and am/pm text render correctly in both 12h and 24h modes.
- Nightstand mode: battery arc renders correctly, no multisample renderbuffer journal warning.
- AoD: implicit — watch enters ambient after approximately 10 seconds of inactivity, no regressions observed.
- No visual tuning commit needed — the face renders identically on Qt5 and Qt6. All text anchoring is geometry-relative rather than text-boundary-relative, making it immune to the Qt6 bounding box expansion.
- No regressions found across all three commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- `watchfaceRoot` carries a `layer.enabled: true` with `layer.effect: DropShadow` applied to the full text assembly. This is appropriate — all four text items update at most once per minute and the single compositor pass is cheaper than per-item effects.
- No `textFormat: Text.StyledText` needed — no HTML markup appears in any text binding.