### PR TITLE
Refactor 012-analog-words watchface for Qt6

### DIFF
--- a/src/watchfaces/012-analog-words.qml
+++ b/src/watchfaces/012-analog-words.qml
@@ -2,16 +2,12 @@
 // SPDX-FileCopyrightText: 2021 Ed Beroset <github.com/beroset>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
-    anchors.fill: parent
-
     property string currentColor: ""
     property string userColor: ""
     property int hour: wallClock.time.toLocaleString(Qt.locale(), "h ap").slice(0, 2) === "12" ? 0 : wallClock.time.toLocaleString(Qt.locale(), "h ap").slice(0, 2)
@@ -30,12 +26,13 @@ Item {
     property var wordsTR: ["on iki", "bir", "iki", "üç", "dört", "beş", "altı", "yedi", "sekiz", "dokuz", "on", "onbir"]
     property var wordsNB: ["tolv", "en", "to", "tre", "fire", "fem", "seks", "syv", "åtte", "ni", "ti", "elleve"]
 
+    anchors.fill: parent
+
     Item {
         id: root
 
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
-
         anchors.centerIn: parent
 
         Item {
@@ -55,17 +52,17 @@ Item {
                 property int gap: 6
                 property int endFromStart: 360
                 property bool clockwise: true
-                property real arcStrokeWidth: .02
-                property real scalefactor: .48 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.02
+                property real scalefactor: 0.48 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 model: segmentAmount
 
                 Shape {
                     id: segment
 
-                    visible: index === 0 ? true : (index/segmentedArc.segmentAmount) < segmentedArc.inputValue
+                    visible: index === 0 ? true : (index / segmentedArc.segmentAmount) < segmentedArc.inputValue
 
                     ShapePath {
                         fillColor: "transparent"
@@ -74,7 +71,7 @@ Item {
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
                         startX: root.width / 2
-                        startY: root.height * (.5 - segmentedArc.scalefactor)
+                        startY: root.height * (0.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
                             centerX: root.width / 2
@@ -85,9 +82,13 @@ Item {
                             sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
+
                     }
+
                 }
+
             }
+
         }
 
         MceBatteryLevel {
@@ -96,11 +97,12 @@ Item {
 
         Rectangle {
             id: circleBack
-            // z: 2 retained — must always paint above backRectangles delegates whose z is dynamic (hour == index ? 1 : 0)
-            z: 2
 
             property var toggle: 1
-            antialiasing : true
+
+            // z: 2 retained — must always paint above backRectangles delegates whose z is dynamic (hour == index ? 1 : 0)
+            z: 2
+            antialiasing: true
             x: parent.width / 2 - width / 2
             y: parent.height / 2 - height / 2
             color: "white"
@@ -109,16 +111,17 @@ Item {
             radius: width * 0.5
 
             Text {
-                    id: minuteDisplay
+                id: minuteDisplay
 
-                    font.pixelSize: parent.height * 0.549
-                    font.family: "Montserrat"
-                    renderType: Text.NativeRendering
-                    color: "black"
-                    opacity: 1
-                    anchors.centerIn: parent
-                    text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+                font.pixelSize: parent.height * 0.549
+                font.family: "Montserrat"
+                renderType: Text.NativeRendering
+                color: "black"
+                opacity: 1
+                anchors.centerIn: parent
+                text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
+
         }
 
         Repeater {
@@ -126,18 +129,20 @@ Item {
 
             Rectangle {
                 id: backRectangles
-                z: hour == index ? 1 : 0
 
+                z: hour == index ? 1 : 0
                 antialiasing: true
                 width: hourText.paintedWidth + (hourText.x * 1.21)
                 height: parent.height * 0.138
                 color: hour == index ? "white" : colorOffset[index]
                 opacity: 1
                 radius: width * 0.5
+                state: currentColor
+                layer.enabled: true
                 transform: [
                     Rotation {
-                        origin.x: backRectangles.height / 2;
-                        origin.y: backRectangles.height / 2;
+                        origin.x: backRectangles.height / 2
+                        origin.y: backRectangles.height / 2
                         angle: ((index) * 30) - 90
                     },
                     Translate {
@@ -145,22 +150,13 @@ Item {
                         y: (parent.height - backRectangles.height) / 2
                     }
                 ]
-                state: currentColor
-                states: State { name: "black";
-                    PropertyChanges { target: backRectangles;
-                        color: hour == index ? "white" : "black" }
-                }
-                transitions: Transition {
-                    from: ""; to: "black"; reversible: true
-                        ColorAnimation { duration: 500 }
-                }
 
                 Text {
                     id: hourText
 
                     property var heightFontOffest: (index > 0 && index < 7) ? -parent.height * 0.05 : parent.height * 0.05
 
-                    font.pixelSize: parent.height * (hour == index ? 0.70 : 0.56)
+                    font.pixelSize: parent.height * (hour == index ? 0.7 : 0.56)
                     font.family: "SourceSansPro"
                     font.weight: hour == index ? Font.DemiBold : Font.Light
                     font.letterSpacing: hour == index ? -parent.height * 0.02 : parent.height * 0.001
@@ -168,36 +164,60 @@ Item {
                     color: "black"
                     x: hour == index ? parent.height * 1.58 : parent.height * 1.94
                     y: ((parent.height - hourText.height) / 2) + heightFontOffest
-                    text: Qt.locale().name.substring(0,2) === "de" ? wordsDE[index]:
-                          Qt.locale().name.substring(0,2) === "fr" ? wordsFR[index]:
-                          Qt.locale().name.substring(0,2) === "es" ? wordsES[index]:
-                          Qt.locale().name.substring(0,2) === "it" ? wordsIT[index]:
-                          Qt.locale().name.substring(0,2) === "nl" ? wordsNL[index]:
-                          Qt.locale().name.substring(0,2) === "el" ? wordsGR[index]:
-                          Qt.locale().name.substring(0,2) === "sv" ? wordsSV[index]:
-                          Qt.locale().name.substring(0,2) === "sk" ? wordsSK[index]:
-                          Qt.locale().name.substring(0,2) === "da" ? wordsDA[index]:
-                          Qt.locale().name.substring(0,2) === "pt" ? wordsPT[index]:
-                          Qt.locale().name.substring(0,2) === "tr" ? wordsTR[index]:
-                          Qt.locale().name.substring(0,2) === "nb" ? wordsNB[index]:
-                                                                     wordsEN[index]
+                    text: Qt.locale().name.substring(0, 2) === "de" ? wordsDE[index] : Qt.locale().name.substring(0, 2) === "fr" ? wordsFR[index] : Qt.locale().name.substring(0, 2) === "es" ? wordsES[index] : Qt.locale().name.substring(0, 2) === "it" ? wordsIT[index] : Qt.locale().name.substring(0, 2) === "nl" ? wordsNL[index] : Qt.locale().name.substring(0, 2) === "el" ? wordsGR[index] : Qt.locale().name.substring(0, 2) === "sv" ? wordsSV[index] : Qt.locale().name.substring(0, 2) === "sk" ? wordsSK[index] : Qt.locale().name.substring(0, 2) === "da" ? wordsDA[index] : Qt.locale().name.substring(0, 2) === "pt" ? wordsPT[index] : Qt.locale().name.substring(0, 2) === "tr" ? wordsTR[index] : Qt.locale().name.substring(0, 2) === "nb" ? wordsNB[index] : wordsEN[index]
+                    state: currentColor
+
                     transform: Rotation {
-                        origin.x: hourText.width / 2;
-                        origin.y: hourText.height / 2;
-                        /* flip text for readability for hours 1 through 6 */
+                        origin.x: hourText.width / 2
+                        origin.y: hourText.height / 2
+                        // flip text for readability for hours 1 through 6
                         angle: (index > 0 && index < 7) ? 0 : 180
                     }
-                    state: currentColor
-                    states: State { name: "black";
-                        PropertyChanges { target: hourText;
-                            color: hour == index ? "black" : "white" }
+
+                    states: State {
+                        name: "black"
+
+                        PropertyChanges {
+                            target: hourText
+                            color: hour == index ? "black" : "white"
+                        }
+
                     }
+
                     transitions: Transition {
-                        from: ""; to: "black"; reversible: true
-                            ColorAnimation { duration: 500 }
+                        from: ""
+                        to: "black"
+                        reversible: true
+
+                        ColorAnimation {
+                            duration: 500
+                        }
+
                     }
+
                 }
-                layer.enabled: true
+
+                states: State {
+                    name: "black"
+
+                    PropertyChanges {
+                        target: backRectangles
+                        color: hour == index ? "white" : "black"
+                    }
+
+                }
+
+                transitions: Transition {
+                    from: ""
+                    to: "black"
+                    reversible: true
+
+                    ColorAnimation {
+                        duration: 500
+                    }
+
+                }
+
                 layer.effect: DropShadow {
                     transparentBorder: true
                     horizontalOffset: 3
@@ -206,26 +226,30 @@ Item {
                     samples: 17
                     color: "#50000000"
                 }
+
             }
+
         }
 
         Connections {
-            target: compositor
-
             function onDisplayAmbientEntered() {
                 if (currentColor == "") {
-                    currentColor = "black"
-                    userColor = ""
+                    currentColor = "black";
+                    userColor = "";
+                } else {
+                    userColor = "black";
                 }
-                else
-                    userColor = "black"
             }
 
             function onDisplayAmbientLeft() {
-                if (userColor == "") {
-                    currentColor = ""
-                }
+                if (userColor == "")
+                    currentColor = "";
+
             }
+
+            target: compositor
         }
+
     }
+
 }

--- a/src/watchfaces/012-analog-words.qml
+++ b/src/watchfaces/012-analog-words.qml
@@ -44,13 +44,6 @@ Item {
             readonly property bool active: nightstand
 
             anchors.fill: parent
-
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
             visible: nightstandMode.active
 
             Repeater {
@@ -64,8 +57,8 @@ Item {
                 property bool clockwise: true
                 property real arcStrokeWidth: .02
                 property real scalefactor: .48 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 model: segmentAmount
 
@@ -77,20 +70,19 @@ Item {
                     ShapePath {
                         fillColor: "transparent"
                         strokeColor: segmentedArc.colorArray[segmentedArc.chargecolor]
-                        strokeWidth: parent.height * segmentedArc.arcStrokeWidth
+                        strokeWidth: root.height * segmentedArc.arcStrokeWidth
                         capStyle: ShapePath.FlatCap
                         joinStyle: ShapePath.MiterJoin
-                        startX: parent.width / 2
-                        startY: parent.height * ( .5 - segmentedArc.scalefactor)
+                        startX: root.width / 2
+                        startY: root.height * (.5 - segmentedArc.scalefactor)
 
                         PathAngleArc {
-                            centerX: parent.width / 2
-                            centerY: parent.height / 2
-                            radiusX: segmentedArc.scalefactor * parent.width
-                            radiusY: segmentedArc.scalefactor * parent.height
+                            centerX: root.width / 2
+                            centerY: root.height / 2
+                            radiusX: segmentedArc.scalefactor * root.width
+                            radiusY: segmentedArc.scalefactor * root.height
                             startAngle: -90 + index * (sweepAngle + (segmentedArc.clockwise ? +segmentedArc.gap : -segmentedArc.gap)) + segmentedArc.start
-                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap :
-                                                                 -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
+                            sweepAngle: segmentedArc.clockwise ? (segmentedArc.endFromStart / segmentedArc.segmentAmount) - segmentedArc.gap : -(segmentedArc.endFromStart / segmentedArc.segmentAmount) + segmentedArc.gap
                             moveToStart: true
                         }
                     }

--- a/src/watchfaces/012-analog-words.qml
+++ b/src/watchfaces/012-analog-words.qml
@@ -1,22 +1,6 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2021 - Ed Beroset <github.com/beroset>
- *
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2021 Ed Beroset <github.com/beroset>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/012-analog-words.qml
+++ b/src/watchfaces/012-analog-words.qml
@@ -96,6 +96,7 @@ Item {
 
         Rectangle {
             id: circleBack
+            // z: 2 retained — must always paint above backRectangles delegates whose z is dynamic (hour == index ? 1 : 0)
             z: 2
 
             property var toggle: 1
@@ -108,15 +109,15 @@ Item {
             radius: width * 0.5
 
             Text {
-                id: minuteDisplay
+                    id: minuteDisplay
 
-                font.pixelSize: parent.height * 0.549
-                font.family: "Montserrat"
-                font.styleName: "Regular"
-                color: "black"
-                opacity: 1
-                anchors.centerIn: parent
-                text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+                    font.pixelSize: parent.height * 0.549
+                    font.family: "Montserrat"
+                    renderType: Text.NativeRendering
+                    color: "black"
+                    opacity: 1
+                    anchors.centerIn: parent
+                    text: wallClock.time.toLocaleString(Qt.locale(), "mm")
             }
         }
 
@@ -161,8 +162,9 @@ Item {
 
                     font.pixelSize: parent.height * (hour == index ? 0.70 : 0.56)
                     font.family: "SourceSansPro"
-                    font.styleName: hour == index ? "Semibold" : "Light"
+                    font.weight: hour == index ? Font.DemiBold : Font.Light
                     font.letterSpacing: hour == index ? -parent.height * 0.02 : parent.height * 0.001
+                    renderType: Text.NativeRendering
                     color: "black"
                     x: hour == index ? parent.height * 1.58 : parent.height * 1.94
                     y: ((parent.height - hourText.height) / 2) + heightFontOffest
@@ -200,7 +202,7 @@ Item {
                     transparentBorder: true
                     horizontalOffset: 3
                     verticalOffset: 3
-                    radius: 12.0
+                    radius: 12
                     samples: 17
                     color: "#50000000"
                 }


### PR DESCRIPTION
Qt6 refactor of the 012-analog-words watchface. Four commits covering SPDX header, nightstand arc correctness, text rendering, and a conventions and qmlformat pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Two authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Adds `| 0` bitwise cast to `chargecolor`; Qt6 rejects implicit double-to-int coercion on array index access. Replaces `parent` references in `ShapePath` and `PathAngleArc` with `root`; the parent chain inside both resolves to items with no geometry. Collapses `sweepAngle` ternary to a single line and normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Add Qt6 text rendering properties** — adds `renderType: Text.NativeRendering` to `minuteDisplay` and the `hourText` Repeater delegate. Removes `font.styleName: "Regular"` from `minuteDisplay` as it is the default value. Converts the conditional `font.styleName` on `hourText` from `"Semibold"` / `"Light"` to `font.weight: Font.DemiBold` / `Font.Light` enum constants. Adds a mandatory comment to the `z: 2` declaration on `circleBack`; the `backRectangles` Repeater delegates use dynamic `z` (`hour == index ? 1 : 0`) and `circleBack` must always paint above all delegates — declaration order cannot guarantee this and the `z: 2` must not be removed. Normalises `radius: 12.0` to `radius: 12` on the `backRectangles` DropShadow.

4. **Conventions, formatting, and qmlformat pass** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.controls` and `org.asteroid.utils`, neither of which has any references in the file. Replaces root square sizing ternary with `Math.min`. Full `qmlformat -i` normalisation pass; groups the flat `font.*` property declarations on `minuteDisplay` into a `font {}` block.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: all twelve coloured hour-word petals render correctly, current hour petal highlighted in white with enlarged text, minute display centred correctly.
- Hour word localisation: language selection responds correctly to system locale.
- Colour theme: ambient entry switches to black theme, ambient exit restores previous colour state correctly via `compositor` Connections.
- `circleBack` centre disc correctly paints above all petal delegates at all times.
- Nightstand mode: battery arc renders correctly, no multisample renderbuffer journal warning.
- AoD: colour theme transitions to black correctly on ambient entry.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`root`) prevents layout squish on non-square panels.
- `z: 2` on `circleBack` is intentional and must be preserved. The `backRectangles` Repeater delegates use dynamic `z: hour == index ? 1 : 0`; a static declaration order cannot guarantee `circleBack` always paints above the active delegate. This is the confirmed exception to the no-z-value rule documented in the project patterns.
- The `property int hour` binding always reads in 12h format regardless of the `use12H` setting. This is intentional — the face displays twelve named petals representing clock hours 0–11 and the highlighted petal always tracks the 12h hour position.
- No visual tuning commit was needed — the face renders identically on Qt5 and Qt6.