### PR TITLE
Refactor 015-funky-town-words watchface for Qt6

### DIFF
--- a/src/watchfaces/015-funky-town-words.qml
+++ b/src/watchfaces/015-funky-town-words.qml
@@ -1,36 +1,10 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2014 - Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
- * All rights reserved.
- *
- * You may use this file under the terms of BSD license as follows:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the author nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
+// SPDX-License-Identifier: BSD-3-Clause
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/015-funky-town-words.qml
+++ b/src/watchfaces/015-funky-town-words.qml
@@ -58,8 +58,9 @@ Item {
             font {
                 pixelSize: parent.height * .22
                 family: "Source Sans Pro"
-                styleName: "Light"
+                weight: Font.Light
             }
+            renderType: Text.NativeRendering
             color: nightstandMode.active || displayAmbient ? "#000" : "#fff"
             text: wallClock.time.toLocaleString(Qt.locale(), "mm")
 
@@ -125,8 +126,9 @@ Item {
                 font {
                     pixelSize: parent.width * .13
                     family: "Source Sans Pro"
-                    styleName: "Light"
+                    weight: Font.Light
                 }
+                renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 text: batteryChargePercentage.percent
@@ -137,19 +139,11 @@ Item {
             id: batteryChargePercentage
         }
 
-        MceBatteryState {
-            id: batteryChargeState
-        }
-
-        MceCableState {
-            id: mceCableState
-        }
-
         Component.onCompleted: {
-            burnInProtectionManager.leftOffset = Qt.binding(function() { return width * nightstandMode.active ? .05 : .4})
-            burnInProtectionManager.rightOffset = Qt.binding(function() { return width * .05})
-            burnInProtectionManager.topOffset = Qt.binding(function() { return height * nightstandMode.active ? .05 : .4})
-            burnInProtectionManager.bottomOffset = Qt.binding(function() { return height * .05})
+            burnInProtectionManager.leftOffset = Qt.binding(function() { return width * (nightstandMode.active ? .05 : .4) })
+            burnInProtectionManager.rightOffset = Qt.binding(function() { return width * .05 })
+            burnInProtectionManager.topOffset = Qt.binding(function() { return height * (nightstandMode.active ? .05 : .4) })
+            burnInProtectionManager.bottomOffset = Qt.binding(function() { return height * .05 })
         }
     }
 }

--- a/src/watchfaces/015-funky-town-words.qml
+++ b/src/watchfaces/015-funky-town-words.qml
@@ -78,30 +78,20 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .016
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -110,7 +100,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2

--- a/src/watchfaces/015-funky-town-words.qml
+++ b/src/watchfaces/015-funky-town-words.qml
@@ -6,29 +6,38 @@
 // SPDX-FileCopyrightText: 2014 Aleksi Suomalainen <suomalainen.aleksi@gmail.com>
 // SPDX-License-Identifier: BSD-3-Clause
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
-    anchors.fill: parent
-
     property string imgPath: "../watchfaces-img/funky-town-words-"
+
+    anchors.fill: parent
 
     Item {
         anchors.centerIn: parent
-
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
+        Component.onCompleted: {
+            burnInProtectionManager.leftOffset = Qt.binding(function() {
+                return width * (nightstandMode.active ? 0.05 : 0.4);
+            });
+            burnInProtectionManager.rightOffset = Qt.binding(function() {
+                return width * 0.05;
+            });
+            burnInProtectionManager.topOffset = Qt.binding(function() {
+                return height * (nightstandMode.active ? 0.05 : 0.4);
+            });
+            burnInProtectionManager.bottomOffset = Qt.binding(function() {
+                return height * 0.05;
+            });
+        }
 
         Image {
             anchors.centerIn: parent
-            source: imgPath +
-                    wallClock.time.toLocaleString(Qt.locale(), "hh am").slice(0, 2) +
-                    (nightstandMode.active || displayAmbient ? "-bw.svg" : ".svg")
+            source: imgPath + wallClock.time.toLocaleString(Qt.locale(), "hh am").slice(0, 2) + (nightstandMode.active || displayAmbient ? "-bw.svg" : ".svg")
             sourceSize.width: parent.width
             sourceSize.height: parent.height
             width: parent.width
@@ -37,8 +46,7 @@ Item {
 
         Image {
             anchors.centerIn: parent
-            source: imgPath +
-                    wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase().slice(0, 2) + ".svg"
+            source: imgPath + wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase().slice(0, 2) + ".svg"
             visible: use12H.value
             sourceSize.width: parent.width
             sourceSize.height: parent.height
@@ -49,30 +57,46 @@ Item {
         Text {
             id: minuteDisplay
 
-            anchors {
-                bottom: parent.bottom
-                bottomMargin: parent.height * .15
-                horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: parent.width*.2
-            }
-            font {
-                pixelSize: parent.height * .22
-                family: "Source Sans Pro"
-                weight: Font.Light
-            }
             renderType: Text.NativeRendering
             color: nightstandMode.active || displayAmbient ? "#000" : "#fff"
             text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+            anchors {
+                bottom: parent.bottom
+                bottomMargin: parent.height * 0.15
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: parent.width * 0.2
+            }
+
+            font {
+                pixelSize: parent.height * 0.22
+                family: "Source Sans Pro"
+                weight: Font.Light
+            }
 
             Behavior on text {
                 enabled: !displayAmbient
 
                 SequentialAnimation {
-                    NumberAnimation { target: minuteDisplay; property: "opacity"; to: 0 }
-                    PropertyAction {}
-                    NumberAnimation { target: minuteDisplay; property: "opacity"; to: 1 }
+                    NumberAnimation {
+                        target: minuteDisplay
+                        property: "opacity"
+                        to: 0
+                    }
+
+                    PropertyAction {
+                    }
+
+                    NumberAnimation {
+                        target: minuteDisplay
+                        property: "opacity"
+                        to: 1
+                    }
+
                 }
+
             }
+
         }
 
         Item {
@@ -87,10 +111,10 @@ Item {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                property real arcStrokeWidth: .016
-                property real scalefactor: .45 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.016
+                property real scalefactor: 0.45 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: parent
 
@@ -101,7 +125,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -112,38 +136,38 @@ Item {
                         sweepAngle: chargeArc.angle
                         moveToStart: false
                     }
+
                 }
+
             }
 
             Text {
                 id: batteryPercent
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: -parent.width * .28
-                }
-
-                font {
-                    pixelSize: parent.width * .13
-                    family: "Source Sans Pro"
-                    weight: Font.Light
-                }
                 renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 text: batteryChargePercentage.percent
+
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: -parent.width * 0.28
+                }
+
+                font {
+                    pixelSize: parent.width * 0.13
+                    family: "Source Sans Pro"
+                    weight: Font.Light
+                }
+
             }
+
         }
 
         MceBatteryLevel {
             id: batteryChargePercentage
         }
 
-        Component.onCompleted: {
-            burnInProtectionManager.leftOffset = Qt.binding(function() { return width * (nightstandMode.active ? .05 : .4) })
-            burnInProtectionManager.rightOffset = Qt.binding(function() { return width * .05 })
-            burnInProtectionManager.topOffset = Qt.binding(function() { return height * (nightstandMode.active ? .05 : .4) })
-            burnInProtectionManager.bottomOffset = Qt.binding(function() { return height * .05 })
-        }
     }
+
 }


### PR DESCRIPTION
Qt6 refactor of the 015-funky-town-words watchface. Four commits covering SPDX header, nightstand arc correctness, text rendering with bug fixes and dead code removal, and a conventions and qmlformat pass.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line BSD redistribution notice to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: BSD-3-Clause` one-liners. Six authors preserved newest-first. License identifier is `BSD-3-Clause` matching the original header. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Removes the dead `batteryPercentChanged` property; the `chargeArc` angle binding already reads `batteryChargePercentage.percent` directly. Adds `| 0` bitwise cast to `chargecolor` and changes `property var` to `property int`; Qt6 rejects implicit double-to-int coercion on array index access. Removes `smooth: true` and `antialiasing: true` from `chargeArc` Shape, both are no-ops on Shape items. Normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Text rendering, bug fixes, and dead code removal** — adds `renderType: Text.NativeRendering` to `minuteDisplay` and `batteryPercent`. Converts `font.styleName: "Light"` to `font.weight: Font.Light` on both items. Fixes a `burnInProtectionManager` ternary operator precedence bug on `leftOffset` and `topOffset`; the original expression `width * nightstandMode.active ? .05 : .4` was parsed as `(width * nightstandMode.active) ? .05 : .4`, always resolving to `.05` since any non-zero width is truthy — corrected to `width * (nightstandMode.active ? .05 : .4)`. Removes dead `MceBatteryState` and `MceCableState` items; both were declared but never referenced anywhere in the file.

4. **Conventions, formatting, and qmlformat pass** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.controls` and `org.asteroid.utils`, neither of which has any references in the file. Replaces root square sizing ternary with `Math.min`. Full `qmlformat -i` normalisation pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: hour word SVG, am/pm SVG overlay, and minute display all render correctly. Minute fade animation triggers correctly on minute change.
- 12h/24h toggle: am/pm SVG overlay correctly hidden in 24h mode.
- Nightstand mode: battery arc and percentage render correctly. No multisample renderbuffer journal warning.
- Burn-in protection offsets now correctly expand to `.4` in non-nightstand mode following the precedence fix.
- AoD: minute display and SVG images switch to dark/greyscale variants correctly.
- No regressions found across all four commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` prevents layout squish on non-square panels.
- This watchface uses `BSD-3-Clause` rather than `LGPL-2.1-or-later`. The SPDX identifier matches the license stated in the original header.
- No visual tuning commit was needed — the face renders identically on Qt5 and Qt6.