### PR TITLE
Refactor 009-analog-scientific-v2 watchface for Qt6

### DIFF
--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -1,25 +1,10 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -37,13 +37,12 @@ Item {
             anchors.fill: root
 
             layer.enabled: true
-            layer.samples: 2
             layer.effect: DropShadow {
                 transparentBorder: true
-                horizontalOffset: 2
-                verticalOffset: 2
-                radius: 5.0
-                samples: 11
+                horizontalOffset: root.width * .005
+                verticalOffset: root.width * .005
+                radius: root.width * .013
+                samples: 9
                 color: "#99000000"
             }
 
@@ -540,35 +539,23 @@ Item {
 
                 anchors.centerIn: handBox
                 source: imgPath + (displayAmbient ? "hour-bw.svg" : "hour.svg")
-                antialiasing: true
                 width: handBox.width
                 height: handBox.height
                 transform: Rotation {
+                    id: hourRotation
+
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: hourSVG.toggle24h ?
-                               (wallClock.time.getHours() * 15) + (wallClock.time.getMinutes() * .25) :
-                               (wallClock.time.getHours() * 30) + (wallClock.time.getMinutes() * .5)
-                    Behavior on angle {
-                        RotationAnimation {
-                            duration: 500
-                            direction: RotationAnimation.Clockwise
-                            easing.type: Easing.InOutQuad
-                        }
-                    }
+                    angle: 0
                 }
-                layer {
-                    enabled: true
-                    samples: 2
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 4
-                        verticalOffset: 4
-                        radius: 7.0
-                        samples: 15
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: root.width * .01
+                    verticalOffset: root.width * .01
+                    radius: root.width * .018
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
@@ -577,32 +564,23 @@ Item {
 
                 anchors.centerIn: handBox
                 source: imgPath + (displayAmbient ? "minute-bw.svg" : "minute.svg")
-                antialiasing: true
                 width: handBox.width
                 height: handBox.height
                 transform: Rotation {
+                    id: minuteRotation
+
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getMinutes() * 6) + (wallClock.time.getSeconds() * 6 / 60)
-                    Behavior on angle {
-                        RotationAnimation {
-                            duration: 1000
-                            direction: RotationAnimation.Clockwise
-                        }
-                    }
+                    angle: 0
                 }
-                layer {
-                    enabled: true
-                    samples: 2
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 5
-                        verticalOffset: 5
-                        radius: 9.0
-                        samples: 19
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                layer.enabled: true
+                layer.effect: DropShadow {
+                    transparentBorder: true
+                    horizontalOffset: root.width * .012
+                    verticalOffset: root.width * .012
+                    radius: root.width * .022
+                    samples: 9
+                    color: Qt.rgba(0, 0, 0, .2)
                 }
             }
 
@@ -611,30 +589,50 @@ Item {
 
                 anchors.centerIn: handBox
                 source: imgPath + "second.svg"
-                antialiasing: true
                 visible: !displayAmbient
                 width: handBox.width
                 height: handBox.height
                 transform: Rotation {
+                    id: secondRotation
+
                     origin.x: handBox.width / 2
                     origin.y: handBox.height / 2
-                    angle: (wallClock.time.getSeconds() * 6)
-                }
-                layer {
-                    enabled: true
-                    samples: 2
-                    textureSize: Qt.size(root.width * 2, root.height * 2)
-                    effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 7
-                        verticalOffset: 7
-                        radius: 10.0
-                        samples: 21
-                        color: Qt.rgba(0, 0, 0, .2)
-                    }
+                    angle: 0
                 }
             }
+            
+            Connections {
+                function onTimeChanged() {
+                    var hours = wallClock.time.getHours()
+                    var minutes = wallClock.time.getMinutes()
+                    hourRotation.angle = use12H.value ?
+                        (hours % 12 * 30) + (minutes * .5) :
+                        (hours * 15) + (minutes * .25)
+                    minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
+                }
+                target: wallClock
+            }
+
+            Timer {
+                interval: 16
+                repeat: true
+                running: !displayAmbient && visible
+                onTriggered: {
+                    var now = new Date()
+                    secondRotation.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+                }
+            }
+
+            Component.onCompleted: {
+                var hours = wallClock.time.getHours()
+                var minutes = wallClock.time.getMinutes()
+                hourRotation.angle = use12H.value ?
+                    (hours % 12 * 30) + (minutes * .5) :
+                    (hours * 15) + (minutes * .25)
+                minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
+            }
         }
+        
         Item {
             id: nightstandMode
 

--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -641,13 +641,6 @@ Item {
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
             visible: nightstandMode.active
 
             Repeater {
@@ -661,8 +654,8 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .016
                 property real scalefactor: .50 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
@@ -674,20 +667,19 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }

--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -6,15 +6,15 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Mce
 import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Nemo.Mce
 
 Item {
-    anchors.fill: parent
-
     property string imgPath: "../watchfaces-img/analog-scientific-v2-"
+
+    anchors.fill: parent
 
     MceBatteryLevel {
         id: batteryChargePercentage
@@ -24,7 +24,6 @@ Item {
         id: root
 
         anchors.centerIn: parent
-
         height: Math.min(parent.width, parent.height)
         width: height
 
@@ -32,16 +31,7 @@ Item {
             id: dialBox
 
             anchors.fill: root
-
             layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: root.width * .005
-                verticalOffset: root.width * .005
-                radius: root.width * .013
-                samples: 9
-                color: "#99000000"
-            }
 
             Repeater {
                 model: 60
@@ -53,20 +43,21 @@ Item {
                     property real centerX: root.width / 2 - width / 2
                     property real centerY: root.height / 2 - height / 2
 
-                    x: index % 5 ? centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * .488 :
-                                   centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * .480
-                    y: index % 5 ? centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * .488 :
-                                   centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * .480
-                    antialiasing : true
+                    x: index % 5 ? centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.488 : centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
+                    y: index % 5 ? centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.488 : centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
+                    antialiasing: true
                     color: index % 5 ? "#77ffffff" : "#ffffffff"
-                    width: index % 5 ? parent.width * .0066 : parent.width * .009
-                    height: index % 5 ? parent.height * .026 : parent.height * .038
+                    width: index % 5 ? parent.width * 0.0066 : parent.width * 0.009
+                    height: index % 5 ? parent.height * 0.026 : parent.height * 0.038
+
                     transform: Rotation {
                         origin.x: width / 2
                         origin.y: height / 2
                         angle: (index) * 6
                     }
+
                 }
+
             }
 
             Repeater {
@@ -75,29 +66,24 @@ Item {
                 Text {
                     id: hourNumbers
 
-                    property real rotM: ((index * 5 ) - 15) / 60
+                    property real rotM: ((index * 5) - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
                     property real centerY: parent.height / 2 - height / 2
 
-                    x: index === 10 ?
-                           centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .378 :
-                           index === 11 ?
-                               centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .388 :
-                               centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .4
-                    y: index === 10 ?
-                           centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .378 :
-                           index === 11 ?
-                               centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .388 :
-                               centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .4
-                    font {
-                        pixelSize: parent.height * .088
-                        family: "Outfit"
-                    }
+                    x: index === 10 ? centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.378 : index === 11 ? centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.388 : centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.4
+                    y: index === 10 ? centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.378 : index === 11 ? centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.388 : centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.4
                     renderType: Text.NativeRendering
                     horizontalAlignment: Text.AlignHCenter
                     color: "#ffffffff"
                     text: index === 0 ? "12" : index
+
+                    font {
+                        pixelSize: parent.height * 0.088
+                        family: "Outfit"
+                    }
+
                 }
+
             }
 
             Image {
@@ -106,98 +92,114 @@ Item {
                 visible: !displayAmbient
                 source: "../watchfaces-img/asteroid-logo.svg"
                 antialiasing: true
+                width: parent.width * 0.12
+                height: parent.height * 0.12
+                opacity: 0.7
+
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: -parent.height * .272
+                    verticalCenterOffset: -parent.height * 0.272
                 }
-                width: parent.width * .12
-                height: parent.height * .12
-                opacity: .7
 
                 Text {
                     id: asteroidSlogan
 
-                    anchors {
-                        centerIn: parent
-                        verticalCenterOffset: -parent.height * .005
-                    }
-                    font {
-                        pixelSize: parent.height * .31
-                        family: "Raleway"
-                    }
                     renderType: Text.NativeRendering
                     visible: !displayAmbient
                     color: "white"
                     horizontalAlignment: Text.AlignHCenter
                     textFormat: Text.StyledText
                     text: "<b>AsteroidOS</b><br>Free Your Wrist"
+
+                    anchors {
+                        centerIn: parent
+                        verticalCenterOffset: -parent.height * 0.005
+                    }
+
+                    font {
+                        pixelSize: parent.height * 0.31
+                        family: "Raleway"
+                    }
+
                 }
+
                 MouseArea {
                     anchors.fill: parent
-                    onPressAndHold: asteroidLogo.visible ?
-                                        asteroidLogo.visible = false :
-                                        asteroidLogo.visible = true
+                    onPressAndHold: asteroidLogo.visible ? asteroidLogo.visible = false : asteroidLogo.visible = true
                 }
+
             }
 
             Text {
                 id: digitalDisplay
 
-                anchors {
-                    right: parent.horizontalCenter
-                    rightMargin: parent.width * .004
-                    verticalCenter: parent.verticalCenter
-                    verticalCenterOffset: -parent.width * .124
-                }
-                font {
-                    pixelSize: parent.height * .15
-                    family: "Open Sans"
-                    letterSpacing: -parent.width * .001
-                }
                 renderType: Text.NativeRendering
                 color: "#bbffffff"
-                text: if (use12H.value) {
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2)}
-                      else
-                          wallClock.time.toLocaleString(Qt.locale(), "HH")
+                text: {
+                    if (use12H.value) {
+                        wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
+                    } else {
+                        wallClock.time.toLocaleString(Qt.locale(), "HH");
+                    }
+                }
+
+                anchors {
+                    right: parent.horizontalCenter
+                    rightMargin: parent.width * 0.004
+                    verticalCenter: parent.verticalCenter
+                    verticalCenterOffset: -parent.width * 0.124
+                }
+
+                font {
+                    pixelSize: parent.height * 0.15
+                    family: "Open Sans"
+                    letterSpacing: -parent.width * 0.001
+                }
+
             }
 
             Text {
                 id: digitalMinutes
 
-                anchors {
-                    left: digitalDisplay.right
-                    bottom: digitalDisplay.bottom
-                    leftMargin: root.width * .004
-                }
-                font {
-                    pixelSize: root.height * .15
-                    family: "Open Sans"
-                    weight: Font.Light
-                    letterSpacing: -parent.width * .001
-                }
                 renderType: Text.NativeRendering
                 color: "#ccffffff"
                 text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+                anchors {
+                    left: digitalDisplay.right
+                    bottom: digitalDisplay.bottom
+                    leftMargin: root.width * 0.004
+                }
+
+                font {
+                    pixelSize: root.height * 0.15
+                    family: "Open Sans"
+                    weight: Font.Light
+                    letterSpacing: -parent.width * 0.001
+                }
+
             }
 
             Text {
                 id: apDisplay
 
-                anchors {
-                    left: digitalMinutes.right
-                    leftMargin: parent.width * .014
-                    bottom: digitalMinutes.verticalCenter
-                    bottomMargin: -parent.width * .012
-                }
-                font {
-                    pixelSize: root.height * .06
-                    family: "Open Sans Condensed"
-                }
                 renderType: Text.NativeRendering
                 visible: use12H.value
                 color: "#ddffffff"
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
+
+                anchors {
+                    left: digitalMinutes.right
+                    leftMargin: parent.width * 0.014
+                    bottom: digitalMinutes.verticalCenter
+                    bottomMargin: -parent.width * 0.012
+                }
+
+                font {
+                    pixelSize: root.height * 0.06
+                    family: "Open Sans Condensed"
+                }
+
             }
 
             Item {
@@ -205,23 +207,24 @@ Item {
 
                 property int currentDayOfWeek: wallClock.time.getDay()
 
+                width: parent.width * 0.22
+                height: parent.height * 0.22
+
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: parent.width * .06
-                    horizontalCenterOffset: -parent.width * .23
+                    verticalCenterOffset: parent.width * 0.06
+                    horizontalCenterOffset: -parent.width * 0.23
                 }
-                width: parent.width * .22
-                height: parent.height * .22
 
                 Rectangle {
                     id: dayArc
 
                     anchors.centerIn: parent
-                    width: parent.width * .9
+                    width: parent.width * 0.9
                     height: width
                     radius: width / 2
                     color: "#22ffffff"
-                    opacity: !displayAmbient ? 1 : .3
+                    opacity: !displayAmbient ? 1 : 0.3
 
                     Rectangle {
                         anchors.centerIn: parent
@@ -229,33 +232,36 @@ Item {
                         height: width
                         radius: width / 2
                         color: "transparent"
-                        border.width: root.height * .002
+                        border.width: root.height * 0.002
                         border.color: "#77ffffff"
                     }
+
                 }
 
                 Shape {
                     anchors.fill: parent
-                    opacity: !displayAmbient ? 1 : .3
+                    opacity: !displayAmbient ? 1 : 0.3
 
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: "#ff98E2C6"
-                        strokeWidth: root.height * .005
+                        strokeWidth: root.height * 0.005
                         capStyle: ShapePath.RoundCap
                         startX: dayBox.width / 2
-                        startY: dayBox.height * (.5 - .456)
+                        startY: dayBox.height * (0.5 - 0.456)
 
                         PathAngleArc {
                             centerX: dayBox.width / 2
                             centerY: dayBox.height / 2
-                            radiusX: dayBox.width * .456
-                            radiusY: dayBox.height * .456
+                            radiusX: dayBox.width * 0.456
+                            radiusY: dayBox.height * 0.456
                             startAngle: 169
                             sweepAngle: dayBox.currentDayOfWeek / 7 * 360
                             moveToStart: true
                         }
+
                     }
+
                 }
 
                 Repeater {
@@ -266,49 +272,55 @@ Item {
                         id: dayStrokes
 
                         property bool currentDayHighlight: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd") === wallClock.time.toLocaleString(Qt.locale(), "ddd")
-                        property real rotM: ((index * 8.7) -15) / 60
+                        property real rotM: ((index * 8.7) - 15) / 60
                         property real centerX: parent.width / 2 - width / 2
                         property real centerY: parent.height / 2 - height / 2
 
-                        x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .35
-                        y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .35
+                        x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
+                        y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
                         antialiasing: true
-                        opacity: !displayAmbient ? 1 : .6
-                        color: currentDayHighlight ?
-                                   "#ffffffff" :
-                                   "#88ffffff"
+                        opacity: !displayAmbient ? 1 : 0.6
+                        color: currentDayHighlight ? "#ffffffff" : "#88ffffff"
+                        renderType: Text.NativeRendering
+                        text: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
+
                         font {
-                            pixelSize: currentDayHighlight ? root.height * .036 : root.height * .03
-                            letterSpacing: parent.width * .004
+                            pixelSize: currentDayHighlight ? root.height * 0.036 : root.height * 0.03
+                            letterSpacing: parent.width * 0.004
                             family: "Outfit"
                             weight: currentDayHighlight ? Font.Bold : Font.Normal
                         }
-                        renderType: Text.NativeRendering
-                        text: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
+
                         transform: Rotation {
                             origin.x: width / 2
                             origin.y: height / 2
                             angle: index * 52
                         }
+
                     }
+
                 }
 
                 Text {
                     id: dayDisplay
 
-                    anchors {
-                        centerIn: parent
-                        verticalCenterOffset: -root.width * .003
-                    }
-                    font {
-                        pixelSize: parent.height * .39
-                        family: "Noto Sans"
-                        styleName: "Condensed Light"
-                    }
                     renderType: Text.NativeRendering
                     color: "#ffffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
+
+                    anchors {
+                        centerIn: parent
+                        verticalCenterOffset: -root.width * 0.003
+                    }
+
+                    font {
+                        pixelSize: parent.height * 0.39
+                        family: "Noto Sans"
+                        styleName: "Condensed Light"
+                    }
+
                 }
+
             }
 
             Item {
@@ -316,23 +328,24 @@ Item {
 
                 property int currentMonth: wallClock.time.getMonth() + 1
 
+                width: parent.width * 0.22
+                height: parent.height * 0.22
+
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: parent.width * .06
-                    horizontalCenterOffset: parent.width * .23
+                    verticalCenterOffset: parent.width * 0.06
+                    horizontalCenterOffset: parent.width * 0.23
                 }
-                width: parent.width * .22
-                height: parent.height * .22
 
                 Rectangle {
                     id: monthArc
 
                     anchors.centerIn: parent
-                    width: parent.width * .9
+                    width: parent.width * 0.9
                     height: width
                     radius: width / 2
                     color: "#22ffffff"
-                    opacity: !displayAmbient ? 1 : .3
+                    opacity: !displayAmbient ? 1 : 0.3
 
                     Rectangle {
                         anchors.centerIn: parent
@@ -340,33 +353,36 @@ Item {
                         height: width
                         radius: width / 2
                         color: "transparent"
-                        border.width: root.height * .002
+                        border.width: root.height * 0.002
                         border.color: "#77ffffff"
                     }
+
                 }
 
                 Shape {
                     anchors.fill: parent
-                    opacity: !displayAmbient ? 1 : .3
+                    opacity: !displayAmbient ? 1 : 0.3
 
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: "#ff98E2C6"
-                        strokeWidth: root.height * .005
+                        strokeWidth: root.height * 0.005
                         capStyle: ShapePath.RoundCap
                         startX: monthBox.width / 2
-                        startY: monthBox.height * (.5 - .456)
+                        startY: monthBox.height * (0.5 - 0.456)
 
                         PathAngleArc {
                             centerX: monthBox.width / 2
                             centerY: monthBox.height / 2
-                            radiusX: monthBox.width * .456
-                            radiusY: monthBox.height * .456
+                            radiusX: monthBox.width * 0.456
+                            radiusY: monthBox.height * 0.456
                             startAngle: -90
                             sweepAngle: monthBox.currentMonth / 12 * 360
                             moveToStart: false
                         }
+
                     }
+
                 }
 
                 Repeater {
@@ -375,33 +391,34 @@ Item {
                     Text {
                         id: monthStrokes
 
-                        property bool currentMonthHighlight: Number(wallClock.time.toLocaleString(Qt.locale(), "MM")) === index ||
-                                                             Number(wallClock.time.toLocaleString(Qt.locale(), "MM")) === index + 12
+                        property bool currentMonthHighlight: Number(wallClock.time.toLocaleString(Qt.locale(), "MM")) === index || Number(wallClock.time.toLocaleString(Qt.locale(), "MM")) === index + 12
                         property real rotM: ((index * 5) - 15) / 60
                         property real centerX: parent.width / 2 - width / 2
                         property real centerY: parent.height / 2 - height / 2
 
-                        x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * .35
-                        y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * .35
+                        x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
+                        y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
                         antialiasing: true
-                        opacity: !displayAmbient ? 1 : .6
+                        opacity: !displayAmbient ? 1 : 0.6
+                        renderType: Text.NativeRendering
+                        color: currentMonthHighlight ? "#ffffffff" : "#88ffffff"
+                        text: index === 0 ? 12 : index
+
                         font {
-                            pixelSize: currentMonthHighlight ? root.height * .036 : root.height * .03
-                            letterSpacing: parent.width * .004
+                            pixelSize: currentMonthHighlight ? root.height * 0.036 : root.height * 0.03
+                            letterSpacing: parent.width * 0.004
                             family: "Outfit"
                             weight: currentMonthHighlight ? Font.Bold : Font.Normal
                         }
-                        renderType: Text.NativeRendering
-                        color:  currentMonthHighlight ?
-                                    "#ffffffff" :
-                                    "#88ffffff"
-                        text: index === 0 ? 12 : index
+
                         transform: Rotation {
                             origin.x: width / 2
                             origin.y: height / 2
                             angle: (index * 30)
                         }
+
                     }
+
                 }
 
                 Text {
@@ -409,36 +426,40 @@ Item {
 
                     anchors.centerIn: parent
                     renderType: Text.NativeRendering
-                    font {
-                        pixelSize: parent.height * .366
-                        family: "Noto Sans"
-                        styleName: "Condensed Light"
-                        letterSpacing: -root.width * .0018
-                    }
                     color: "#ddffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "MMM").slice(0, 3).toUpperCase()
+
+                    font {
+                        pixelSize: parent.height * 0.366
+                        family: "Noto Sans"
+                        styleName: "Condensed Light"
+                        letterSpacing: -root.width * 0.0018
+                    }
+
                 }
+
             }
 
             Item {
                 id: batteryBox
 
+                width: parent.width * 0.26
+                height: parent.height * 0.26
+
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: parent.width * .206
+                    verticalCenterOffset: parent.width * 0.206
                 }
-                width: parent.width * .26
-                height: parent.height * .26
 
                 Rectangle {
                     id: batteryArc
 
                     anchors.centerIn: parent
-                    width: parent.width * .9
+                    width: parent.width * 0.9
                     height: width
                     radius: width / 2
                     color: "#22ffffff"
-                    opacity: !displayAmbient ? 1 : .3
+                    opacity: !displayAmbient ? 1 : 0.3
 
                     Rectangle {
                         anchors.centerIn: parent
@@ -446,34 +467,36 @@ Item {
                         height: width
                         radius: width / 2
                         color: "transparent"
-                        border.width: root.height * .002
+                        border.width: root.height * 0.002
                         border.color: "#77ffffff"
                     }
+
                 }
 
                 Shape {
                     anchors.fill: parent
-                    opacity: !displayAmbient ? 1 : .3
+                    opacity: !displayAmbient ? 1 : 0.3
 
                     ShapePath {
                         fillColor: "transparent"
-                        strokeColor: batteryChargePercentage.percent < 30 ? "#EF476F" :
-                                     batteryChargePercentage.percent < 60 ? "#D0E562" : "#23F0C7"
-                        strokeWidth: root.height * .005
+                        strokeColor: batteryChargePercentage.percent < 30 ? "#EF476F" : batteryChargePercentage.percent < 60 ? "#D0E562" : "#23F0C7"
+                        strokeWidth: root.height * 0.005
                         capStyle: ShapePath.RoundCap
                         startX: batteryBox.width / 2
-                        startY: batteryBox.height * (.5 - .456)
+                        startY: batteryBox.height * (0.5 - 0.456)
 
                         PathAngleArc {
                             centerX: batteryBox.width / 2
                             centerY: batteryBox.height / 2
-                            radiusX: batteryBox.width * .456
-                            radiusY: batteryBox.height * .456
+                            radiusX: batteryBox.width * 0.456
+                            radiusY: batteryBox.height * 0.456
                             startAngle: -90
                             sweepAngle: batteryChargePercentage.percent / 100 * 360
                             moveToStart: false
                         }
+
                     }
+
                 }
 
                 Text {
@@ -481,42 +504,62 @@ Item {
 
                     anchors.centerIn: parent
                     renderType: Text.NativeRendering
-                    font {
-                        pixelSize: parent.height * (batteryDisplay.text === "100" ? 0.46 : .48)
-                        family: "Outfit"
-                        weight: Font.Thin
-                    }
                     color: "#ffffffff"
                     text: batteryChargePercentage.percent
 
-                    Text {
-                         id: batteryPercent
+                    font {
+                        pixelSize: parent.height * (batteryDisplay.text === "100" ? 0.46 : 0.48)
+                        family: "Outfit"
+                        weight: Font.Thin
+                    }
 
-                         anchors {
-                             centerIn: batteryDisplay
-                             verticalCenterOffset: parent.height*.34
-                         }
-                         font {
-                             pixelSize: parent.height * .194
-                             family: "Open Sans"
-                         }
-                         renderType: Text.NativeRendering
-                         horizontalAlignment: Text.AlignHCenter
-                         lineHeightMode: Text.FixedHeight
-                         lineHeight: parent.height * .94
-                         color: !displayAmbient ?
-                                    "#bbffffff" :
-                                    "#55ffffff"
-                         text: "BAT<br>%"
-                     }
+                    Text {
+                        id: batteryPercent
+
+                        renderType: Text.NativeRendering
+                        horizontalAlignment: Text.AlignHCenter
+                        lineHeightMode: Text.FixedHeight
+                        lineHeight: parent.height * 0.94
+                        color: !displayAmbient ? "#bbffffff" : "#55ffffff"
+                        text: "BAT<br>%"
+
+                        anchors {
+                            centerIn: batteryDisplay
+                            verticalCenterOffset: parent.height * 0.34
+                        }
+
+                        font {
+                            pixelSize: parent.height * 0.194
+                            family: "Open Sans"
+                        }
+
+                    }
+
                 }
+
             }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: root.width * 0.005
+                verticalOffset: root.width * 0.005
+                radius: root.width * 0.013
+                samples: 9
+                color: "#99000000"
+            }
+
         }
 
         Item {
             id: handBox
 
             anchors.fill: root
+            Component.onCompleted: {
+                var hours = wallClock.time.getHours();
+                var minutes = wallClock.time.getMinutes();
+                hourRotation.angle = use12H.value ? (hours % 12 * 30) + (minutes * 0.5) : (hours * 15) + (minutes * 0.25);
+                minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * 0.1);
+            }
 
             Image {
                 id: hourSVG
@@ -525,6 +568,8 @@ Item {
                 source: imgPath + (displayAmbient ? "hour-bw.svg" : "hour.svg")
                 width: handBox.width
                 height: handBox.height
+                layer.enabled: true
+
                 transform: Rotation {
                     id: hourRotation
 
@@ -532,15 +577,16 @@ Item {
                     origin.y: handBox.height / 2
                     angle: 0
                 }
-                layer.enabled: true
+
                 layer.effect: DropShadow {
                     transparentBorder: true
-                    horizontalOffset: root.width * .01
-                    verticalOffset: root.width * .01
-                    radius: root.width * .018
+                    horizontalOffset: root.width * 0.01
+                    verticalOffset: root.width * 0.01
+                    radius: root.width * 0.018
                     samples: 9
-                    color: Qt.rgba(0, 0, 0, .2)
+                    color: Qt.rgba(0, 0, 0, 0.2)
                 }
+
             }
 
             Image {
@@ -550,6 +596,8 @@ Item {
                 source: imgPath + (displayAmbient ? "minute-bw.svg" : "minute.svg")
                 width: handBox.width
                 height: handBox.height
+                layer.enabled: true
+
                 transform: Rotation {
                     id: minuteRotation
 
@@ -557,15 +605,16 @@ Item {
                     origin.y: handBox.height / 2
                     angle: 0
                 }
-                layer.enabled: true
+
                 layer.effect: DropShadow {
                     transparentBorder: true
-                    horizontalOffset: root.width * .012
-                    verticalOffset: root.width * .012
-                    radius: root.width * .022
+                    horizontalOffset: root.width * 0.012
+                    verticalOffset: root.width * 0.012
+                    radius: root.width * 0.022
                     samples: 9
-                    color: Qt.rgba(0, 0, 0, .2)
+                    color: Qt.rgba(0, 0, 0, 0.2)
                 }
+
             }
 
             Image {
@@ -576,6 +625,7 @@ Item {
                 visible: !displayAmbient
                 width: handBox.width
                 height: handBox.height
+
                 transform: Rotation {
                     id: secondRotation
 
@@ -583,17 +633,17 @@ Item {
                     origin.y: handBox.height / 2
                     angle: 0
                 }
+
             }
-            
+
             Connections {
                 function onTimeChanged() {
-                    var hours = wallClock.time.getHours()
-                    var minutes = wallClock.time.getMinutes()
-                    hourRotation.angle = use12H.value ?
-                        (hours % 12 * 30) + (minutes * .5) :
-                        (hours * 15) + (minutes * .25)
-                    minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
+                    var hours = wallClock.time.getHours();
+                    var minutes = wallClock.time.getMinutes();
+                    hourRotation.angle = use12H.value ? (hours % 12 * 30) + (minutes * 0.5) : (hours * 15) + (minutes * 0.25);
+                    minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * 0.1);
                 }
+
                 target: wallClock
             }
 
@@ -602,21 +652,13 @@ Item {
                 repeat: true
                 running: !displayAmbient && visible
                 onTriggered: {
-                    var now = new Date()
-                    secondRotation.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+                    var now = new Date();
+                    secondRotation.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000;
                 }
             }
 
-            Component.onCompleted: {
-                var hours = wallClock.time.getHours()
-                var minutes = wallClock.time.getMinutes()
-                hourRotation.angle = use12H.value ?
-                    (hours % 12 * 30) + (minutes * .5) :
-                    (hours * 15) + (minutes * .25)
-                minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
-            }
         }
-        
+
         Item {
             id: nightstandMode
 
@@ -634,17 +676,17 @@ Item {
                 property int gap: 4
                 property int endFromStart: 360
                 property bool clockwise: true
-                property real arcStrokeWidth: .016
-                property real scalefactor: .50 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.016
+                property real scalefactor: 0.5 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -653,7 +695,7 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * (.5 - segmentedArc.scalefactor)
+                        startY: root.height * (0.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2
@@ -664,9 +706,15 @@ Item {
                             sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
+
                     }
+
                 }
+
             }
+
         }
+
     }
+
 }

--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -17,7 +17,6 @@ Item {
     anchors.fill: parent
 
     property string imgPath: "../watchfaces-img/analog-scientific-v2-"
-    property real rad: .01745
 
     MceBatteryLevel {
         id: batteryChargePercentage
@@ -95,8 +94,8 @@ Item {
                     font {
                         pixelSize: parent.height * .088
                         family: "Outfit"
-                        styleName: "Regular"
                     }
+                    renderType: Text.NativeRendering
                     horizontalAlignment: Text.AlignHCenter
                     color: "#ffffffff"
                     text: index === 0 ? "12" : index
@@ -128,9 +127,11 @@ Item {
                         pixelSize: parent.height * .31
                         family: "Raleway"
                     }
+                    renderType: Text.NativeRendering
                     visible: !displayAmbient
                     color: "white"
                     horizontalAlignment: Text.AlignHCenter
+                    textFormat: Text.StyledText
                     text: "<b>AsteroidOS</b><br>Free Your Wrist"
                 }
                 MouseArea {
@@ -153,9 +154,9 @@ Item {
                 font {
                     pixelSize: parent.height * .15
                     family: "Open Sans"
-                    styleName: "Regular"
                     letterSpacing: -parent.width * .001
                 }
+                renderType: Text.NativeRendering
                 color: "#bbffffff"
                 text: if (use12H.value) {
                           wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2)}
@@ -174,9 +175,10 @@ Item {
                 font {
                     pixelSize: root.height * .15
                     family: "Open Sans"
-                    styleName: "Light"
+                    weight: Font.Light
                     letterSpacing: -parent.width * .001
                 }
+                renderType: Text.NativeRendering
                 color: "#ccffffff"
                 text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
@@ -193,8 +195,8 @@ Item {
                 font {
                     pixelSize: root.height * .06
                     family: "Open Sans Condensed"
-                    styleName: "Regular"
                 }
+                renderType: Text.NativeRendering
                 visible: use12H.value
                 color: "#ddffffff"
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
@@ -203,9 +205,7 @@ Item {
             Item {
                 id: dayBox
 
-                property var day: wallClock.time.toLocaleString(Qt.locale(), "dd")
-
-                onDayChanged: dayArc.requestPaint()
+                property int currentDayOfWeek: wallClock.time.getDay()
 
                 anchors {
                     centerIn: parent
@@ -215,41 +215,48 @@ Item {
                 width: parent.width * .22
                 height: parent.height * .22
 
-                Canvas {
+                Rectangle {
                     id: dayArc
 
+                    anchors.centerIn: parent
+                    width: parent.width * .9
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
+                    opacity: !displayAmbient ? 1 : .3
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: root.height * .002
+                        border.color: "#77ffffff"
+                    }
+                }
+
+                Shape {
                     anchors.fill: parent
                     opacity: !displayAmbient ? 1 : .3
-                    smooth: true
-                    renderStrategy: Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .45,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = root.height * .002
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = root.height * .005
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#ff98E2C6"
-                        ctx.beginPath()
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .456,
-                                169 * rad,
-                                ((wallClock.time.getDay() / 7 * 360) + 169) * rad,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    ShapePath {
+                        fillColor: "transparent"
+                        strokeColor: "#ff98E2C6"
+                        strokeWidth: root.height * .005
+                        capStyle: ShapePath.RoundCap
+                        startX: dayBox.width / 2
+                        startY: dayBox.height * (.5 - .456)
+
+                        PathAngleArc {
+                            centerX: dayBox.width / 2
+                            centerY: dayBox.height / 2
+                            radiusX: dayBox.width * .456
+                            radiusY: dayBox.height * .456
+                            startAngle: 169
+                            sweepAngle: dayBox.currentDayOfWeek / 7 * 360
+                            moveToStart: true
+                        }
                     }
                 }
 
@@ -276,10 +283,9 @@ Item {
                             pixelSize: currentDayHighlight ? root.height * .036 : root.height * .03
                             letterSpacing: parent.width * .004
                             family: "Outfit"
-                            styleName: currentDayHighlight ?
-                                            "Bold" :
-                                            "Regular"
+                            weight: currentDayHighlight ? Font.Bold : Font.Normal
                         }
+                        renderType: Text.NativeRendering
                         text: new Date(2017, 1, index).toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
                         transform: Rotation {
                             origin.x: width / 2
@@ -301,6 +307,7 @@ Item {
                         family: "Noto Sans"
                         styleName: "Condensed Light"
                     }
+                    renderType: Text.NativeRendering
                     color: "#ffffffff"
                     text: wallClock.time.toLocaleString(Qt.locale(), "dd").slice(0, 2).toUpperCase()
                 }
@@ -309,9 +316,7 @@ Item {
             Item {
                 id: monthBox
 
-                property var month: wallClock.time.toLocaleString(Qt.locale(), "mm")
-
-                onMonthChanged: monthArc.requestPaint()
+                property int currentMonth: wallClock.time.getMonth() + 1
 
                 anchors {
                     centerIn: parent
@@ -321,41 +326,48 @@ Item {
                 width: parent.width * .22
                 height: parent.height * .22
 
-                Canvas {
+                Rectangle {
                     id: monthArc
 
+                    anchors.centerIn: parent
+                    width: parent.width * .9
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
+                    opacity: !displayAmbient ? 1 : .3
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: root.height * .002
+                        border.color: "#77ffffff"
+                    }
+                }
+
+                Shape {
                     anchors.fill: parent
                     opacity: !displayAmbient ? 1 : .3
-                    smooth: true
-                    renderStrategy: Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .45,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = root.height * .002
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        ctx.lineWidth = root.height * .005
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = "#ff98E2C6"
-                        ctx.beginPath()
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .456,
-                                270 * rad,
-                                ((wallClock.time.toLocaleString(Qt.locale(),"MM") / 12 * 360) + 270) * rad,
-                                false);
-                        ctx.stroke()
-                        ctx.closePath()
+
+                    ShapePath {
+                        fillColor: "transparent"
+                        strokeColor: "#ff98E2C6"
+                        strokeWidth: root.height * .005
+                        capStyle: ShapePath.RoundCap
+                        startX: monthBox.width / 2
+                        startY: monthBox.height * (.5 - .456)
+
+                        PathAngleArc {
+                            centerX: monthBox.width / 2
+                            centerY: monthBox.height / 2
+                            radiusX: monthBox.width * .456
+                            radiusY: monthBox.height * .456
+                            startAngle: -90
+                            sweepAngle: monthBox.currentMonth / 12 * 360
+                            moveToStart: false
+                        }
                     }
                 }
 
@@ -376,15 +388,12 @@ Item {
                         antialiasing: true
                         opacity: !displayAmbient ? 1 : .6
                         font {
-                            pixelSize: currentMonthHighlight ?
-                                           root.height * .036 :
-                                           root.height * .03
+                            pixelSize: currentMonthHighlight ? root.height * .036 : root.height * .03
                             letterSpacing: parent.width * .004
                             family: "Outfit"
-                            styleName: currentMonthHighlight ?
-                                           "Bold" :
-                                           "Regular"
+                            weight: currentMonthHighlight ? Font.Bold : Font.Normal
                         }
+                        renderType: Text.NativeRendering
                         color:  currentMonthHighlight ?
                                     "#ffffffff" :
                                     "#88ffffff"
@@ -416,10 +425,6 @@ Item {
             Item {
                 id: batteryBox
 
-                property int value: batteryChargePercentage.percent
-
-                onValueChanged: batteryArc.requestPaint()
-
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: parent.width * .206
@@ -427,67 +432,49 @@ Item {
                 width: parent.width * .26
                 height: parent.height * .26
 
-                Canvas {
+                Rectangle {
                     id: batteryArc
 
-                    property int hour: 0
-
+                    anchors.centerIn: parent
+                    width: parent.width * .9
+                    height: width
+                    radius: width / 2
+                    color: "#22ffffff"
                     opacity: !displayAmbient ? 1 : .3
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: root.height * .002
+                        border.color: "#77ffffff"
+                    }
+                }
+
+                Shape {
                     anchors.fill: parent
-                    smooth: true
-                    renderStrategy: Canvas.Cooperative
-                    onPaint: {
-                        var ctx = getContext("2d")
-                        ctx.reset()
-                        ctx.beginPath()
-                        ctx.fillStyle = "#22ffffff"
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .45,
-                                270 * rad,
-                                360,
-                                false);
-                        ctx.strokeStyle = "#77ffffff"
-                        ctx.lineWidth = root.height * .002
-                        ctx.stroke()
-                        ctx.fill()
-                        ctx.closePath()
-                        var gradient = ctx.createRadialGradient (parent.width / 2,
-                                                                 parent.height / 2,
-                                                                 0,
-                                                                 parent.width / 2,
-                                                                 parent.height / 2,
-                                                                 parent.width * .46
-                                                                 )
-                        gradient.addColorStop(.44,
-                                              batteryChargePercentage.percent < 30 ?
-                                                  "#00EF476F" :
-                                                  batteryChargePercentage.percent < 60 ?
-                                                      "#00D0E562" :
-                                                      "#0023F0C7"
-                                              )
-                        gradient.addColorStop(.97,
-                                              batteryChargePercentage.percent < 30 ?
-                                                  "#ffEF476F" :
-                                                  batteryChargePercentage.percent < 60 ?
-                                                      "#ffD0E562" :
-                                                      "#ff23F0C7"
-                                              )
-                        ctx.lineWidth = root.height * .005
-                        ctx.lineCap="round"
-                        ctx.strokeStyle = gradient
-                        ctx.beginPath()
-                        ctx.arc(parent.width / 2,
-                                parent.height / 2,
-                                parent.width * .456,
-                                270 * rad,
-                                ((batteryChargePercentage.percent/100*360)+270) * rad,
-                                false
-                                );
-                        ctx.lineTo(parent.width / 2,
-                                   parent.height / 2)
-                        ctx.stroke()
-                        ctx.closePath()
+                    opacity: !displayAmbient ? 1 : .3
+
+                    ShapePath {
+                        fillColor: "transparent"
+                        strokeColor: batteryChargePercentage.percent < 30 ? "#EF476F" :
+                                     batteryChargePercentage.percent < 60 ? "#D0E562" : "#23F0C7"
+                        strokeWidth: root.height * .005
+                        capStyle: ShapePath.RoundCap
+                        startX: batteryBox.width / 2
+                        startY: batteryBox.height * (.5 - .456)
+
+                        PathAngleArc {
+                            centerX: batteryBox.width / 2
+                            centerY: batteryBox.height / 2
+                            radiusX: batteryBox.width * .456
+                            radiusY: batteryBox.height * .456
+                            startAngle: -90
+                            sweepAngle: batteryChargePercentage.percent / 100 * 360
+                            moveToStart: false
+                        }
                     }
                 }
 
@@ -499,7 +486,7 @@ Item {
                     font {
                         pixelSize: parent.height * (batteryDisplay.text === "100" ? 0.46 : .48)
                         family: "Outfit"
-                        styleName:"Thin"
+                        weight: Font.Thin
                     }
                     color: "#ffffffff"
                     text: batteryChargePercentage.percent
@@ -514,7 +501,6 @@ Item {
                          font {
                              pixelSize: parent.height * .194
                              family: "Open Sans"
-                             styleName:"Regular"
                          }
                          renderType: Text.NativeRendering
                          horizontalAlignment: Text.AlignHCenter

--- a/src/watchfaces/009-analog-scientific-v2.qml
+++ b/src/watchfaces/009-analog-scientific-v2.qml
@@ -6,11 +6,9 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
 import Nemo.Mce
 
 Item {
@@ -27,7 +25,7 @@ Item {
 
         anchors.centerIn: parent
 
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Item {


### PR DESCRIPTION
Qt6 refactor of the 009-analog-scientific-v2 watchface. Seven commits covering SPDX header, nightstand arc correctness, animation system overhaul, full Canvas-to-Qt-objects conversion, text rendering, conventions, and a qmlformat pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Six authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Adds `| 0` bitwise cast to `chargecolor`; Qt6 rejects implicit double-to-int coercion on array index access. Replaces `parent` references in `ShapePath` and `PathAngleArc` with `root`; the parent chain inside both resolves to items with no geometry. Collapses `sweepAngle` ternary to a single line and normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Fix Qt6 animation system** — removes `layer.samples: 2` from `dialBox`; hardware has no multisample renderbuffers. Converts hardcoded pixel `DropShadow` values on `dialBox` to screen-relative fractions of `root.width`. Removes `Behavior on angle RotationAnimation` from `hourSVG` and `minuteSVG`; the Behavior causes a dramatic catch-up sweep on wake from ambient. Replaces direct `wallClock.time` rotation bindings with a `Connections` block and `Component.onCompleted` initialisation using named `Rotation` ids `hourRotation`, `minuteRotation`, and `secondRotation`. Removes the full `layer` block and `DropShadow` from `secondSVG`; a DropShadow on a 60fps hand forces a full shader recomposite on every frame. Removes `antialiasing` from all three hand Images; it is a no-op when `layer.enabled` is true. Adds a 16ms `Timer` for smooth second hand motion using `new Date()` millisecond precision.

4. **Replace Canvas arcs with Qt objects** — converts `dayArc`, `monthArc`, and `batteryArc` from Canvas to nested `Rectangle` items with `radius: width / 2` for the static circle background and `Shape` with `PathAngleArc` for the progress arc. All three Canvas items drew an identical filled circle background using a full-circle `ctx.arc`; Rectangles are a direct equivalent with zero per-frame cost and no `onPaint` overhead. The `dayArc` progress arc starts at 169° and sweeps proportionally through the current day of week; `moveToStart: true` prevents a stray connecting line since the arc does not start at 12 o'clock. The `monthArc` and `batteryArc` start at -90° (12 o'clock). Removes the dead trigger properties `property var day` / `onDayChanged`, `property var month` / `onMonthChanged`, and `property int value` / `onValueChanged`; replaces with stored intermediate properties `currentDayOfWeek` and `currentMonth` that `PathAngleArc sweepAngle` binds to declaratively. Removes the dead `property int hour` from the old `batteryArc` Canvas. The `batteryArc` radial gradient is replaced with a solid colour using the same three-threshold battery level logic as all other stock watchfaces; `createRadialGradient` on a Canvas stroke has no `QtShapes` equivalent. Removes `property real rad` which was used solely as a degree-to-radian conversion factor in the three Canvas `onPaint` handlers.

5. **Add Qt6 text rendering properties** — adds `renderType: Text.NativeRendering` to all Text items that were missing it: the `hourNumbers` delegate, `asteroidSlogan`, `digitalDisplay`, `digitalMinutes`, `apDisplay`, the `dayStrokes` delegate, `dayDisplay`, the `monthStrokes` delegate, and `batteryDisplay`. `monthDisplay` and `batteryPercent` already had it. Adds `textFormat: Text.StyledText` to `asteroidSlogan`; its text binding uses `<b>` and `<br>` markup and Qt6 AutoText mode treats `<br>` as a paragraph boundary rather than an inline line break. Converts simple weight-only `font.styleName` values to `font.weight` enum constants: `Light` on `digitalMinutes`, `Thin` on `batteryDisplay`, and the `Bold`/`Regular` conditional on `dayStrokes` and `monthStrokes` delegates. Removes `styleName: "Regular"` from `hourNumbers`, `digitalDisplay`, `apDisplay`, and `batteryPercent` as it is the default. Compound `styleName` values `Condensed Light` on `dayDisplay` and `monthDisplay` are preserved intact.

6. **Conventions and formatting** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.controls` and `org.asteroid.utils`; neither has any remaining references in the file after the Canvas conversion removed the last usage. Replaces root square sizing ternary with `Math.min`.

7. **qmlformat pass** — full `-i` normalisation pass over the file following the Canvas conversion and conventions commits.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: tick ring, hour numerals, digital display, sub-dials, and all three SVG hands render correctly.
- Second hand sweeps smoothly at 60fps via 16ms Timer; no catch-up sweep on wake from ambient.
- Day sub-dial: day abbreviations orbit correctly, current day highlighted, progress arc starts at correct position and sweeps clockwise through the week.
- Month sub-dial: month numerals orbit correctly, current month highlighted, progress arc starts at 12 o'clock and sweeps through the year.
- Battery sub-dial: percentage and BAT/% labels render correctly, progress arc starts at 12 o'clock, colour transitions at 30% and 60% thresholds.
- Nightstand mode: battery arc renders correctly, no multisample renderbuffer journal warning.
- AsteroidOS logo and slogan: two-line layout correct with `textFormat: Text.StyledText`.
- 12h/24h toggle: `apDisplay` visibility and `hourSVG` rotation both respond correctly.
- AoD: second hand hidden, sub-dial and hand opacity changes correct.
- No regressions found across all seven commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- The `dialBox` layer carries a `layer.effect: DropShadow` applied to the full dial assembly including tick ring, numerals, and sub-dials. This is accepted for items updating at per-minute cadence or less.
- `dayArc` uses `moveToStart: true` on its `PathAngleArc`. The arc starts at 169° (approximately 7 o'clock) rather than 12 o'clock; without `moveToStart: true` the renderer draws a visible connecting line from the `ShapePath startX/startY` position to the arc start. `monthArc` and `batteryArc` start at -90° which coincides with their `startY` position and use `moveToStart: false`.
- The `batteryArc` radial gradient from the original Canvas implementation cannot be replicated as a `QtShapes` stroke. The solid colour replacement matches the visual language of all other stock watchfaces.
- No visual tuning commit was needed — the face renders identically on Qt5 and Qt6.