### PR TITLE
Refactor 008-numerals-duo-synth-neon-green watchface for Qt6

### DIFF
--- a/src/watchfaces/008-numerals-duo-synth-neon-green.qml
+++ b/src/watchfaces/008-numerals-duo-synth-neon-green.qml
@@ -10,27 +10,24 @@
 import QtQuick
 import QtQuick.Shapes
 import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
 import org.asteroid.utils
 import Nemo.Mce
 
 Item {
     anchors.fill: parent
 
-    property int length: width > height ? height : width
     property string imgPath: "../watchfaces-img/numerals-duo-synth-neon-green-"
 
     Item {
         id: root
 
         anchors.centerIn: parent
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Text {
             id: dowDisplay
 
-            z: 0
             visible: !displayAmbient
             font {
                 pixelSize: root.height * 0.054
@@ -53,7 +50,7 @@ Item {
                 transparentBorder: true
                 horizontalOffset: 0
                 verticalOffset: 3
-                radius: 12.0
+                radius: 12
                 samples: 16
                 color: "#fe16a2"
             }
@@ -62,7 +59,6 @@ Item {
         Text {
             id: dateDisplay
 
-            z: 0
             visible: !displayAmbient
             font {
                 pixelSize: root.height * 0.056
@@ -84,17 +80,17 @@ Item {
                 transparentBorder: true
                 horizontalOffset: 0
                 verticalOffset: -3
-                radius: 12.0
+                radius: 12
                 samples: 16
                 color: "#fe16a2"
             }
         }
 
         Item {
-            x: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.width != length ? root.width/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
-            y: DeviceSpecs.hasRoundScreen ? length * 0.1 : (root.height != length ? root.height/2 - length/2 : !displayAmbient ? length * 0.1 : 0)
-            width: DeviceSpecs.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
-            height: DeviceSpecs.hasRoundScreen ? length * 0.8 : displayAmbient ? length : length * 0.8
+            x: DeviceSpecs.hasRoundScreen ? root.height * 0.1 : (!displayAmbient ? root.height * 0.1 : 0)
+            y: DeviceSpecs.hasRoundScreen ? root.height * 0.1 : (!displayAmbient ? root.height * 0.1 : 0)
+            width: DeviceSpecs.hasRoundScreen ? root.height * 0.8 : (displayAmbient ? root.height : root.height * 0.8)
+            height: DeviceSpecs.hasRoundScreen ? root.height * 0.8 : (displayAmbient ? root.height : root.height * 0.8)
             Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             Behavior on y { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
             Behavior on width { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
@@ -103,7 +99,6 @@ Item {
             LinearGradient {
                 id: greenColor
                 anchors.fill: parent
-                smooth: true
                 visible: false
                 start: Qt.point(0, 0)
                 end: Qt.point(300, 300)
@@ -116,7 +111,6 @@ Item {
             LinearGradient {
                 id: whiteColor
                 anchors.fill: parent
-                smooth: true
                 visible: false
                 start: Qt.point(0, 0)
                 end: Qt.point(300, 300)
@@ -126,46 +120,45 @@ Item {
                 }
             }
 
-           Image {
-               id: topLeft
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width*0.135)
-               y: parseInt(parent.height*0.045)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(0, 1) + ".png"
-           }
-           Image {
-               id: topRight
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width/2 + parent.width*0.03)
-               y: parseInt(parent.height*0.045)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(1, 2) + ".png"
-           }
-           Image {
-               id: bottomLeft
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width*0.135)
-               y: parseInt(parent.height/2 + parent.height*0.025)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(0, 1) + ".png"
-           }
-           Image {
-               id: bottomRight
-               visible: false
-               smooth: true
-               fillMode: Image.PreserveAspectFit
-               x: parseInt(parent.width/2 + parent.width*0.03)
-               y: parseInt(parent.height/2 + parent.height*0.025)
-               sourceSize: Qt.size(parent.width/2 - parent.width*0.15, parent.height/2 - parent.height*0.15)
-               source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(1, 2) + ".png"
-           }
+            Image {
+                id: topLeft
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width * 0.135)
+                y: parseInt(parent.height * 0.045)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(0, 1) + ".png"
+            }
+
+            Image {
+                id: topRight
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width / 2 + parent.width * 0.03)
+                y: parseInt(parent.height * 0.045)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "HH").slice(1, 2) + ".png"
+            }
+
+            Image {
+                id: bottomLeft
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width * 0.135)
+                y: parseInt(parent.height / 2 + parent.height * 0.025)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(0, 1) + ".png"
+            }
+
+            Image {
+                id: bottomRight
+                visible: false
+                fillMode: Image.PreserveAspectFit
+                x: parseInt(parent.width / 2 + parent.width * 0.03)
+                y: parseInt(parent.height / 2 + parent.height * 0.025)
+                sourceSize: Qt.size(parent.width / 2 - parent.width * 0.15, parent.height / 2 - parent.height * 0.15)
+                source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "mm").slice(1, 2) + ".png"
+            }
 
             OpacityMask {
                 invert: true
@@ -177,11 +170,12 @@ Item {
                     transparentBorder: true
                     horizontalOffset: 1
                     verticalOffset: 1
-                    radius: 12.0
+                    radius: 12
                     samples: 20
                     color: "#f800ff"
                 }
             }
+
             OpacityMask {
                 invert: true
                 anchors.fill: topRight
@@ -192,11 +186,12 @@ Item {
                     transparentBorder: true
                     horizontalOffset: -1
                     verticalOffset: 1
-                    radius: 12.0
+                    radius: 12
                     samples: 20
                     color: "#f800ff"
                 }
             }
+
             OpacityMask {
                 invert: true
                 anchors.fill: bottomLeft
@@ -207,11 +202,12 @@ Item {
                     transparentBorder: true
                     horizontalOffset: -1
                     verticalOffset: -1
-                    radius: 12.0
+                    radius: 12
                     samples: 20
                     color: "#9600ff"
                 }
             }
+
             OpacityMask {
                 invert: true
                 anchors.fill: bottomRight
@@ -222,7 +218,7 @@ Item {
                     transparentBorder: true
                     horizontalOffset: 1
                     verticalOffset: -1
-                    radius: 12.0
+                    radius: 12
                     samples: 20
                     color: "#9600ff"
                 }

--- a/src/watchfaces/008-numerals-duo-synth-neon-green.qml
+++ b/src/watchfaces/008-numerals-duo-synth-neon-green.qml
@@ -35,9 +35,10 @@ Item {
             font {
                 pixelSize: root.height * 0.054
                 family: "Sunflower"
-                styleName: "Light"
-                letterSpacing: root.height*0.003
+                weight: Font.Light
+                letterSpacing: root.height * 0.003
             }
+            renderType: Text.NativeRendering
             color: "white"
             opacity: 0.95
             horizontalAlignment: Text.AlignHCenter
@@ -66,8 +67,9 @@ Item {
             font {
                 pixelSize: root.height * 0.056
                 family: "Sunflower"
-                styleName: "Light"
+                weight: Font.Light
             }
+            renderType: Text.NativeRendering
             color: "white"
             opacity: 0.95
             horizontalAlignment: Text.AlignHCenter

--- a/src/watchfaces/008-numerals-duo-synth-neon-green.qml
+++ b/src/watchfaces/008-numerals-duo-synth-neon-green.qml
@@ -1,26 +1,11 @@
-/*
-* Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
-*               2021 - Darrel Griët <dgriet@gmail.com>
-*               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
-*               2015 - Florent Revest <revestflo@gmail.com>
-*               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
-*                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
-*                      Arto Jalkanen <ajalkane@gmail.com>
-* All rights reserved.
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Lesser General Public License as
-* published by the Free Software Foundation, either version 2.1 of the
-* License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2021 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/008-numerals-duo-synth-neon-green.qml
+++ b/src/watchfaces/008-numerals-duo-synth-neon-green.qml
@@ -10,13 +10,13 @@
 import QtQuick
 import QtQuick.Shapes
 import Qt5Compat.GraphicalEffects
-import org.asteroid.utils
 import Nemo.Mce
+import org.asteroid.utils
 
 Item {
-    anchors.fill: parent
-
     property string imgPath: "../watchfaces-img/numerals-duo-synth-neon-green-"
+
+    anchors.fill: parent
 
     Item {
         id: root
@@ -29,23 +29,26 @@ Item {
             id: dowDisplay
 
             visible: !displayAmbient
+            renderType: Text.NativeRendering
+            color: "white"
+            opacity: 0.95
+            horizontalAlignment: Text.AlignHCenter
+            text: wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
+            layer.enabled: true
+
             font {
                 pixelSize: root.height * 0.054
                 family: "Sunflower"
                 weight: Font.Light
                 letterSpacing: root.height * 0.003
             }
-            renderType: Text.NativeRendering
-            color: "white"
-            opacity: 0.95
-            horizontalAlignment: Text.AlignHCenter
+
             anchors {
                 bottom: root.verticalCenter
-                bottomMargin: DeviceSpecs.hasRoundScreen ? root.height*0.387 : root.height*0.402
+                bottomMargin: DeviceSpecs.hasRoundScreen ? root.height * 0.387 : root.height * 0.402
                 horizontalCenter: root.horizontalCenter
             }
-            text: wallClock.time.toLocaleString(Qt.locale(), "dddd").toUpperCase()
-            layer.enabled: true
+
             layer.effect: DropShadow {
                 transparentBorder: true
                 horizontalOffset: 0
@@ -54,28 +57,32 @@ Item {
                 samples: 16
                 color: "#fe16a2"
             }
+
         }
 
         Text {
             id: dateDisplay
 
             visible: !displayAmbient
+            renderType: Text.NativeRendering
+            color: "white"
+            opacity: 0.95
+            horizontalAlignment: Text.AlignHCenter
+            text: wallClock.time.toLocaleString(Qt.locale(), "yyyy-MM-dd")
+            layer.enabled: true
+
             font {
                 pixelSize: root.height * 0.056
                 family: "Sunflower"
                 weight: Font.Light
             }
-            renderType: Text.NativeRendering
-            color: "white"
-            opacity: 0.95
-            horizontalAlignment: Text.AlignHCenter
+
             anchors {
                 top: root.verticalCenter
-                topMargin: DeviceSpecs.hasRoundScreen ? root.height*0.394 : root.height*0.406
+                topMargin: DeviceSpecs.hasRoundScreen ? root.height * 0.394 : root.height * 0.406
                 horizontalCenter: root.horizontalCenter
             }
-            text: wallClock.time.toLocaleString(Qt.locale(), "yyyy-MM-dd")
-            layer.enabled: true
+
             layer.effect: DropShadow {
                 transparentBorder: true
                 horizontalOffset: 0
@@ -84,6 +91,7 @@ Item {
                 samples: 16
                 color: "#fe16a2"
             }
+
         }
 
         Item {
@@ -91,37 +99,56 @@ Item {
             y: DeviceSpecs.hasRoundScreen ? root.height * 0.1 : (!displayAmbient ? root.height * 0.1 : 0)
             width: DeviceSpecs.hasRoundScreen ? root.height * 0.8 : (displayAmbient ? root.height : root.height * 0.8)
             height: DeviceSpecs.hasRoundScreen ? root.height * 0.8 : (displayAmbient ? root.height : root.height * 0.8)
-            Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
-            Behavior on y { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
-            Behavior on width { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
-            Behavior on height { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
 
             LinearGradient {
                 id: greenColor
+
                 anchors.fill: parent
                 visible: false
                 start: Qt.point(0, 0)
                 end: Qt.point(300, 300)
+
                 gradient: Gradient {
-                    GradientStop { position: 0.0; color: "#38FF12" }
-                    GradientStop { position: 1.0; color: "#00F5FB" }
+                    GradientStop {
+                        position: 0
+                        color: "#38FF12"
+                    }
+
+                    GradientStop {
+                        position: 1
+                        color: "#00F5FB"
+                    }
+
                 }
+
             }
 
             LinearGradient {
                 id: whiteColor
+
                 anchors.fill: parent
                 visible: false
                 start: Qt.point(0, 0)
                 end: Qt.point(300, 300)
+
                 gradient: Gradient {
-                    GradientStop { position: 0.0; color: "#FFF100" }
-                    GradientStop { position: 1.0; color: "#FFFFFF" }
+                    GradientStop {
+                        position: 0
+                        color: "#FFF100"
+                    }
+
+                    GradientStop {
+                        position: 1
+                        color: "#FFFFFF"
+                    }
+
                 }
+
             }
 
             Image {
                 id: topLeft
+
                 visible: false
                 fillMode: Image.PreserveAspectFit
                 x: parseInt(parent.width * 0.135)
@@ -132,6 +159,7 @@ Item {
 
             Image {
                 id: topRight
+
                 visible: false
                 fillMode: Image.PreserveAspectFit
                 x: parseInt(parent.width / 2 + parent.width * 0.03)
@@ -142,6 +170,7 @@ Item {
 
             Image {
                 id: bottomLeft
+
                 visible: false
                 fillMode: Image.PreserveAspectFit
                 x: parseInt(parent.width * 0.135)
@@ -152,6 +181,7 @@ Item {
 
             Image {
                 id: bottomRight
+
                 visible: false
                 fillMode: Image.PreserveAspectFit
                 x: parseInt(parent.width / 2 + parent.width * 0.03)
@@ -166,6 +196,7 @@ Item {
                 source: greenColor
                 maskSource: topLeft
                 layer.enabled: true
+
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: 1
@@ -174,6 +205,7 @@ Item {
                     samples: 20
                     color: "#f800ff"
                 }
+
             }
 
             OpacityMask {
@@ -182,6 +214,7 @@ Item {
                 source: greenColor
                 maskSource: topRight
                 layer.enabled: true
+
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: -1
@@ -190,6 +223,7 @@ Item {
                     samples: 20
                     color: "#f800ff"
                 }
+
             }
 
             OpacityMask {
@@ -198,6 +232,7 @@ Item {
                 source: whiteColor
                 maskSource: bottomLeft
                 layer.enabled: true
+
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: -1
@@ -206,6 +241,7 @@ Item {
                     samples: 20
                     color: "#9600ff"
                 }
+
             }
 
             OpacityMask {
@@ -214,6 +250,7 @@ Item {
                 source: whiteColor
                 maskSource: bottomRight
                 layer.enabled: true
+
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: 1
@@ -222,7 +259,43 @@ Item {
                     samples: 20
                     color: "#9600ff"
                 }
+
             }
+
+            Behavior on x {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.OutQuad
+                }
+
+            }
+
+            Behavior on y {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.OutQuad
+                }
+
+            }
+
+            Behavior on width {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.OutQuad
+                }
+
+            }
+
+            Behavior on height {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.OutQuad
+                }
+
+            }
+
         }
+
     }
+
 }


### PR DESCRIPTION
Qt6 refactor of the 008-numerals-duo-synth-neon-green watchface. Four commits covering SPDX header, text rendering, conventions, and a qmlformat pass with one confirmed import order exception.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Seven authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Add Qt6 text rendering properties** — adds `renderType: Text.NativeRendering` to `dowDisplay` and `dateDisplay`. Converts `font.styleName: "Light"` to `font.weight: Font.Light` on both text items per project convention.

3. **Conventions and formatting** — removes `org.asteroid.controls` which has no references in this file. Import order intentionally kept with `QtQuick` before `Qt5Compat.GraphicalEffects`; alphabetical reordering causes a runtime load failure on Qt6 when `OpacityMask` and `LinearGradient` are used together — confirmed exception to the qmlformat alpha-sort rule. Removes the outer `length` property; it computed `Math.min(width, height)` on the screen-filling Item, equivalent to `root.height` on the already-square inner Item, with all references replaced accordingly and the now-always-false rectangular-screen centering branches collapsed. Replaces root square sizing ternary with `Math.min`. Removes `z: 0` from both text items (default value). Removes `smooth: true` from both `LinearGradient` items and all four `Image` items where it has no effect. Normalises `radius: 12.0` to `radius: 12` across all six `DropShadow` blocks.

4. **qmlformat pass** — full `-i` normalisation pass with import order manually restored afterward. Alphabetical reordering by qmlformat breaks runtime loading in this file; see commit 3 note.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: all four numeral glyphs render with correct neon gradient fill and glow shadows. Day-of-week and date text render correctly.
- Ambient mode: numeral container expands to fill the square with the `Behavior` transitions intact. Day and date text correctly hidden.
- AoD: implicit — no regressions observed.
- Import order confirmed: reordering to strict alphabetical breaks the watchface at load on Qt6; working order retained and documented.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- `DropShadow` radius and samples on all six glow effects are intentionally preserved at design values. The coloured neon glow is the entire visual identity of this watchface; reducing radius or samples would alter the appearance MagneFire designed.
- `QtQuick` must precede `Qt5Compat.GraphicalEffects` in this file. This is a Qt6 module resolution constraint when `OpacityMask` and `LinearGradient` from `Qt5Compat.GraphicalEffects` are used together. qmlformat reorders this incorrectly and produces a broken file; the import order is restored manually after each formatter run. This may be worth a bug report upstream to Qt.