### PR TITLE
Refactor 013-analog-nordic watchface for Qt6

### DIFF
--- a/src/watchfaces/013-analog-nordic.qml
+++ b/src/watchfaces/013-analog-nordic.qml
@@ -33,30 +33,20 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .02
                 property real scalefactor: .471 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -65,7 +55,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2

--- a/src/watchfaces/013-analog-nordic.qml
+++ b/src/watchfaces/013-analog-nordic.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/013-analog-nordic.qml
+++ b/src/watchfaces/013-analog-nordic.qml
@@ -9,12 +9,11 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
 import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
     anchors.fill: parent
@@ -23,9 +22,28 @@ Item {
         id: rootitem
 
         anchors.centerIn: parent
-
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
+        Component.onCompleted: {
+            var hour = wallClock.time.getHours();
+            var minute = wallClock.time.getMinutes();
+            var second = wallClock.time.getSeconds();
+            secondHand.second = second;
+            secondHand.requestPaint();
+            minuteHand.minute = minute;
+            minuteHand.requestPaint();
+            hourHand.hour = hour;
+            hourHand.requestPaint();
+            hourStrokes.requestPaint();
+            minuteStrokes.requestPaint();
+            numberStrokes.requestPaint();
+            burnInProtectionManager.widthOffset = Qt.binding(function() {
+                return width * (nightstandMode.active ? 0.11 : 0.06);
+            });
+            burnInProtectionManager.heightOffset = Qt.binding(function() {
+                return height * (nightstandMode.active ? 0.11 : 0.06);
+            });
+        }
 
         Item {
             id: nightstandMode
@@ -39,10 +57,10 @@ Item {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                property real arcStrokeWidth: .02
-                property real scalefactor: .471 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.02
+                property real scalefactor: 0.471 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: parent
 
@@ -53,7 +71,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -64,20 +82,24 @@ Item {
                         sweepAngle: chargeArc.angle
                         moveToStart: false
                     }
+
                 }
+
             }
 
             Icon {
                 id: batteryIcon
 
                 name: "ios-battery-charging"
+                visible: nightstandMode.active
+                width: parent.width * 0.13
+                height: parent.height * 0.13
+
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: -parent.width * .16
+                    verticalCenterOffset: -parent.width * 0.16
                 }
-                visible: nightstandMode.active
-                width: parent.width * .13
-                height: parent.height * .13
+
             }
 
             ColorOverlay {
@@ -89,22 +111,26 @@ Item {
             Text {
                 id: batteryPercent
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: parent.width * .155
-                }
-                font {
-                    pixelSize: parent.width * .12
-                    family: "Noto Sans"
-                    styleName: "ExtraCondensed"
-                }
                 renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 style: Text.Outline
                 styleColor: "#80000000"
                 text: batteryChargePercentage.percent
+
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: parent.width * 0.155
+                }
+
+                font {
+                    pixelSize: parent.width * 0.12
+                    family: "Noto Sans"
+                    styleName: "ExtraCondensed"
+                }
+
             }
+
         }
 
         MceBatteryLevel {
@@ -115,7 +141,6 @@ Item {
             id: watchfaceRoot
 
             anchors.centerIn: parent
-
             width: parent.width
             height: width
 
@@ -126,23 +151,22 @@ Item {
                 smooth: true
                 renderStrategy: Canvas.Cooperative
                 onPaint: {
-                    var ctx = getContext("2d")
-
-                    ctx.lineWidth = parent.width*.0093
-                    ctx.strokeStyle = Qt.rgba(1, 1, 1, 1)
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .7)
-                    ctx.shadowOffsetX = 0
-                    ctx.shadowOffsetY = 0
-                    ctx.shadowBlur = 2
-                    ctx.translate(parent.width / 2, parent.height / 2)
+                    var ctx = getContext("2d");
+                    ctx.lineWidth = parent.width * 0.0093;
+                    ctx.strokeStyle = Qt.rgba(1, 1, 1, 1);
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0.7);
+                    ctx.shadowOffsetX = 0;
+                    ctx.shadowOffsetY = 0;
+                    ctx.shadowBlur = 2;
+                    ctx.translate(parent.width / 2, parent.height / 2);
                     for (var i = 0; i < 12; i++) {
-                        if ( i % 3 != 0) {
-                            ctx.beginPath()
-                            ctx.moveTo(0, parent.height * .3)
-                            ctx.lineTo(0, parent.height * .42)
-                            ctx.stroke()
+                        if (i % 3 != 0) {
+                            ctx.beginPath();
+                            ctx.moveTo(0, parent.height * 0.3);
+                            ctx.lineTo(0, parent.height * 0.42);
+                            ctx.stroke();
                         }
-                        ctx.rotate(Math.PI / 6)
+                        ctx.rotate(Math.PI / 6);
                     }
                 }
             }
@@ -154,21 +178,21 @@ Item {
                 smooth: true
                 renderStrategy: Canvas.Cooperative
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.lineWidth = parent.width * .014
-                    ctx.lineCap = "round"
-                    ctx.strokeStyle = Qt.rgba(1, 1, 1, 1)
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .7)
-                    ctx.shadowOffsetX = 0
-                    ctx.shadowOffsetY = 0
-                    ctx.shadowBlur = 2
-                    ctx.translate(parent.width / 2, parent.height / 2)
+                    var ctx = getContext("2d");
+                    ctx.lineWidth = parent.width * 0.014;
+                    ctx.lineCap = "round";
+                    ctx.strokeStyle = Qt.rgba(1, 1, 1, 1);
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0.7);
+                    ctx.shadowOffsetX = 0;
+                    ctx.shadowOffsetY = 0;
+                    ctx.shadowBlur = 2;
+                    ctx.translate(parent.width / 2, parent.height / 2);
                     for (var i = 0; i < 60; i++) {
-                        ctx.beginPath()
-                        ctx.moveTo(0, parent.height * .46)
-                        ctx.lineTo(0, parent.height * .461)
-                        ctx.stroke()
-                        ctx.rotate(Math.PI / 30)
+                        ctx.beginPath();
+                        ctx.moveTo(0, parent.height * 0.46);
+                        ctx.lineTo(0, parent.height * 0.461);
+                        ctx.stroke();
+                        ctx.rotate(Math.PI / 30);
                     }
                 }
             }
@@ -176,32 +200,27 @@ Item {
             Canvas {
                 id: numberStrokes
 
-                property real voffset: -parent.height * .025
+                property real voffset: -parent.height * 0.025
                 property real hoffset: parent.height * 0
 
                 anchors.fill: parent
                 antialiasing: true
                 smooth: true
                 renderStrategy: Canvas.Cooperative
-
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.fillStyle = Qt.rgba(1, 1, 1, .9)
-                    ctx.lineWidth = parent.height * .0124
-                    ctx.font = "0 " + parent.height * .18 + "px FatCow"
-                    ctx.textAlign = "center"
+                    var ctx = getContext("2d");
+                    ctx.fillStyle = Qt.rgba(1, 1, 1, 0.9);
+                    ctx.lineWidth = parent.height * 0.0124;
+                    ctx.font = "0 " + parent.height * 0.18 + "px FatCow";
+                    ctx.textAlign = "center";
                     ctx.textBaseline = 'middle';
-                    ctx.strokeStyle = Qt.rgba(0, 0, 0, .3)
-                    ctx.translate(parent.width / 2, parent.height / 2)
+                    ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.3);
+                    ctx.translate(parent.width / 2, parent.height / 2);
                     for (var i = 0; i < 12; i = i + 3) {
-                        ctx.beginPath()
-                        ctx.strokeText(i != 0 ? i: 12,
-                                                Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * .346 - hoffset,
-                                                Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * .346 - voffset)
-                        ctx.fillText(i != 0 ? i: 12,
-                                              Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * .34 - hoffset,
-                                              Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * .34 - voffset)
-                        ctx.closePath()
+                        ctx.beginPath();
+                        ctx.strokeText(i != 0 ? i : 12, Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * 0.346 - hoffset, Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * 0.346 - voffset);
+                        ctx.fillText(i != 0 ? i : 12, Math.cos((i - 3) / 12 * 2 * Math.PI) * parent.height * 0.34 - hoffset, Math.sin((i - 3) / 12 * 2 * Math.PI) * parent.height * 0.34 - voffset);
+                        ctx.closePath();
                     }
                 }
             }
@@ -214,62 +233,42 @@ Item {
                 anchors.fill: parent
                 smooth: true
                 renderStrategy: Canvas.Cooperative
-
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.reset()
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .6)
-                    ctx.shadowOffsetX = 3
-                    ctx.shadowOffsetY = 3
-                    ctx.shadowBlur = 4
-                    ctx.beginPath()
-                    ctx.lineWidth = parent.height*.004
-                    var gradient = ctx.createRadialGradient (parent.width / 2,
-                                                             parent.height / 2,
-                                                             0,
-                                                             parent.width / 2,
-                                                             parent.height / 2,
-                                                             parent.width * .285)
-                    gradient.addColorStop(.1, Qt.rgba(.2, .2, .2, 1)) // darker shaft
-                    gradient.addColorStop(.4, Qt.rgba(.4, .4, .4, 1)) // light gold center
-                    gradient.addColorStop(.6, Qt.rgba(.3, .3, .3, 1)) // dark gold tip
-
-                    ctx.strokeStyle = gradient
-
-                    var gradient2 = ctx.createLinearGradient (parent.width / 2 + Math.cos(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                                                              parent.height / 2 + Math.sin(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                                                              parent.width / 2 + Math.cos(((hour+0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                                                              parent.height / 2 + Math.sin(((hour+0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033)
-                    gradient2.addColorStop(.35, Qt.rgba(1, 1, 1, 1)) // darker gold
-                    gradient2.addColorStop(.5, Qt.rgba(.7, .7, .7, 1)) // light gold center
-                    gradient2.addColorStop(.65, Qt.rgba(1, 1, 1, 1)) // dark gold tip
-                    ctx.fillStyle = gradient2
-                    ctx.moveTo(parent.width/2+Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285,
-                               parent.height/2+Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 3.12 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                               parent.height/2+Math.sin(((hour - 3.12 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                               parent.height/2+Math.sin(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033,
-                               parent.height/2+Math.sin(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .033)
-
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 2.88 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                               parent.height/2+Math.sin(((hour - 2.88 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                    ctx.lineTo(parent.width/2+Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285,
-                               parent.height/2+Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .285)
-                    ctx.fill()
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .0)
-                    ctx.stroke()
-                    ctx.closePath()
-                    ctx.beginPath()
-                    ctx.strokeStyle = Qt.rgba(0, 0, 0, .4)
-                    ctx.lineWidth = parent.height * .003
-                    ctx.moveTo(parent.width / 2,
-                               parent.height / 2)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((hour-3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .284,
-                               parent.height / 2 + Math.sin(((hour-3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .284)
-                    ctx.stroke()
-                    ctx.closePath()
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0.6);
+                    ctx.shadowOffsetX = 3;
+                    ctx.shadowOffsetY = 3;
+                    ctx.shadowBlur = 4;
+                    ctx.beginPath();
+                    ctx.lineWidth = parent.height * 0.004;
+                    var gradient = ctx.createRadialGradient(parent.width / 2, parent.height / 2, 0, parent.width / 2, parent.height / 2, parent.width * 0.285);
+                    gradient.addColorStop(0.1, Qt.rgba(0.2, 0.2, 0.2, 1)); // darker shaft
+                    gradient.addColorStop(0.4, Qt.rgba(0.4, 0.4, 0.4, 1)); // light gold center
+                    gradient.addColorStop(0.6, Qt.rgba(0.3, 0.3, 0.3, 1)); // dark gold tip
+                    ctx.strokeStyle = gradient;
+                    var gradient2 = ctx.createLinearGradient(parent.width / 2 + Math.cos(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033, parent.height / 2 + Math.sin(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033, parent.width / 2 + Math.cos(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033, parent.height / 2 + Math.sin(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033);
+                    gradient2.addColorStop(0.35, Qt.rgba(1, 1, 1, 1)); // darker gold
+                    gradient2.addColorStop(0.5, Qt.rgba(0.7, 0.7, 0.7, 1)); // light gold center
+                    gradient2.addColorStop(0.65, Qt.rgba(1, 1, 1, 1)); // dark gold tip
+                    ctx.fillStyle = gradient2;
+                    ctx.moveTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.285, parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.285);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3.12 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275, parent.height / 2 + Math.sin(((hour - 3.12 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033, parent.height / 2 + Math.sin(((hour - 6 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033, parent.height / 2 + Math.sin(((hour + 0 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.033);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 2.88 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275, parent.height / 2 + Math.sin(((hour - 2.88 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.285, parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.285);
+                    ctx.fill();
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0);
+                    ctx.stroke();
+                    ctx.closePath();
+                    ctx.beginPath();
+                    ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.4);
+                    ctx.lineWidth = parent.height * 0.003;
+                    ctx.moveTo(parent.width / 2, parent.height / 2);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.284, parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.284);
+                    ctx.stroke();
+                    ctx.closePath();
                 }
             }
 
@@ -281,59 +280,40 @@ Item {
                 anchors.fill: parent
                 smooth: true
                 renderStrategy: Canvas.Cooperative
-
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.reset()
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .6)
-                    ctx.shadowOffsetX = 3
-                    ctx.shadowOffsetY = 3
-                    ctx.shadowBlur = 4
-                    ctx.beginPath()
-                    ctx.lineWidth = parent.height*.004
-                    var gradient = ctx.createRadialGradient (parent.width / 2,
-                                                             parent.height / 2,
-                                                             0,
-                                                             parent.width / 2,
-                                                             parent.height / 2,
-                                                             parent.width * .45)
-                    gradient.addColorStop(.1, Qt.rgba(.2, .2, .2, 1)) // darker shaft
-                    gradient.addColorStop(.4, Qt.rgba(.4, .4, .4, 1)) // light gold center
-                    gradient.addColorStop(.6, Qt.rgba(.3, .3, .3, 1)) // dark gold tip
-
-                    ctx.strokeStyle = gradient
-                    var gradient2 = ctx.createLinearGradient (parent.width / 2 + Math.cos(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
-                                                              parent.height / 2 + Math.sin(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
-                                                              parent.width / 2 + Math.cos(((minute + 0) / 60) * 2 * Math.PI) * width * .03,
-                                                              parent.height / 2 + Math.sin(((minute + 0) / 60) * 2 * Math.PI) * width * .03)
-                    gradient2.addColorStop(.35, Qt.rgba(1, 1, 1, 1)) // darker gold
-                    gradient2.addColorStop(.5, Qt.rgba(.7, .7, .7, 1)) // light gold center
-                    gradient2.addColorStop(.65, Qt.rgba(1, 1, 1, 1)) // dark gold tip
-
-                    ctx.fillStyle = gradient2
-                    ctx.moveTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * .45,
-                               parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * .45)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15.3) / 60) * 2 * Math.PI) * width * .445,
-                               parent.height / 2 + Math.sin(((minute - 15.3) / 60) * 2 * Math.PI) * width * .445)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 30) / 60) * 2 * Math.PI) * width * .03,
-                               parent.height / 2 + Math.sin(((minute - 30) / 60) * 2 * Math.PI) * width * .03)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute + 0) / 60) * 2 * Math.PI) * width * .03,
-                               parent.height / 2 + Math.sin(((minute + 0) / 60) * 2 * Math.PI) * width * .03)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 14.7) / 60) * 2 * Math.PI) * width * .445,
-                               parent.height / 2 + Math.sin(((minute - 14.7) / 60) * 2 * Math.PI) * width * .445)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * .45,
-                               parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * .45)
-                    ctx.fill()
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .0)
-                    ctx.stroke()
-                    ctx.lineWidth = parent.height * .003
-                    ctx.strokeStyle = Qt.rgba(0, 0, 0, .4)
-                    ctx.moveTo(parent.width / 2,
-                               parent.height / 2)
-                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15)/60) * 2 * Math.PI) * width * .448,
-                               parent.height / 2 + Math.sin(((minute - 15)/60) * 2 * Math.PI) * width * .448)
-                    ctx.stroke()
-                    ctx.closePath()
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0.6);
+                    ctx.shadowOffsetX = 3;
+                    ctx.shadowOffsetY = 3;
+                    ctx.shadowBlur = 4;
+                    ctx.beginPath();
+                    ctx.lineWidth = parent.height * 0.004;
+                    var gradient = ctx.createRadialGradient(parent.width / 2, parent.height / 2, 0, parent.width / 2, parent.height / 2, parent.width * 0.45);
+                    gradient.addColorStop(0.1, Qt.rgba(0.2, 0.2, 0.2, 1)); // darker shaft
+                    gradient.addColorStop(0.4, Qt.rgba(0.4, 0.4, 0.4, 1)); // light gold center
+                    gradient.addColorStop(0.6, Qt.rgba(0.3, 0.3, 0.3, 1)); // dark gold tip
+                    ctx.strokeStyle = gradient;
+                    var gradient2 = ctx.createLinearGradient(parent.width / 2 + Math.cos(((minute - 30) / 60) * 2 * Math.PI) * width * 0.03, parent.height / 2 + Math.sin(((minute - 30) / 60) * 2 * Math.PI) * width * 0.03, parent.width / 2 + Math.cos(((minute + 0) / 60) * 2 * Math.PI) * width * 0.03, parent.height / 2 + Math.sin(((minute + 0) / 60) * 2 * Math.PI) * width * 0.03);
+                    gradient2.addColorStop(0.35, Qt.rgba(1, 1, 1, 1)); // darker gold
+                    gradient2.addColorStop(0.5, Qt.rgba(0.7, 0.7, 0.7, 1)); // light gold center
+                    gradient2.addColorStop(0.65, Qt.rgba(1, 1, 1, 1)); // dark gold tip
+                    ctx.fillStyle = gradient2;
+                    ctx.moveTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * 0.45, parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * 0.45);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15.3) / 60) * 2 * Math.PI) * width * 0.445, parent.height / 2 + Math.sin(((minute - 15.3) / 60) * 2 * Math.PI) * width * 0.445);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 30) / 60) * 2 * Math.PI) * width * 0.03, parent.height / 2 + Math.sin(((minute - 30) / 60) * 2 * Math.PI) * width * 0.03);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute + 0) / 60) * 2 * Math.PI) * width * 0.03, parent.height / 2 + Math.sin(((minute + 0) / 60) * 2 * Math.PI) * width * 0.03);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 14.7) / 60) * 2 * Math.PI) * width * 0.445, parent.height / 2 + Math.sin(((minute - 14.7) / 60) * 2 * Math.PI) * width * 0.445);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * 0.45, parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * 0.45);
+                    ctx.fill();
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0);
+                    ctx.stroke();
+                    ctx.lineWidth = parent.height * 0.003;
+                    ctx.strokeStyle = Qt.rgba(0, 0, 0, 0.4);
+                    ctx.moveTo(parent.width / 2, parent.height / 2);
+                    ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * 0.448, parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * 0.448);
+                    ctx.stroke();
+                    ctx.closePath();
                 }
             }
 
@@ -346,32 +326,28 @@ Item {
                 smooth: true
                 renderStrategy: Canvas.Cooperative
                 visible: !displayAmbient && !nightstandMode.active
-
                 onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.reset()
-                    ctx.shadowColor = Qt.rgba(0, 0, 0, .7)
-                    ctx.shadowOffsetX = 5
-                    ctx.shadowOffsetY = 5
-                    ctx.shadowBlur = 3
-                    ctx.strokeStyle = "red"
-                    ctx.lineWidth = parent.height * .01
-                    ctx.beginPath()
-                    ctx.moveTo(parent.width / 2, parent.height / 2)
-                    ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .15,
-                               parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .15)
-                    ctx.stroke()
-                    ctx.closePath()
-                    ctx.beginPath()
-                    ctx.lineWidth = parent.height * .006
-                    ctx.arc(parent.width / 2, parent.height / 2, parent.height * .012, 0, 2 * Math.PI, false)
-                    ctx.fill()
-                    ctx.moveTo(parent.width / 2, parent.height / 2)
-                    ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * .45,
-                               parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .45)
-                    ctx.stroke()
-                    ctx.closePath()
-
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    ctx.shadowColor = Qt.rgba(0, 0, 0, 0.7);
+                    ctx.shadowOffsetX = 5;
+                    ctx.shadowOffsetY = 5;
+                    ctx.shadowBlur = 3;
+                    ctx.strokeStyle = "red";
+                    ctx.lineWidth = parent.height * 0.01;
+                    ctx.beginPath();
+                    ctx.moveTo(parent.width / 2, parent.height / 2);
+                    ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * 0.15, parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * 0.15);
+                    ctx.stroke();
+                    ctx.closePath();
+                    ctx.beginPath();
+                    ctx.lineWidth = parent.height * 0.006;
+                    ctx.arc(parent.width / 2, parent.height / 2, parent.height * 0.012, 0, 2 * Math.PI, false);
+                    ctx.fill();
+                    ctx.moveTo(parent.width / 2, parent.height / 2);
+                    ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * 0.45, parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * 0.45);
+                    ctx.stroke();
+                    ctx.closePath();
                 }
             }
 
@@ -379,49 +355,38 @@ Item {
                 id: nailDot
 
                 anchors.centerIn: parent
-                width: parent.height * .048
+                width: parent.height * 0.048
                 height: width
                 radius: width / 2
                 color: "transparent"
-                border.width: parent.height * .0185
+                border.width: parent.height * 0.0185
                 border.color: "black"
             }
+
         }
 
         Connections {
-            target: wallClock
             function onTimeChanged() {
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var second = wallClock.time.getSeconds()
-                if(secondHand.second !== second) {
-                    secondHand.second = second
-                    secondHand.requestPaint()
-                }if(hourHand.hour !== hour) {
-                    hourHand.hour = hour
-                }if(minuteHand.minute !== minute) {
-                    minuteHand.minute = minute
-                    minuteHand.requestPaint()
-                    hourHand.requestPaint()
+                var hour = wallClock.time.getHours();
+                var minute = wallClock.time.getMinutes();
+                var second = wallClock.time.getSeconds();
+                if (secondHand.second !== second) {
+                    secondHand.second = second;
+                    secondHand.requestPaint();
+                }
+                if (hourHand.hour !== hour)
+                    hourHand.hour = hour;
+
+                if (minuteHand.minute !== minute) {
+                    minuteHand.minute = minute;
+                    minuteHand.requestPaint();
+                    hourHand.requestPaint();
                 }
             }
+
+            target: wallClock
         }
 
-        Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var second = wallClock.time.getSeconds()
-            secondHand.second = second
-            secondHand.requestPaint()
-            minuteHand.minute = minute
-            minuteHand.requestPaint()
-            hourHand.hour = hour
-            hourHand.requestPaint()
-            hourStrokes.requestPaint()
-            minuteStrokes.requestPaint()
-            numberStrokes.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .11 : .06) })
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .11 : .06) })
-        }
     }
+
 }

--- a/src/watchfaces/013-analog-nordic.qml
+++ b/src/watchfaces/013-analog-nordic.qml
@@ -19,8 +19,6 @@ import Nemo.Mce
 Item {
     anchors.fill: parent
 
-    property real radian: .01745
-
     Item {
         id: rootitem
 
@@ -100,9 +98,11 @@ Item {
                     family: "Noto Sans"
                     styleName: "ExtraCondensed"
                 }
+                renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
+                style: Text.Outline
+                styleColor: "#80000000"
                 text: batteryChargePercentage.percent
             }
         }
@@ -375,23 +375,16 @@ Item {
                 }
             }
 
-            Canvas {
+            Rectangle {
                 id: nailDot
 
-                anchors.fill: parent
-                smooth: true
-                renderStrategy: Canvas.Cooperative
-
-                onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.reset()
-                    ctx.beginPath()
-                    ctx.strokeStyle = Qt.rgba(0, 0, 0, 1)
-                    ctx.lineWidth = parent.height * .0185
-                    ctx.arc(parent.width / 2, parent.height / 2, parent.height * .024, 0, 2 * Math.PI, false)
-                    ctx.stroke()
-                    ctx.closePath()
-                }
+                anchors.centerIn: parent
+                width: parent.height * .048
+                height: width
+                radius: width / 2
+                color: "transparent"
+                border.width: parent.height * .0185
+                border.color: "black"
             }
         }
 
@@ -427,8 +420,8 @@ Item {
             hourStrokes.requestPaint()
             minuteStrokes.requestPaint()
             numberStrokes.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .11 : .06)})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .11 : .06)})
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .11 : .06) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .11 : .06) })
         }
     }
 }


### PR DESCRIPTION
Qt6 refactor of the 013-analog-nordic watchface. Four commits covering SPDX header, nightstand arc correctness, partial Canvas conversion and text rendering, and a conventions and qmlformat pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Nine authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Removes the dead `batteryPercentChanged` property; the `chargeArc` angle binding already reads `batteryChargePercentage.percent` directly. Adds `| 0` bitwise cast to `chargecolor` and changes `property var` to `property int`; Qt6 rejects implicit double-to-int coercion on array index access. Removes `smooth: true` and `antialiasing: true` from `chargeArc` Shape, both are no-ops on Shape items. Normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Canvas partial conversion and text rendering** — converts `nailDot` Canvas to a `Rectangle` with `radius: width / 2` and a border. The Canvas drew a plain black ring outline using `ctx.arc` and `ctx.stroke` with no fill; the Rectangle with `color: transparent` and `border.color: black` is a direct equivalent with zero per-frame cost. Removes the now-dead `nailDot.requestPaint()` call from `Component.onCompleted`. Removes the dead `property real radian` declared at root level but never referenced by name in any Canvas handler. Adds `renderType: Text.NativeRendering` to `batteryPercent`. Splits `style` and `styleColor` onto separate lines. Retains `font.styleName: "ExtraCondensed"` intact as a compound Noto Sans width variant. The five remaining Canvas items are intentionally retained: `hourHand` and `minuteHand` use radial and linear gradient filled polygon geometry that has no `QtShapes` equivalent and defines the visual identity of the face; `hourStrokes`, `minuteStrokes`, and `numberStrokes` are static elements that paint once at startup with the double-stroke shadow on `numberStrokes` being an intentional artistic effect replicating a strong centre light source; `secondHand` is retained with per-second ticking as the design intent for this watchface.

4. **Conventions, formatting, and qmlformat pass** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.utils` which has no references in the file. Retains `org.asteroid.controls` for the `Icon` item used in the nightstand battery charging indicator. Replaces root square sizing ternary with `Math.min`. Full `qmlformat -i` normalisation pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: tick ring, minute dots, numerals, hour and minute hands all render correctly with gradient fill and shadow effects intact.
- Second hand ticks per second as intended for this watchface design.
- Centre nail dot renders correctly as a black ring over the hand pivot.
- Nightstand mode: battery arc, charging icon, and percentage text render correctly. No multisample renderbuffer journal warning.
- Burn-in protection: offsets initialised correctly for both normal and nightstand mode in `Component.onCompleted`.
- AoD: second hand correctly hidden via `visible: !displayAmbient && !nightstandMode.active`.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`rootitem`) prevents layout squish on non-square panels.
- Five Canvas items are retained by design. The hand geometry uses radial and linear gradients that have no declarative `QtShapes` equivalent. The static tick and numeral Canvas items paint once at startup and carry an intentional double-stroke shadow effect that replicates a strong centre light source — converting these would alter the established visual identity.
- `secondHand` is intentionally kept as a per-second Canvas repaint rather than a 16ms Timer sweep. The ticking second hand suits the minimalist Nordic aesthetic of this watchface.
- No visual tuning commit was needed — the face renders identically on Qt5 and Qt6.