### PR TITLE
Build-time QML pre-compilation via qt_add_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,62 @@ set(HEADERS
 
 add_executable(asteroid-launcher ${SRC} ${HEADERS} resources-qml.qrc)
 
+set(QML_FILES
+	qml/MainScreen.qml
+	qml/today/Today.qml
+	qml/today/weathericons.js
+	qml/compositor/compositor.qml
+	qml/compositor/WindowWrapperBase.qml
+	qml/compositor/CircleMaskShader.qml
+	qml/misc/Splash.qml
+	qml/misc/PanelsGrid.qml
+	qml/misc/ShutdownScreen.qml
+	qml/misc/VolumeControl.qml
+	qml/misc/USBModeSelector.qml
+	qml/misc/ConnectionSelector.qml
+	qml/misc/BluetoothAgent.qml
+	qml/misc/desktop.js
+	qml/notifications/NotificationActions.qml
+	qml/notifications/NotificationButton.qml
+	qml/notifications/NotificationIndicator.qml
+	qml/notifications/NotificationView.qml
+	qml/notifications/NotificationsPanel.qml
+	qml/notifications/NotificationPreview.qml
+	qml/quickpanel/QuickPanel.qml
+	qml/quickpanel/QuickPanelToggle.qml
+	qml/firstrun/FakeAlarmclock.qml
+	qml/firstrun/FirstRunConfig.qml
+	qml/firstrun/Tutorial.qml
+)
+
+set_source_files_properties(qml/MainScreen.qml                       PROPERTIES QT_RESOURCE_ALIAS MainScreen.qml)
+set_source_files_properties(qml/today/Today.qml                      PROPERTIES QT_RESOURCE_ALIAS Today.qml)
+set_source_files_properties(qml/today/weathericons.js                PROPERTIES QT_RESOURCE_ALIAS weathericons.js)
+set_source_files_properties(qml/compositor/compositor.qml            PROPERTIES QT_RESOURCE_ALIAS compositor.qml)
+set_source_files_properties(qml/compositor/WindowWrapperBase.qml     PROPERTIES QT_RESOURCE_ALIAS compositor/WindowWrapperBase.qml)
+set_source_files_properties(qml/compositor/CircleMaskShader.qml      PROPERTIES QT_RESOURCE_ALIAS compositor/CircleMaskShader.qml)
+set_source_files_properties(qml/misc/Splash.qml                      PROPERTIES QT_RESOURCE_ALIAS Splash.qml)
+set_source_files_properties(qml/misc/PanelsGrid.qml                  PROPERTIES QT_RESOURCE_ALIAS PanelsGrid.qml)
+set_source_files_properties(qml/misc/ShutdownScreen.qml              PROPERTIES QT_RESOURCE_ALIAS system/ShutdownScreen.qml)
+set_source_files_properties(qml/misc/VolumeControl.qml               PROPERTIES QT_RESOURCE_ALIAS volumecontrol/VolumeControl.qml)
+set_source_files_properties(qml/misc/USBModeSelector.qml             PROPERTIES QT_RESOURCE_ALIAS connectivity/USBModeSelector.qml)
+set_source_files_properties(qml/misc/ConnectionSelector.qml          PROPERTIES QT_RESOURCE_ALIAS connectivity/ConnectionSelector.qml)
+set_source_files_properties(qml/misc/BluetoothAgent.qml              PROPERTIES QT_RESOURCE_ALIAS connectivity/BluetoothAgent.qml)
+set_source_files_properties(qml/misc/desktop.js                      PROPERTIES QT_RESOURCE_ALIAS desktop.js)
+set_source_files_properties(qml/notifications/NotificationActions.qml   PROPERTIES QT_RESOURCE_ALIAS NotificationActions.qml)
+set_source_files_properties(qml/notifications/NotificationButton.qml    PROPERTIES QT_RESOURCE_ALIAS NotificationButton.qml)
+set_source_files_properties(qml/notifications/NotificationIndicator.qml PROPERTIES QT_RESOURCE_ALIAS NotificationIndicator.qml)
+set_source_files_properties(qml/notifications/NotificationView.qml      PROPERTIES QT_RESOURCE_ALIAS NotificationView.qml)
+set_source_files_properties(qml/notifications/NotificationsPanel.qml    PROPERTIES QT_RESOURCE_ALIAS NotificationsPanel.qml)
+set_source_files_properties(qml/notifications/NotificationPreview.qml   PROPERTIES QT_RESOURCE_ALIAS notifications/NotificationPreview.qml)
+set_source_files_properties(qml/quickpanel/QuickPanel.qml            PROPERTIES QT_RESOURCE_ALIAS QuickPanel.qml)
+set_source_files_properties(qml/quickpanel/QuickPanelToggle.qml      PROPERTIES QT_RESOURCE_ALIAS QuickPanelToggle.qml)
+set_source_files_properties(qml/firstrun/FakeAlarmclock.qml          PROPERTIES QT_RESOURCE_ALIAS FakeAlarmclock.qml)
+set_source_files_properties(qml/firstrun/FirstRunConfig.qml          PROPERTIES QT_RESOURCE_ALIAS FirstRunConfig.qml)
+set_source_files_properties(qml/firstrun/Tutorial.qml                PROPERTIES QT_RESOURCE_ALIAS Tutorial.qml)
+
+asteroid_app_qml_module(asteroid-launcher ${QML_FILES})
+
 qt_add_shaders(
     asteroid-launcher "asteroid-launcher_shaders"
     FILES "qml/compositor/circlemaskshader.frag"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@
 
 int main(int argc, char **argv)
 {
-    QmlPath::append(":/qml/");
+    QmlPath::append(":/Launcher/");
     HomeApplication app(argc, argv, QString());
 
     FirstRun *firstRun = new FirstRun();
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
     QObject::connect(app.localeManager(), SIGNAL(localeChanged()), launcherLocaleManager, SLOT(onLocaleChanged()));
 
     QGuiApplication::setFont(QFont("Noto Sans"));
-    app.setCompositorPath("qrc:/qml/compositor.qml");
+    app.setCompositorPath("qrc:/Launcher/compositor.qml");
     Qt::ScreenOrientation nativeOrientation = app.primaryScreen()->nativeOrientation();
     QByteArray v = qgetenv("LAUNCHER_NATIVEORIENTATION");
     if (!v.isEmpty()) {
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
     qmlRegisterType<GestureFilterArea>("org.asteroid.launcher", 1, 0, "GestureFilterArea");
     qmlRegisterType<NotificationSnoozer>("org.asteroid.launcher", 1, 0, "NotificationSnoozer");
     qmlRegisterType<AppLauncher>("org.asteroid.launcher", 1, 0, "AppLauncher");
-    app.setQmlPath("qrc:/qml/MainScreen.qml");
+    app.setQmlPath("qrc:/Launcher/MainScreen.qml");
 
     // Give these to the environment inside the lipstick homescreen
     // Fixes a bug where some applications wouldn't launch, eg. terminal or browser

--- a/src/qml/firstrun/FakeAlarmclock.qml
+++ b/src/qml/firstrun/FakeAlarmclock.qml
@@ -31,7 +31,7 @@ import QtQml
 import QtQuick
 import org.asteroid.controls
 import org.asteroid.utils
-import "qrc:/qml/compositor/";
+import "qrc:/Launcher/compositor/";
 import Nemo.Time
 import Nemo.Configuration
 

--- a/src/resources-qml.qrc
+++ b/src/resources-qml.qrc
@@ -2,31 +2,4 @@
     <qresource prefix="/">
         <file>images/bootlogo.svg</file>
     </qresource>
-    <qresource prefix="/qml/">
-        <file alias="MainScreen.qml">qml/MainScreen.qml</file>
-        <file alias="Today.qml">qml/today/Today.qml</file>
-        <file alias="compositor.qml">qml/compositor/compositor.qml</file>
-        <file alias="Splash.qml">qml/misc/Splash.qml</file>
-        <file alias="PanelsGrid.qml">qml/misc/PanelsGrid.qml</file>
-        <file alias="NotificationActions.qml">qml/notifications/NotificationActions.qml</file>
-        <file alias="NotificationButton.qml">qml/notifications/NotificationButton.qml</file>
-        <file alias="NotificationIndicator.qml">qml/notifications/NotificationIndicator.qml</file>
-        <file alias="NotificationView.qml">qml/notifications/NotificationView.qml</file>
-        <file alias="NotificationsPanel.qml">qml/notifications/NotificationsPanel.qml</file>
-        <file alias="QuickPanel.qml">qml/quickpanel/QuickPanel.qml</file>
-        <file alias="QuickPanelToggle.qml">qml/quickpanel/QuickPanelToggle.qml</file>
-        <file alias="FakeAlarmclock.qml">qml/firstrun/FakeAlarmclock.qml</file>
-        <file alias="FirstRunConfig.qml">qml/firstrun/FirstRunConfig.qml</file>
-        <file alias="Tutorial.qml">qml/firstrun/Tutorial.qml</file>
-        <file alias="desktop.js">qml/misc/desktop.js</file>
-        <file alias="weathericons.js">qml/today/weathericons.js</file>
-        <file alias="compositor/WindowWrapperBase.qml">qml/compositor/WindowWrapperBase.qml</file>
-        <file alias="compositor/CircleMaskShader.qml">qml/compositor/CircleMaskShader.qml</file>
-        <file alias="system/ShutdownScreen.qml">qml/misc/ShutdownScreen.qml</file>
-        <file alias="volumecontrol/VolumeControl.qml">qml/misc/VolumeControl.qml</file>
-        <file alias="connectivity/USBModeSelector.qml">qml/misc/USBModeSelector.qml</file>
-        <file alias="connectivity/ConnectionSelector.qml">qml/misc/ConnectionSelector.qml</file>
-        <file alias="connectivity/BluetoothAgent.qml">qml/misc/BluetoothAgent.qml</file>
-        <file alias="notifications/NotificationPreview.qml">qml/notifications/NotificationPreview.qml</file>
-    </qresource>
 </RCC>


### PR DESCRIPTION
The launcher's QML ships as pre-compiled bytecode and the engine skips the parse/JIT pipeline on every launch.