### PR TITLE
Refactor 014-analog-50s-americana watchface for Qt6

### DIFF
--- a/src/watchfaces/014-analog-50s-americana.qml
+++ b/src/watchfaces/014-analog-50s-americana.qml
@@ -29,23 +29,15 @@ Item {
         height: parent.width > parent.height ? parent.height : parent.width
         width: height
 
-        Canvas {
+        Rectangle {
             id: backCircle
 
-            anchors.fill: parent
-            antialiasing: true
-            smooth: true
-            renderStrategy: Canvas.Cooperative
+            anchors.centerIn: parent
+            width: parent.width
+            height: width
+            radius: width / 2
+            color: Qt.rgba(1, 1, 1, .20)
             visible: !displayAmbient
-            onPaint: {
-                var ctx = getContext("2d")
-                ctx.reset()
-                ctx.fillStyle = Qt.rgba(1, 1, 1, .20)
-                ctx.beginPath()
-                ctx.arc(parent.height / 2, parent.width / 2, parent.width * .5, 0*radian, 360 * radian, false);
-                ctx.fill()
-                ctx.closePath()
-            }
         }
 
         Item {
@@ -99,9 +91,11 @@ Item {
                     pixelSize: parent.width * .14
                     family: "Fyodor"
                 }
+                renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
+                style: Text.Outline
+                styleColor: "#80000000"
                 text: batteryChargePercentage.percent
             }
         }
@@ -364,8 +358,8 @@ Item {
             secondHand.requestPaint()
             minuteHand.minute = minute
             minuteHand.requestPaint()
-            hourHand.hour = hournightstandMode
+            hourHand.hour = hour
             hourHand.requestPaint()
-         }
+        }
     }
 }

--- a/src/watchfaces/014-analog-50s-americana.qml
+++ b/src/watchfaces/014-analog-50s-americana.qml
@@ -1,28 +1,13 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/014-analog-50s-americana.qml
+++ b/src/watchfaces/014-analog-50s-americana.qml
@@ -52,30 +52,20 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .04
                 property real scalefactor: .482 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -84,7 +74,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2

--- a/src/watchfaces/014-analog-50s-americana.qml
+++ b/src/watchfaces/014-analog-50s-americana.qml
@@ -9,25 +9,33 @@
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
-    anchors.fill: parent
+    property real radian: 0.01745
 
-    property real radian: .01745
+    anchors.fill: parent
 
     Item {
         id: rootitem
 
         anchors.centerIn: parent
-
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
+        Component.onCompleted: {
+            var hour = wallClock.time.getHours();
+            var minute = wallClock.time.getMinutes();
+            var second = wallClock.time.getSeconds();
+            secondHand.second = second;
+            secondHand.requestPaint();
+            minuteHand.minute = minute;
+            minuteHand.requestPaint();
+            hourHand.hour = hour;
+            hourHand.requestPaint();
+        }
 
         Rectangle {
             id: backCircle
@@ -36,7 +44,7 @@ Item {
             width: parent.width
             height: width
             radius: width / 2
-            color: Qt.rgba(1, 1, 1, .20)
+            color: Qt.rgba(1, 1, 1, 0.2)
             visible: !displayAmbient
         }
 
@@ -52,10 +60,10 @@ Item {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                property real arcStrokeWidth: .04
-                property real scalefactor: .482 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.04
+                property real scalefactor: 0.482 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: parent
 
@@ -66,7 +74,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -77,27 +85,33 @@ Item {
                         sweepAngle: chargeArc.angle
                         moveToStart: false
                     }
+
                 }
+
             }
 
             Text {
                 id: batteryPercent
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: -parent.width * .17
-                }
-                font {
-                    pixelSize: parent.width * .14
-                    family: "Fyodor"
-                }
                 renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 style: Text.Outline
                 styleColor: "#80000000"
                 text: batteryChargePercentage.percent
+
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: -parent.width * 0.17
+                }
+
+                font {
+                    pixelSize: parent.width * 0.14
+                    family: "Fyodor"
+                }
+
             }
+
         }
 
         MceBatteryLevel {
@@ -107,33 +121,28 @@ Item {
         Canvas {
             id: numberStrokes
 
-            property real voffset: -parent.height * .022
-            property real hoffset: -parent.height * .007
+            property real voffset: -parent.height * 0.022
+            property real hoffset: -parent.height * 0.007
 
             anchors.fill: parent
             antialiasing: true
             smooth: true
             renderStrategy: Canvas.Cooperative
-
             onPaint: {
-                var ctx = getContext("2d")
-                ctx.reset()
-                ctx.lineWidth = parent.height * .0031
-                ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, .7) : Qt.rgba(.1, .1, .1, 1)
-                ctx.strokeStyle = displayAmbient ? Qt.rgba(1, 1, 1, .3) : Qt.rgba(1, 1, 1, .4)
-                ctx.textAlign = "center"
-                ctx.textBaseline = 'middle'
-                ctx.translate(parent.width / 2, parent.height / 2)
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.lineWidth = parent.height * 0.0031;
+                ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.7) : Qt.rgba(0.1, 0.1, 0.1, 1);
+                ctx.strokeStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.4);
+                ctx.textAlign = "center";
+                ctx.textBaseline = 'middle';
+                ctx.translate(parent.width / 2, parent.height / 2);
                 for (var i = 1; i < 13; i++) {
-                    ctx.beginPath()
-                    ctx.font = height * .14 + "px Fyodor"
-                    ctx.fillText(i,
-                                 Math.cos((i - 3) / 12 * 2 * Math.PI) * height * .375 - hoffset,
-                                 (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * .375) - voffset)
-                    ctx.strokeText(i,
-                                 Math.cos((i - 3) / 12 * 2 * Math.PI) * height * .375 - hoffset,
-                                 (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * .375) - voffset)
-                    ctx.closePath()
+                    ctx.beginPath();
+                    ctx.font = height * 0.14 + "px Fyodor";
+                    ctx.fillText(i, Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.375 - hoffset, (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * 0.375) - voffset);
+                    ctx.strokeText(i, Math.cos((i - 3) / 12 * 2 * Math.PI) * height * 0.375 - hoffset, (Math.sin((i - 3) / 12 * 2 * Math.PI) * height * 0.375) - voffset);
+                    ctx.closePath();
                 }
             }
         }
@@ -145,17 +154,16 @@ Item {
             smooth: true
             renderStrategy: Canvas.Cooperative
             onPaint: {
-                var ctx = getContext("2d")
-
-                ctx.lineWidth = parent.width * .015
-                ctx.strokeStyle = Qt.rgba(.1, .1, .1, .9)
-                ctx.translate(parent.width / 2, parent.height / 2)
+                var ctx = getContext("2d");
+                ctx.lineWidth = parent.width * 0.015;
+                ctx.strokeStyle = Qt.rgba(0.1, 0.1, 0.1, 0.9);
+                ctx.translate(parent.width / 2, parent.height / 2);
                 for (var i = 0; i < 12; i++) {
-                    ctx.beginPath()
-                    ctx.moveTo(0, height * .44)
-                    ctx.lineTo(0, height * .47)
-                    ctx.stroke()
-                    ctx.rotate(Math.PI / 6)
+                    ctx.beginPath();
+                    ctx.moveTo(0, height * 0.44);
+                    ctx.lineTo(0, height * 0.47);
+                    ctx.stroke();
+                    ctx.rotate(Math.PI / 6);
                 }
             }
         }
@@ -167,19 +175,19 @@ Item {
             smooth: true
             renderStrategy: Canvas.Cooperative
             onPaint: {
-                var ctx = getContext("2d")
-                ctx.lineWidth = parent.width * .007
-                ctx.strokeStyle = Qt.rgba(.1, .1, .1, .9)
-                ctx.translate(parent.width / 2, parent.height / 2)
+                var ctx = getContext("2d");
+                ctx.lineWidth = parent.width * 0.007;
+                ctx.strokeStyle = Qt.rgba(0.1, 0.1, 0.1, 0.9);
+                ctx.translate(parent.width / 2, parent.height / 2);
                 for (var i = 0; i < 60; i++) {
                     // do not paint a minute stroke when there is an hour stroke
                     if ((i % 5) != 0) {
-                        ctx.beginPath()
-                        ctx.moveTo(0, height * .45)
-                        ctx.lineTo(0, height * .47)
-                        ctx.stroke()
+                        ctx.beginPath();
+                        ctx.moveTo(0, height * 0.45);
+                        ctx.lineTo(0, height * 0.47);
+                        ctx.stroke();
                     }
-                    ctx.rotate(Math.PI / 30)
+                    ctx.rotate(Math.PI / 30);
                 }
             }
         }
@@ -187,20 +195,23 @@ Item {
         Text {
             id: monthDisplay
 
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: parent.width*.015
-                verticalCenter: parent.verticalCenter
-                verticalCenterOffset: parent.height*.195
-            }
-            font {
-                pixelSize: parent.height * .08
-                family: "Fyodor"
-            }
             renderType: Text.NativeRendering
-            color: displayAmbient ? Qt.rgba(1, 1, 1, .7) : "black"
+            color: displayAmbient ? Qt.rgba(1, 1, 1, 0.7) : "black"
             horizontalAlignment: Text.AlignHCenter
             text: Qt.formatDate(wallClock.time, "MMM dd")
+
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: parent.width * 0.015
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: parent.height * 0.195
+            }
+
+            font {
+                pixelSize: parent.height * 0.08
+                family: "Fyodor"
+            }
+
         }
 
         Canvas {
@@ -212,31 +223,25 @@ Item {
             smooth: true
             renderStrategy: Canvas.Cooperative
             onPaint: {
-                var ctx = getContext("2d")
-                ctx.reset()
-                ctx.shadowColor = Qt.rgba(.1, .1, .1, .7)
-                ctx.shadowOffsetX = 2
-                ctx.shadowOffsetY = 2
-                ctx.shadowBlur = 3
-                ctx.beginPath()
-                ctx.lineWidth = parent.height * .0031
-                ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, .9) : Qt.rgba(0, 0, 0, 1)
-                ctx.strokeStyle = Qt.rgba(1, 1, 1, .4)
-                ctx.moveTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                           parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3.11 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26,
-                           parent.height / 2 + Math.sin(((hour - 3.11 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 8.68 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14,
-                           parent.height / 2 + Math.sin(((hour - 8.68 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 9.32 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14,
-                           parent.height / 2 + Math.sin(((hour - 9.32 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .14)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 2.89 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26,
-                           parent.height / 2 + Math.sin(((hour - 2.89 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .26)
-                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275,
-                           parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * .275)
-                ctx.fill()
-                ctx.stroke()
-                ctx.closePath()
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.shadowColor = Qt.rgba(0.1, 0.1, 0.1, 0.7);
+                ctx.shadowOffsetX = 2;
+                ctx.shadowOffsetY = 2;
+                ctx.shadowBlur = 3;
+                ctx.beginPath();
+                ctx.lineWidth = parent.height * 0.0031;
+                ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.9) : Qt.rgba(0, 0, 0, 1);
+                ctx.strokeStyle = Qt.rgba(1, 1, 1, 0.4);
+                ctx.moveTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275, parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275);
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3.11 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.26, parent.height / 2 + Math.sin(((hour - 3.11 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.26);
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 8.68 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.14, parent.height / 2 + Math.sin(((hour - 8.68 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.14);
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 9.32 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.14, parent.height / 2 + Math.sin(((hour - 9.32 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.14);
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 2.89 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.26, parent.height / 2 + Math.sin(((hour - 2.89 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.26);
+                ctx.lineTo(parent.width / 2 + Math.cos(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275, parent.height / 2 + Math.sin(((hour - 3 + wallClock.time.getMinutes() / 60) / 12) * 2 * Math.PI) * width * 0.275);
+                ctx.fill();
+                ctx.stroke();
+                ctx.closePath();
             }
         }
 
@@ -249,31 +254,25 @@ Item {
             smooth: true
             renderStrategy: Canvas.Cooperative
             onPaint: {
-                var ctx = getContext("2d")
-                ctx.reset()
-                ctx.shadowColor = Qt.rgba(.1, .1, .1, .7)
-                ctx.shadowOffsetX = 3
-                ctx.shadowOffsetY = 3
-                ctx.shadowBlur = 2
-                ctx.beginPath()
-                ctx.lineWidth = parent.height * .0031
-                ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, .9) : Qt.rgba(0, 0, 0, 1)
-                ctx.strokeStyle = Qt.rgba(1, 1, 1, .4)
-                ctx.moveTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * .44,
-                           parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * .44)
-                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15.28) / 60) * 2 * Math.PI) * width * .43,
-                           parent.height / 2 + Math.sin(((minute - 15.28) / 60) * 2 * Math.PI) * width * .43)
-                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 43.6) / 60) * 2 * Math.PI) * width * .14,
-                           parent.height / 2 + Math.sin(((minute - 43.6) / 60) * 2 * Math.PI) * width * .14)
-                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 46.4) / 60) * 2 * Math.PI) * width * .14,
-                           parent.height / 2 + Math.sin(((minute - 46.4) / 60) * 2 * Math.PI) * width * .14)
-                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 14.72) / 60) * 2 * Math.PI) * width * .43,
-                           parent.height / 2 + Math.sin(((minute - 14.72) / 60) * 2 * Math.PI) * width * .43)
-                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * .44,
-                           parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * .44)
-                ctx.fill()
-                ctx.stroke()
-                ctx.closePath()
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.shadowColor = Qt.rgba(0.1, 0.1, 0.1, 0.7);
+                ctx.shadowOffsetX = 3;
+                ctx.shadowOffsetY = 3;
+                ctx.shadowBlur = 2;
+                ctx.beginPath();
+                ctx.lineWidth = parent.height * 0.0031;
+                ctx.fillStyle = displayAmbient ? Qt.rgba(1, 1, 1, 0.9) : Qt.rgba(0, 0, 0, 1);
+                ctx.strokeStyle = Qt.rgba(1, 1, 1, 0.4);
+                ctx.moveTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * 0.44, parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * 0.44);
+                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15.28) / 60) * 2 * Math.PI) * width * 0.43, parent.height / 2 + Math.sin(((minute - 15.28) / 60) * 2 * Math.PI) * width * 0.43);
+                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 43.6) / 60) * 2 * Math.PI) * width * 0.14, parent.height / 2 + Math.sin(((minute - 43.6) / 60) * 2 * Math.PI) * width * 0.14);
+                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 46.4) / 60) * 2 * Math.PI) * width * 0.14, parent.height / 2 + Math.sin(((minute - 46.4) / 60) * 2 * Math.PI) * width * 0.14);
+                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 14.72) / 60) * 2 * Math.PI) * width * 0.43, parent.height / 2 + Math.sin(((minute - 14.72) / 60) * 2 * Math.PI) * width * 0.43);
+                ctx.lineTo(parent.width / 2 + Math.cos(((minute - 15) / 60) * 2 * Math.PI) * width * 0.44, parent.height / 2 + Math.sin(((minute - 15) / 60) * 2 * Math.PI) * width * 0.44);
+                ctx.fill();
+                ctx.stroke();
+                ctx.closePath();
             }
         }
 
@@ -287,79 +286,69 @@ Item {
             renderStrategy: Canvas.Cooperative
             visible: !displayAmbient
             onPaint: {
-                var ctx = getContext("2d")
-                ctx.reset()
-                ctx.shadowColor = Qt.rgba(0, 0, 0, .5)
-                ctx.shadowOffsetX = 4
-                ctx.shadowOffsetY = 4
-                ctx.shadowBlur = 3
-                ctx.strokeStyle = "red"
-                ctx.lineWidth = parent.height * .008
-                ctx.beginPath()
-                ctx.moveTo(parent.width / 2, parent.height / 2)
-                ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .07,
-                        parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .07)
-                ctx.stroke()
-                ctx.closePath()
-                ctx.beginPath()
-                ctx.lineWidth = parent.height * .022
-                ctx.moveTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .07,
-                           parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .07)
-                ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * .16,
-                        parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * .16)
-                ctx.stroke()
-                ctx.closePath()
-                ctx.beginPath()
-                ctx.lineWidth = parent.height * .008
-                ctx.fillStyle = "red"
-                ctx.arc(parent.width / 2, parent.height / 2, parent.height * .012, 0, 2 * Math.PI, false)
-                ctx.fill()
-                ctx.moveTo(parent.width / 2, parent.height / 2)
-                ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * .32,
-                        parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * .32)
-                ctx.stroke()
-                ctx.closePath()
+                var ctx = getContext("2d");
+                ctx.reset();
+                ctx.shadowColor = Qt.rgba(0, 0, 0, 0.5);
+                ctx.shadowOffsetX = 4;
+                ctx.shadowOffsetY = 4;
+                ctx.shadowBlur = 3;
+                ctx.strokeStyle = "red";
+                ctx.lineWidth = parent.height * 0.008;
+                ctx.beginPath();
+                ctx.moveTo(parent.width / 2, parent.height / 2);
+                ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * 0.07, parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * 0.07);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineWidth = parent.height * 0.022;
+                ctx.moveTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * 0.07, parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * 0.07);
+                ctx.lineTo(parent.width / 2 + Math.cos((second - 45) / 60 * 2 * Math.PI) * width * 0.16, parent.height / 2 + Math.sin((second - 45) / 60 * 2 * Math.PI) * width * 0.16);
+                ctx.stroke();
+                ctx.closePath();
+                ctx.beginPath();
+                ctx.lineWidth = parent.height * 0.008;
+                ctx.fillStyle = "red";
+                ctx.arc(parent.width / 2, parent.height / 2, parent.height * 0.012, 0, 2 * Math.PI, false);
+                ctx.fill();
+                ctx.moveTo(parent.width / 2, parent.height / 2);
+                ctx.lineTo(parent.width / 2 + Math.cos((second - 15) / 60 * 2 * Math.PI) * width * 0.32, parent.height / 2 + Math.sin((second - 15) / 60 * 2 * Math.PI) * width * 0.32);
+                ctx.stroke();
+                ctx.closePath();
             }
         }
 
         Connections {
-            target: compositor
             function onDisplayAmbientChanged() {
-                minuteHand.requestPaint()
-                hourHand.requestPaint()
-                numberStrokes.requestPaint()
+                minuteHand.requestPaint();
+                hourHand.requestPaint();
+                numberStrokes.requestPaint();
             }
+
+            target: compositor
         }
 
         Connections {
-            target: wallClock
             function onTimeChanged() {
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var second = wallClock.time.getSeconds()
-                if(secondHand.second !== second) {
-                    secondHand.second = second
-                    secondHand.requestPaint()
-                }if(hourHand.hour !== hour) {
-                    hourHand.hour = hour
-                }if(minuteHand.minute !== minute) {
-                    minuteHand.minute = minute
-                    minuteHand.requestPaint()
-                    hourHand.requestPaint()
+                var hour = wallClock.time.getHours();
+                var minute = wallClock.time.getMinutes();
+                var second = wallClock.time.getSeconds();
+                if (secondHand.second !== second) {
+                    secondHand.second = second;
+                    secondHand.requestPaint();
+                }
+                if (hourHand.hour !== hour)
+                    hourHand.hour = hour;
+
+                if (minuteHand.minute !== minute) {
+                    minuteHand.minute = minute;
+                    minuteHand.requestPaint();
+                    hourHand.requestPaint();
                 }
             }
-         }
 
-         Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var second = wallClock.time.getSeconds()
-            secondHand.second = second
-            secondHand.requestPaint()
-            minuteHand.minute = minute
-            minuteHand.requestPaint()
-            hourHand.hour = hour
-            hourHand.requestPaint()
+            target: wallClock
         }
+
     }
+
 }


### PR DESCRIPTION
Qt6 refactor of the 014-analog-50s-americana watchface. Four commits covering SPDX header, nightstand arc correctness, partial Canvas conversion with bug fix and text rendering, and a conventions and qmlformat pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Nine authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Removes the dead `batteryPercentChanged` property; the `chargeArc` angle binding already reads `batteryChargePercentage.percent` directly. Adds `| 0` bitwise cast to `chargecolor` and changes `property var` to `property int`; Qt6 rejects implicit double-to-int coercion on array index access. Removes `smooth: true` and `antialiasing: true` from `chargeArc` Shape, both are no-ops on Shape items. Normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Canvas partial conversion, bug fix, and text rendering** — converts `backCircle` Canvas to a `Rectangle` with `radius: width / 2`. The Canvas drew a plain semi-transparent white filled circle using `ctx.arc` and `ctx.fill`; the Rectangle is a direct equivalent with zero per-frame cost. Removes the now-dead `property real radian` which was only referenced inside the `backCircle` onPaint handler. Fixes a pre-existing typo in `Component.onCompleted` where `hourHand.hour` was assigned `hournightstandMode` instead of the local variable `hour`; the hour hand previously initialised to `undefined` on load and only corrected itself on the first `wallClock` tick. Adds `renderType: Text.NativeRendering` to `batteryPercent`. Splits `style` and `styleColor` onto separate lines. `monthDisplay` already had `renderType` in the upstream. The remaining Canvas items are intentionally retained: `hourHand` and `minuteHand` use filled polygon geometry with shadow effects that define the visual identity of the face; `numberStrokes`, `hourStrokes`, and `minuteStrokes` are static tick and numeral elements that paint once at startup, with `numberStrokes` also repainting on ambient change to switch between light and dark colours; `secondHand` is retained with per-second ticking as the design intent for this watchface.

4. **Conventions, formatting, and qmlformat pass** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.controls` and `org.asteroid.utils`, neither of which has any references in the file. Replaces root square sizing ternary with `Math.min`. Full `qmlformat -i` normalisation pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: white circle background, tick ring, numerals, hour and minute hands all render correctly. Numerals switch between dark and light colour on ambient entry and exit.
- Date display renders correctly below centre.
- Second hand ticks per second as intended for this watchface design.
- Hour hand initialises to the correct position on load; the pre-existing `hournightstandMode` typo is resolved.
- Nightstand mode: battery arc and percentage text render correctly. No multisample renderbuffer journal warning.
- AoD: hands switch to light fill, numerals switch to light colour, `backCircle` correctly hidden.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` (`rootitem`) prevents layout squish on non-square panels.
- Five Canvas items are retained by design. `hourHand` and `minuteHand` use filled polygon geometry with drop shadow that defines the visual identity of the face and has no `QtShapes` equivalent. `hourStrokes` and `minuteStrokes` are static tick rings that paint once at startup. `numberStrokes` paints once at startup and repaints on ambient change to switch numeral colour; this ambient-aware repaint pattern is intentional and correct. `secondHand` is retained with per-second ticking to match the design intent of this watchface.
- No visual tuning commit was needed — the face renders identically on Qt5 and Qt6.