### PR TITLE
Refactor 010-analog-aviator watchface for Qt6

### DIFF
--- a/src/watchfaces/010-analog-aviator.qml
+++ b/src/watchfaces/010-analog-aviator.qml
@@ -1,19 +1,17 @@
 // SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
-    anchors.fill: parent
-
     property string currentColor: ""
     property string userColor: ""
     property string imgPath: "../watchfaces-img/analog-aviator-"
+
+    anchors.fill: parent
 
     MceBatteryLevel {
         id: batteryChargePercentage
@@ -23,9 +21,14 @@ Item {
         id: root
 
         anchors.centerIn: parent
-
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
+        Component.onCompleted: {
+            var hours = wallClock.time.getHours();
+            var minutes = wallClock.time.getMinutes();
+            hourRotation.angle = (hours * 30) + (minutes * 0.5);
+            minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * 0.1);
+        }
 
         Item {
             id: nightstandMode
@@ -44,17 +47,17 @@ Item {
                 property int gap: 0
                 property int endFromStart: 360
                 property bool clockwise: true
-                property real arcStrokeWidth: .015
-                property real scalefactor: .49 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.015
+                property real scalefactor: 0.49 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -63,7 +66,7 @@ Item {
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * (.5 - segmentedArc.scalefactor)
+                        startY: root.height * (0.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2
@@ -74,59 +77,51 @@ Item {
                             sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
+
                     }
+
                 }
+
             }
+
         }
 
         Item {
             id: dialBox
 
             anchors.fill: parent
-
             layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: root.width * .005
-                verticalOffset: root.width * .005
-                radius: root.width * .03
-                samples: 25
-                color: "#bb000000"
-            }
 
             Image {
                 id: asteroidLogo
+
+                source: "../watchfaces-img/asteroid-logo-white.svg"
+                antialiasing: true
+                width: parent.width / 5.5
+                height: parent.height / 5.5
+                opacity: 1
+                state: currentColor
 
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: -parent.height * 0.324
                 }
-                source: "../watchfaces-img/asteroid-logo-white.svg"
-                antialiasing: true
 
-                width: parent.width / 5.5
-                height: parent.height / 5.5
-                opacity: 1
-                state: currentColor
-                states: State { name: "black"
+                states: State {
+                    name: "black"
+
                     PropertyChanges {
                         target: asteroidLogo
                         source: "../watchfaces-img/asteroid-logo-black.svg"
                     }
+
                 }
+
             }
 
             Text {
                 id: asteroidSlogan
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: -parent.height * 0.146
-                }
-                font {
-                    pixelSize: parent.height * 0.048
-                    family: "Raleway"
-                }
                 renderType: Text.NativeRendering
                 visible: !displayAmbient
                 color: "#bbffffff"
@@ -134,26 +129,43 @@ Item {
                 textFormat: Text.StyledText
                 text: "<b>AsteroidOS</b><br>Free Your Wrist"
                 state: currentColor
-                states: State { name: "black";
-                    PropertyChanges { target: asteroidSlogan; color: "black" }
+
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: -parent.height * 0.146
                 }
+
+                font {
+                    pixelSize: parent.height * 0.048
+                    family: "Raleway"
+                }
+
+                states: State {
+                    name: "black"
+
+                    PropertyChanges {
+                        target: asteroidSlogan
+                        color: "black"
+                    }
+
+                }
+
                 transitions: Transition {
-                    from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    from: ""
+                    to: "black"
+                    reversible: true
+
+                    ColorAnimation {
+                        duration: 300
+                    }
+
                 }
+
             }
 
             Text {
                 id: dateDisplay
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: parent.height*0.14
-                }
-                font {
-                    pixelSize: parent.height * 0.052
-                    family: "Raleway"
-                }
                 renderType: Text.NativeRendering
                 visible: !displayAmbient
                 color: "#bbffffff"
@@ -161,65 +173,124 @@ Item {
                 textFormat: Text.StyledText
                 text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b> MMMM<br>yyyy")
                 state: currentColor
-                states: State { name: "black";
-                    PropertyChanges { target: dateDisplay; color: "black" }
+
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: parent.height * 0.14
                 }
+
+                font {
+                    pixelSize: parent.height * 0.052
+                    family: "Raleway"
+                }
+
+                states: State {
+                    name: "black"
+
+                    PropertyChanges {
+                        target: dateDisplay
+                        color: "black"
+                    }
+
+                }
+
                 transitions: Transition {
-                    from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    from: ""
+                    to: "black"
+                    reversible: true
+
+                    ColorAnimation {
+                        duration: 300
+                    }
+
                 }
+
             }
 
             Text {
                 id: apDisplay
+
+                renderType: Text.NativeRendering
+                color: "white"
+                horizontalAlignment: Text.AlignHCenter
+                text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
+                state: currentColor
 
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: parent.height / 3.8
                     horizontalCenterOffset: parent.width / 3.8
                 }
+
                 font {
                     pixelSize: parent.height * 0.065
                     family: "PTSans"
                 }
-                renderType: Text.NativeRendering
-                color: "white"
-                horizontalAlignment: Text.AlignHCenter
-                text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
-                state: currentColor
-                states: State { name: "black";
-                    PropertyChanges { target: apDisplay; color: "black" }
+
+                states: State {
+                    name: "black"
+
+                    PropertyChanges {
+                        target: apDisplay
+                        color: "black"
+                    }
+
                 }
+
                 transitions: Transition {
-                    from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    from: ""
+                    to: "black"
+                    reversible: true
+
+                    ColorAnimation {
+                        duration: 300
+                    }
+
                 }
+
             }
 
             Text {
                 id: dowDisplay
+
+                renderType: Text.NativeRendering
+                color: "white"
+                horizontalAlignment: Text.AlignHCenter
+                text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
+                state: currentColor
 
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: parent.height / 3.8
                     horizontalCenterOffset: -parent.width / 3.8
                 }
+
                 font {
                     pixelSize: parent.height * 0.065
                     family: "PTSans"
                 }
-                renderType: Text.NativeRendering
-                color: "white"
-                horizontalAlignment: Text.AlignHCenter
-                text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
-                state: currentColor
-                states: State { name: "black";
-                    PropertyChanges { target: dowDisplay; color: "black" }
+
+                states: State {
+                    name: "black"
+
+                    PropertyChanges {
+                        target: dowDisplay
+                        color: "black"
+                    }
+
                 }
+
                 transitions: Transition {
-                    from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 300 }
+                    from: ""
+                    to: "black"
+                    reversible: true
+
+                    ColorAnimation {
+                        duration: 300
+                    }
+
                 }
+
             }
 
             Repeater {
@@ -233,22 +304,43 @@ Item {
                     property real centerY: parent.height / 2 - height / 2
 
                     visible: index % 5
-                    antialiasing : true
-                    x: centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
-                    y: centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
+                    antialiasing: true
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
                     color: "#bbffffff"
                     width: parent.width * 0.0055
                     height: parent.height * 0.04
-                    transform: Rotation { origin.x: width / 2; origin.y: height / 2; angle: (index) * 6}
                     state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: minuteStrokes; color: "black" }
+
+                    transform: Rotation {
+                        origin.x: width / 2
+                        origin.y: height / 2
+                        angle: (index) * 6
                     }
+
+                    states: State {
+                        name: "black"
+
+                        PropertyChanges {
+                            target: minuteStrokes
+                            color: "black"
+                        }
+
+                    }
+
                     transitions: Transition {
-                        from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 300 }
+                        from: ""
+                        to: "black"
+                        reversible: true
+
+                        ColorAnimation {
+                            duration: 300
+                        }
+
                     }
+
                 }
+
             }
 
             Repeater {
@@ -257,31 +349,51 @@ Item {
                 Text {
                     id: hourNumbers
 
-                    property real rotM: ((index * 15 ) - 15) / 60
+                    property real rotM: ((index * 15) - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
-                    property real centerY: parent.height / 2 - height / 2.0
+                    property real centerY: parent.height / 2 - height / 2
+
+                    renderType: Text.NativeRendering
+                    x: centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
+                    y: centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
+                    color: "#ccffffff"
+                    text: {
+                        if (index === 0) {
+                            "";
+                        } else {
+                            index * 3;
+                        }
+                    }
+                    state: currentColor
 
                     font {
                         pixelSize: parent.height * 0.21
                         family: "Signika"
                     }
-                    renderType: Text.NativeRendering
-                    x: centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
-                    y: centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
-                    color: "#ccffffff"
-                    text: if (index === 0)
-                              ""
-                          else
-                              index * 3
-                    state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: hourNumbers; color: "black" }
+
+                    states: State {
+                        name: "black"
+
+                        PropertyChanges {
+                            target: hourNumbers
+                            color: "black"
+                        }
+
                     }
+
                     transitions: Transition {
-                        from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 300 }
+                        from: ""
+                        to: "black"
+                        reversible: true
+
+                        ColorAnimation {
+                            duration: 300
+                        }
+
                     }
+
                 }
+
             }
 
             Repeater {
@@ -290,33 +402,70 @@ Item {
                 Rectangle {
                     id: hourStrokes
 
-                    property real rotM: ((index * 5 ) - 15) / 60
+                    property real rotM: ((index * 5) - 15) / 60
                     property real centerX: parent.width / 2 - width / 2
                     property real centerY: parent.height / 2 - height / 2
 
-                    width: parent.width * 0.020
+                    width: parent.width * 0.02
                     height: [0, 3, 6, 9].includes(index) ? parent.height * 0.04 : parent.height * 0.13
-                    x: if ([0, 3, 6, 9].includes(index))
-                           centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48
-                       else
-                           centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.44
-                    y: if ([0, 3, 6, 9].includes(index))
-                           centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48
-                       else
-                           centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.44
-                    antialiasing : true
+                    x: {
+                        if ([0, 3, 6, 9].includes(index)) {
+                            centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.48;
+                        } else {
+                            centerX + Math.cos(rotM * 2 * Math.PI) * parent.width * 0.44;
+                        }
+                    }
+                    y: {
+                        if ([0, 3, 6, 9].includes(index)) {
+                            centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.48;
+                        } else {
+                            centerY + Math.sin(rotM * 2 * Math.PI) * parent.width * 0.44;
+                        }
+                    }
+                    antialiasing: true
                     color: "#ccffffff"
-                    transform: Rotation { origin.x: width / 2; origin.y: height / 2; angle: (index * 5) * 6}
                     state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: hourStrokes; color: "black" }
+
+                    transform: Rotation {
+                        origin.x: width / 2
+                        origin.y: height / 2
+                        angle: (index * 5) * 6
                     }
+
+                    states: State {
+                        name: "black"
+
+                        PropertyChanges {
+                            target: hourStrokes
+                            color: "black"
+                        }
+
+                    }
+
                     transitions: Transition {
-                        from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 300 }
+                        from: ""
+                        to: "black"
+                        reversible: true
+
+                        ColorAnimation {
+                            duration: 300
+                        }
+
                     }
+
                 }
+
             }
+
+            layer.effect: DropShadow {
+                transparentBorder: true
+                horizontalOffset: root.width * 0.005
+                verticalOffset: root.width * 0.005
+                radius: root.width * 0.03
+                samples: 25
+                color: "#bb000000"
+            }
+
         }
 
         Image {
@@ -324,6 +473,9 @@ Item {
 
             anchors.fill: root
             source: !displayAmbient ? imgPath + "hour-ambient.svg" : imgPath + "hour-ambient.svg"
+            layer.enabled: true
+            state: currentColor
+
             transform: Rotation {
                 id: hourRotation
 
@@ -331,22 +483,26 @@ Item {
                 origin.y: root.height / 2
                 angle: 0
             }
-            layer.enabled: true
+
             layer.effect: DropShadow {
                 transparentBorder: true
-                horizontalOffset: root.width * .01
-                verticalOffset: root.width * .01
-                radius: root.width * .015
+                horizontalOffset: root.width * 0.01
+                verticalOffset: root.width * 0.01
+                radius: root.width * 0.015
                 samples: 13
                 color: "#22000000"
             }
-            state: currentColor
-            states: State { name: "black"
+
+            states: State {
+                name: "black"
+
                 PropertyChanges {
                     target: hourSVG
                     source: imgPath + "hour.svg"
                 }
+
             }
+
         }
 
         Image {
@@ -354,6 +510,9 @@ Item {
 
             anchors.fill: root
             source: !displayAmbient ? imgPath + "minute-ambient.svg" : imgPath + "minute-ambient.svg"
+            layer.enabled: true
+            state: currentColor
+
             transform: Rotation {
                 id: minuteRotation
 
@@ -361,22 +520,26 @@ Item {
                 origin.y: root.height / 2
                 angle: 0
             }
-            layer.enabled: true
+
             layer.effect: DropShadow {
                 transparentBorder: true
-                horizontalOffset: root.width * .015
-                verticalOffset: root.width * .015
-                radius: root.width * .02
+                horizontalOffset: root.width * 0.015
+                verticalOffset: root.width * 0.015
+                radius: root.width * 0.02
                 samples: 17
                 color: "#22000000"
             }
-            state: currentColor
-            states: State { name: "black"
+
+            states: State {
+                name: "black"
+
                 PropertyChanges {
                     target: minuteSVG
                     source: imgPath + "minute.svg"
                 }
+
             }
+
         }
 
         Image {
@@ -387,6 +550,21 @@ Item {
             anchors.fill: root
             visible: !displayAmbient
             source: imgPath + "second-ambient.svg"
+            state: currentColor
+
+            MouseArea {
+                anchors.fill: parent
+                onDoubleClicked: {
+                    if (secondSVG.toggle === 1) {
+                        currentColor = "black";
+                        secondSVG.toggle = 0;
+                    } else {
+                        currentColor = "";
+                        secondSVG.toggle = 1;
+                    }
+                }
+            }
+
             transform: Rotation {
                 id: secondRotation
 
@@ -394,34 +572,27 @@ Item {
                 origin.y: root.height / 2
                 angle: 0
             }
-            MouseArea {
-                anchors.fill: parent
-                onDoubleClicked: {
-                    if (secondSVG.toggle === 1) {
-                        currentColor = "black"
-                        secondSVG.toggle = 0
-                    } else {
-                        currentColor = ""
-                        secondSVG.toggle = 1
-                    }
-                }
-            }
-            state: currentColor
-            states: State { name: "black"
+
+            states: State {
+                name: "black"
+
                 PropertyChanges {
                     target: secondSVG
                     source: imgPath + "second.svg"
                 }
+
             }
+
         }
-        
+
         Connections {
             function onTimeChanged() {
-                var hours = wallClock.time.getHours()
-                var minutes = wallClock.time.getMinutes()
-                hourRotation.angle = (hours * 30) + (minutes * .5)
-                minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
+                var hours = wallClock.time.getHours();
+                var minutes = wallClock.time.getMinutes();
+                hourRotation.angle = (hours * 30) + (minutes * 0.5);
+                minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * 0.1);
             }
+
             target: wallClock
         }
 
@@ -430,33 +601,30 @@ Item {
             repeat: true
             running: !displayAmbient && visible
             onTriggered: {
-                var now = new Date()
-                secondRotation.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+                var now = new Date();
+                secondRotation.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000;
             }
         }
 
-        Component.onCompleted: {
-            var hours = wallClock.time.getHours()
-            var minutes = wallClock.time.getMinutes()
-            hourRotation.angle = (hours * 30) + (minutes * .5)
-            minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
-        }
     }
 
     Connections {
         function onDisplayAmbientEntered() {
             if (currentColor == "black") {
-                currentColor = ""
-                userColor = "black"
+                currentColor = "";
+                userColor = "black";
             } else {
-                userColor = ""
+                userColor = "";
             }
         }
+
         function onDisplayAmbientLeft() {
-            if (userColor == "black") {
-                currentColor = "black"
-            }
+            if (userColor == "black")
+                currentColor = "black";
+
         }
+
         target: compositor
     }
+
 }

--- a/src/watchfaces/010-analog-aviator.qml
+++ b/src/watchfaces/010-analog-aviator.qml
@@ -33,13 +33,6 @@ Item {
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
             visible: nightstandMode.active
 
             Repeater {
@@ -53,8 +46,8 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .015
                 property real scalefactor: .49 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
@@ -66,20 +59,19 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.RoundCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }

--- a/src/watchfaces/010-analog-aviator.qml
+++ b/src/watchfaces/010-analog-aviator.qml
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/010-analog-aviator.qml
+++ b/src/watchfaces/010-analog-aviator.qml
@@ -87,10 +87,10 @@ Item {
             layer.enabled: true
             layer.effect: DropShadow {
                 transparentBorder: true
-                horizontalOffset: 2
-                verticalOffset: 2
-                radius: 12.0
-                samples: 17
+                horizontalOffset: root.width * .005
+                verticalOffset: root.width * .005
+                radius: root.width * .03
+                samples: 25
                 color: "#bb000000"
             }
 
@@ -321,20 +321,21 @@ Item {
             id: hourSVG
 
             anchors.fill: root
-
             source: !displayAmbient ? imgPath + "hour-ambient.svg" : imgPath + "hour-ambient.svg"
             transform: Rotation {
-                origin.x: root.width / 2;
-                origin.y: root.height / 2;
-                angle: (wallClock.time.getHours()*30) + (wallClock.time.getMinutes() * 0.5)
+                id: hourRotation
+
+                origin.x: root.width / 2
+                origin.y: root.height / 2
+                angle: 0
             }
             layer.enabled: true
             layer.effect: DropShadow {
                 transparentBorder: true
-                horizontalOffset: 4
-                verticalOffset: 4
-                radius: 6.0
-                samples: 17
+                horizontalOffset: root.width * .01
+                verticalOffset: root.width * .01
+                radius: root.width * .015
+                samples: 13
                 color: "#22000000"
             }
             state: currentColor
@@ -350,19 +351,20 @@ Item {
             id: minuteSVG
 
             anchors.fill: root
-
             source: !displayAmbient ? imgPath + "minute-ambient.svg" : imgPath + "minute-ambient.svg"
             transform: Rotation {
-                origin.x: root.width / 2;
-                origin.y: root.height / 2;
-                angle: (wallClock.time.getMinutes()*6)+(wallClock.time.getSeconds() * 6 / 60)
+                id: minuteRotation
+
+                origin.x: root.width / 2
+                origin.y: root.height / 2
+                angle: 0
             }
             layer.enabled: true
             layer.effect: DropShadow {
                 transparentBorder: true
-                horizontalOffset: 6
-                verticalOffset: 6
-                radius: 8.0
+                horizontalOffset: root.width * .015
+                verticalOffset: root.width * .015
+                radius: root.width * .02
                 samples: 17
                 color: "#22000000"
             }
@@ -381,30 +383,22 @@ Item {
             property int toggle: 1
 
             anchors.fill: root
-
             visible: !displayAmbient
             source: imgPath + "second-ambient.svg"
             transform: Rotation {
-                origin.x: root.width / 2;
-                origin.y: root.height / 2;
-                angle: (wallClock.time.getSeconds() * 6)
-            }
-            layer.enabled: true
-            layer.effect: DropShadow {
-                transparentBorder: true
-                horizontalOffset: 8
-                verticalOffset: 8
-                radius: 9.0
-                samples: 12
-                color: "#22000000"
+                id: secondRotation
+
+                origin.x: root.width / 2
+                origin.y: root.height / 2
+                angle: 0
             }
             MouseArea {
                 anchors.fill: parent
                 onDoubleClicked: {
-                   if (secondSVG.toggle === 1) {
+                    if (secondSVG.toggle === 1) {
                         currentColor = "black"
                         secondSVG.toggle = 0
-                   } else {
+                    } else {
                         currentColor = ""
                         secondSVG.toggle = 1
                     }
@@ -418,19 +412,49 @@ Item {
                 }
             }
         }
+        
+        Connections {
+            function onTimeChanged() {
+                var hours = wallClock.time.getHours()
+                var minutes = wallClock.time.getMinutes()
+                hourRotation.angle = (hours * 30) + (minutes * .5)
+                minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
+            }
+            target: wallClock
+        }
+
+        Timer {
+            interval: 16
+            repeat: true
+            running: !displayAmbient && visible
+            onTriggered: {
+                var now = new Date()
+                secondRotation.angle = (now.getSeconds() * 1000 + now.getMilliseconds()) * 6 / 1000
+            }
+        }
+
+        Component.onCompleted: {
+            var hours = wallClock.time.getHours()
+            var minutes = wallClock.time.getMinutes()
+            hourRotation.angle = (hours * 30) + (minutes * .5)
+            minuteRotation.angle = (minutes * 6) + (wallClock.time.getSeconds() * .1)
+        }
     }
 
     Connections {
+        function onDisplayAmbientEntered() {
+            if (currentColor == "black") {
+                currentColor = ""
+                userColor = "black"
+            } else {
+                userColor = ""
+            }
+        }
+        function onDisplayAmbientLeft() {
+            if (userColor == "black") {
+                currentColor = "black"
+            }
+        }
         target: compositor
-        onDisplayAmbientEntered: if (currentColor == "black") {
-                                     currentColor = ""
-                                     userColor = "black"
-                                 }
-                                 else
-                                     userColor = ""
-
-        onDisplayAmbientLeft:    if (userColor == "black") {
-                                     currentColor = "black"
-                                 }
     }
 }

--- a/src/watchfaces/010-analog-aviator.qml
+++ b/src/watchfaces/010-analog-aviator.qml
@@ -123,13 +123,15 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: -parent.height * 0.146
                 }
-                visible: !displayAmbient
                 font {
                     pixelSize: parent.height * 0.048
                     family: "Raleway"
                 }
+                renderType: Text.NativeRendering
+                visible: !displayAmbient
                 color: "#bbffffff"
                 horizontalAlignment: Text.AlignHCenter
+                textFormat: Text.StyledText
                 text: "<b>AsteroidOS</b><br>Free Your Wrist"
                 state: currentColor
                 states: State { name: "black";
@@ -148,13 +150,15 @@ Item {
                     centerIn: parent
                     verticalCenterOffset: parent.height*0.14
                 }
-                visible: !displayAmbient
                 font {
                     pixelSize: parent.height * 0.052
                     family: "Raleway"
                 }
+                renderType: Text.NativeRendering
+                visible: !displayAmbient
                 color: "#bbffffff"
                 horizontalAlignment: Text.AlignHCenter
+                textFormat: Text.StyledText
                 text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b> MMMM<br>yyyy")
                 state: currentColor
                 states: State { name: "black";
@@ -169,19 +173,16 @@ Item {
             Text {
                 id: apDisplay
 
-                property int day: wallClock.time.toLocaleString(Qt.locale(), "d")
-                property int month: wallClock.time.toLocaleString(Qt.locale(), "M")
-
                 anchors {
                     centerIn: parent
                     verticalCenterOffset: parent.height / 3.8
-                    horizontalCenterOffset: parent.width/3.8
+                    horizontalCenterOffset: parent.width / 3.8
                 }
                 font {
                     pixelSize: parent.height * 0.065
                     family: "PTSans"
-                    styleName: "Regular"
                 }
+                renderType: Text.NativeRendering
                 color: "white"
                 horizontalAlignment: Text.AlignHCenter
                 text: wallClock.time.toLocaleString(Qt.locale(), "ap").toUpperCase()
@@ -204,10 +205,10 @@ Item {
                     horizontalCenterOffset: -parent.width / 3.8
                 }
                 font {
-                    pixelSize: parent.height*0.065
+                    pixelSize: parent.height * 0.065
                     family: "PTSans"
-                    styleName: "Regular"
                 }
+                renderType: Text.NativeRendering
                 color: "white"
                 horizontalAlignment: Text.AlignHCenter
                 text: wallClock.time.toLocaleString(Qt.locale(), "ddd").slice(0, 2).toUpperCase()
@@ -264,6 +265,7 @@ Item {
                         pixelSize: parent.height * 0.21
                         family: "Signika"
                     }
+                    renderType: Text.NativeRendering
                     x: centerX+Math.cos(rotM * 2 * Math.PI) * parent.width * 0.35
                     y: centerY+Math.sin(rotM * 2 * Math.PI) * parent.width * 0.35
                     color: "#ccffffff"


### PR DESCRIPTION
Qt6 refactor of the 010-analog-aviator watchface. Five commits covering SPDX header, nightstand arc correctness, animation system overhaul including smooth second hand, text rendering, and a conventions and qmlformat pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Single author, creation year 2023 preserved. Updates handle from `eLtMosen` to `moWerk`.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Adds `| 0` bitwise cast to `chargecolor`; Qt6 rejects implicit double-to-int coercion on array index access. Replaces `parent` references in `ShapePath` and `PathAngleArc` with `root`; the parent chain inside both resolves to items with no geometry. Collapses `sweepAngle` ternary to a single line and normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Fix Qt6 animation system** — converts `dialBox` `DropShadow` offset, radius, and samples to screen-relative fractions of `root.width`. Removes direct `wallClock.time` rotation bindings from `hourSVG` and `minuteSVG`; introduces named `Rotation` ids `hourRotation`, `minuteRotation`, and `secondRotation`; replaces bindings with a `Connections` block and `Component.onCompleted` initialisation for correct startup angle. Removes the `layer` block and `DropShadow` entirely from `secondSVG`; a DropShadow on a 60fps hand forces a full shader recomposite on every frame. Adds a 16ms `Timer` for smooth second hand motion using `new Date()` millisecond precision — the second hand now sweeps continuously rather than jumping once per wallClock tick. Converts the `compositor` `Connections` handler syntax from deprecated `onSignalName:` form to `function onSignalName()` form.

4. **Add Qt6 text rendering properties** — adds `renderType: Text.NativeRendering` to all Text items missing it: `asteroidSlogan`, `dateDisplay`, `apDisplay`, `dowDisplay`, and the `hourNumbers` delegate. Adds `textFormat: Text.StyledText` to `asteroidSlogan` and `dateDisplay`; both use `<b>` and `<br>` markup and Qt6 AutoText mode treats `<br>` as a paragraph boundary rather than an inline line break. Removes the dead `property int day` and `property int month` from `apDisplay`; both were declared but never referenced. Removes `font.styleName: "Regular"` from `apDisplay` and `dowDisplay` as it is the default value.

5. **Conventions, formatting, and qmlformat pass** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.controls` and `org.asteroid.utils`, neither of which has any references in the file. Replaces root square sizing ternary with `Math.min`. Full `qmlformat -i` normalisation pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: tick ring, hour strokes, hour numerals, SVG hands, and all text elements render correctly.
- Second hand sweeps smoothly at 60fps via 16ms Timer; no catch-up sweep on wake from ambient.
- Colour theme toggle: double-tap on the second hand switches between white and black theme correctly. All elements transition via `ColorAnimation`.
- Ambient entry/exit: theme state is correctly preserved across ambient transitions via the `compositor` Connections block.
- `asteroidSlogan` and `dateDisplay`: two-line layout correct with `textFormat: Text.StyledText`.
- 12h/24h toggle: `apDisplay` responds correctly.
- Nightstand mode: battery arc renders correctly, no multisample renderbuffer journal warning.
- AoD: second hand hidden, correct opacity and source changes on all state-driven elements.
- No regressions found across all five commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- `hourSVG` has a redundant `displayAmbient` ternary where both branches resolve to `"hour-ambient.svg"`. The coloured variant is loaded via the `state: currentColor` system rather than the ambient ternary. This pre-existing behaviour is intentional and preserved unchanged.
- No visual tuning commit was needed — the face renders identically on Qt5 and Qt6.