### PR TITLE
Refactor 016-masked-spartan watchface for Qt6

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,9 @@ add_executable(asteroid-launcher ${SRC} ${HEADERS} resources-qml.qrc)
 
 qt_add_shaders(
     asteroid-launcher "asteroid-launcher_shaders"
-    FILES "qml/compositor/circlemaskshader.frag"
+    FILES
+        "qml/compositor/circlemaskshader.frag"
+        "shaders/masked-spartan.frag"
 )
 
 target_link_libraries(

--- a/src/shaders/masked-spartan.frag
+++ b/src/shaders/masked-spartan.frag
@@ -1,0 +1,21 @@
+#version 440
+
+layout(location = 0) in vec2 qt_TexCoord0;
+layout(location = 0) out vec4 fragColor;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 qt_Matrix;
+    float qt_Opacity;
+    bool keepInner;
+};
+
+layout(binding = 1) uniform sampler2D source;
+layout(binding = 2) uniform sampler2D maskSource;
+
+void main(void) {
+    if (keepInner) {
+        fragColor = texture(source, qt_TexCoord0.st) * (texture(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+    } else {
+        fragColor = texture(source, qt_TexCoord0.st) * (1.0 - texture(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
+    }
+}

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -19,156 +19,155 @@ import org.asteroid.utils
 
 
 Item {
-    anchors.fill: parent
+    id: faceRoot
 
-    property string imgPath: "../watchfaces-img/funky-town-words-"
+    anchors.fill: parent
+    
+    Rectangle {
+        id: layer2mask
+
+        anchors.fill: parent
+        color: Qt.rgba(0, 0, 0, 0.75)
+        visible: true
+        opacity: 0
+        layer.enabled: true
+        layer.smooth: true
+        radius: DeviceSpecs.hasRoundScreen || nightstand ? faceRoot.width : 0
+    }
+
+    Rectangle {
+        id: _mask
+
+        anchors.fill: layer2mask
+        color: Qt.rgba(0, 1, 0, 0)
+        visible: true
+        opacity: displayAmbient ? 0.75 : 1
+        layer.enabled: !displayAmbient
+
+        Text {
+            property real voffset: parent.height * .01
+
+            renderType: Text.NativeRendering
+            font {
+                pixelSize: parent.height * .58
+                letterSpacing: -parent.width * .08
+                family: "League Spartan"
+            }
+            color: Qt.rgba(1, 1, 1, 1)
+            y: parent.height / 3 - height / 2 + voffset
+            x: -parent.width * .055
+            text: if (use12H.value) {
+                      wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2).replace(/1/g," 1 ") }
+                  else
+                      wallClock.time.toLocaleString(Qt.locale(), "HH").replace(/1/g," 1 ")
+
+
+        }
+
+        Text {
+            property real voffset: parent.height * .075
+
+            renderType: Text.NativeRendering
+            font {
+                pixelSize: parent.height * .58
+                letterSpacing: -parent.width * .06
+                family: "League Spartan"
+            }
+            color: Qt.rgba(1, 1, 1, 1)
+            y: parent.height / 1.3 - height / 2 + voffset
+            x: parent.width*.25
+            text: wallClock.time.toLocaleString(Qt.locale(), "<b>mm</b>").replace(/1/g,"&nbsp;1")
+        }
+
+        Text {
+            renderType: Text.NativeRendering
+            anchors {
+                bottom: parent.verticalCenter
+                bottomMargin: -parent.height * .05
+                left: parent.horizontalCenter
+                leftMargin: parent.height * .19
+            }
+            font {
+                pixelSize: parent.height * .24
+                letterSpacing: -parent.width * .025
+                family: "League Spartan"
+            }
+            color: Qt.rgba(1, 1, 1, 1)
+            visible: !displayAmbient
+            text: wallClock.time.toLocaleString(Qt.locale(), "<b>ss</b>").replace(/1/g,"&nbsp;1")
+        }
+
+        Text {
+            renderType: Text.NativeRendering
+            anchors {
+                bottom: parent.verticalCenter
+                bottomMargin: parent.height * .25
+                left: parent.horizontalCenter
+                leftMargin: parent.height * .222
+            }
+            font {
+                pixelSize: parent.height * .1
+                letterSpacing: -parent.width * .01
+                family: "League Spartan"
+            }
+            visible: use12H.value
+            lineHeight: .9
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignRight
+            text: wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase()
+        }
+
+        Text {
+            renderType: Text.NativeRendering
+            anchors {
+                top: parent.verticalCenter
+                topMargin: parent.height * .02
+                right: parent.horizontalCenter
+                rightMargin: parent.height * .24
+            }
+            font{
+                pixelSize: parent.height * .24
+                letterSpacing: -parent.width * .025
+                family: "League Spartan"
+            }
+            lineHeight: .7
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignRight
+            text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b>").toLowerCase()
+        }
+
+        Text {
+            renderType: Text.NativeRendering
+            anchors {
+                top: parent.verticalCenter
+                topMargin: parent.height * .235
+                right: parent.horizontalCenter
+                rightMargin: parent.height * .23
+            }
+            font {
+                pixelSize: parent.height*.1
+                letterSpacing: -parent.width * .01
+                family: "League Spartan"
+            }
+            lineHeight: .7
+            color: Qt.rgba(1, 1, 1, 1)
+            horizontalAlignment: Text.AlignRight
+            text: wallClock.time.toLocaleString(Qt.locale(), "MMM").toLowerCase()
+        }
+
+        layer.samplerName: "maskSource"
+        layer.effect: ShaderEffect {
+            property variant source: layer2mask
+            property bool keepInner: false
+            fragmentShader: "qrc:/shaders/masked-spartan.frag.qsb"
+        }
+    }
 
     Item {
         anchors.centerIn: parent
 
         height: Math.min(parent.width, parent.height)
         width: height
-
-        Rectangle {
-            id: layer2mask
-
-            anchors.centerIn: parent
-            width: parent.width * (nightstand ? .86 : 1)
-            height: width
-            color: displayAmbient ? Qt.rgba(1, 1, 1, .8) : Qt.rgba(0, 0, 0, .8)
-            visible: true
-            opacity: .0
-            layer.enabled: true
-            layer.smooth: true
-            radius: DeviceSpecs.hasRoundScreen || nightstand ? width : 0
-        }
-
-        Rectangle {
-            id: _mask
-
-            anchors.fill: layer2mask
-            color: Qt.rgba(0, 1, 0, 0)
-            visible: true
-
-            Text {
-                property real voffset: parent.height * .01
-
-                renderType: Text.NativeRendering
-                font {
-                    pixelSize: parent.height * .58
-                    letterSpacing: -parent.width * .08
-                    family: "League Spartan"
-                }
-                color: Qt.rgba(1, 1, 1, 1)
-                y: parent.height / 3 - height / 2 + voffset
-                x: -parent.width * .055
-                text: if (use12H.value) {
-                          wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2).replace(/1/g," 1 ") }
-                      else
-                          wallClock.time.toLocaleString(Qt.locale(), "HH").replace(/1/g," 1 ")
-
-
-            }
-
-            Text {
-                property real voffset: parent.height * .075
-
-                renderType: Text.NativeRendering
-                font {
-                    pixelSize: parent.height * .58
-                    letterSpacing: -parent.width * .06
-                    family: "League Spartan"
-                }
-                color: Qt.rgba(1, 1, 1, 1)
-                y: parent.height / 1.3 - height / 2 + voffset
-                x: parent.width*.25
-                text: wallClock.time.toLocaleString(Qt.locale(), "<b>mm</b>").replace(/1/g,"&nbsp;1")
-            }
-
-            Text {
-                renderType: Text.NativeRendering
-                anchors {
-                    bottom: parent.verticalCenter
-                    bottomMargin: -parent.height * .05
-                    left: parent.horizontalCenter
-                    leftMargin: parent.height * .19
-                }
-                font {
-                    pixelSize: parent.height * .24
-                    letterSpacing: -parent.width * .025
-                    family: "League Spartan"
-                }
-                color: Qt.rgba(1, 1, 1, 1)
-                visible: !displayAmbient
-                text: wallClock.time.toLocaleString(Qt.locale(), "<b>ss</b>").replace(/1/g,"&nbsp;1")
-            }
-
-            Text {
-                renderType: Text.NativeRendering
-                anchors {
-                    bottom: parent.verticalCenter
-                    bottomMargin: parent.height * .25
-                    left: parent.horizontalCenter
-                    leftMargin: parent.height * .222
-                }
-                font {
-                    pixelSize: parent.height * .1
-                    letterSpacing: -parent.width * .01
-                    family: "League Spartan"
-                }
-                visible: use12H.value
-                lineHeight: .9
-                color: Qt.rgba(1, 1, 1, 1)
-                horizontalAlignment: Text.AlignRight
-                text: wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase()
-            }
-
-            Text {
-                renderType: Text.NativeRendering
-                anchors {
-                    top: parent.verticalCenter
-                    topMargin: parent.height * .02
-                    right: parent.horizontalCenter
-                    rightMargin: parent.height * .24
-                }
-                font{
-                    pixelSize: parent.height * .24
-                    letterSpacing: -parent.width * .025
-                    family: "League Spartan"
-                }
-                lineHeight: .7
-                color: Qt.rgba(1, 1, 1, 1)
-                horizontalAlignment: Text.AlignRight
-                text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b>").toLowerCase()
-            }
-
-            Text {
-                renderType: Text.NativeRendering
-                anchors {
-                    top: parent.verticalCenter
-                    topMargin: parent.height * .235
-                    right: parent.horizontalCenter
-                    rightMargin: parent.height * .23
-                }
-                font {
-                    pixelSize: parent.height*.1
-                    letterSpacing: -parent.width * .01
-                    family: "League Spartan"
-                }
-                lineHeight: .7
-                color: Qt.rgba(1, 1, 1, 1)
-                horizontalAlignment: Text.AlignRight
-                text: wallClock.time.toLocaleString(Qt.locale(), "MMM").toLowerCase()
-            }
-
-            layer.enabled: true
-            layer.samplerName: "maskSource"
-            layer.effect: ShaderEffect {
-                property variant source: layer2mask
-                property bool keepInner: false
-                fragmentShader: "qrc:/shaders/masked-spartan.frag.qsb"
-            }
-        }
 
         Item {
             id: nightstandMode

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -11,12 +11,12 @@
 // Based on a fragmentShader example from doc.qt.io. Design is heavily
 // inspired by Jollas "The Bold Font" watchface.
 
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
-import org.asteroid.controls
-import org.asteroid.utils
 import Nemo.Mce
+import org.asteroid.utils
+
 
 Item {
     anchors.fill: parent
@@ -26,7 +26,7 @@ Item {
     Item {
         anchors.centerIn: parent
 
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
 
         Rectangle {
@@ -165,7 +165,7 @@ Item {
             layer.samplerName: "maskSource"
             layer.effect: ShaderEffect {
                 property variant source: layer2mask
-                property bool keepInner: displayAmbient
+                property bool keepInner: false
                 fragmentShader: "qrc:/shaders/masked-spartan.frag.qsb"
             }
         }
@@ -174,16 +174,9 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
@@ -192,12 +185,10 @@ Item {
                 // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .022
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property real chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -206,7 +197,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -166,20 +166,7 @@ Item {
             layer.effect: ShaderEffect {
                 property variant source: layer2mask
                 property bool keepInner: displayAmbient
-                fragmentShader: "
-                        varying highp vec2 qt_TexCoord0;
-                        uniform highp float qt_Opacity;
-                        uniform lowp sampler2D source;
-                        uniform lowp sampler2D maskSource;
-                        uniform bool keepInner;
-                        void main(void) {
-                            if (keepInner) {
-                                gl_FragColor = texture2D(source, qt_TexCoord0.st) * (texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
-                            } else {
-                                gl_FragColor = texture2D(source, qt_TexCoord0.st) * (1.0-texture2D(maskSource, qt_TexCoord0.st).a) * qt_Opacity;
-                            }
-                        }
-                    "
+                fragmentShader: "qrc:/shaders/masked-spartan.frag.qsb"
             }
         }
 

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -1,32 +1,15 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
-/*
- * Based on a fragmentShader example from doc.qt.io. Design is heavily
- * inspired by Jollas "The Bold Font" watchface.
- */
+// Based on a fragmentShader example from doc.qt.io. Design is heavily
+// inspired by Jollas "The Bold Font" watchface.
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/016-masked-spartan.qml
+++ b/src/watchfaces/016-masked-spartan.qml
@@ -7,22 +7,20 @@
 // SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
-
 // Based on a fragmentShader example from doc.qt.io. Design is heavily
 // inspired by Jollas "The Bold Font" watchface.
 
+import Nemo.Mce
 import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Nemo.Mce
 import org.asteroid.utils
-
 
 Item {
     id: faceRoot
 
     anchors.fill: parent
-    
+
     Rectangle {
         id: layer2mask
 
@@ -43,129 +41,147 @@ Item {
         visible: true
         opacity: displayAmbient ? 0.75 : 1
         layer.enabled: !displayAmbient
+        layer.samplerName: "maskSource"
 
         Text {
-            property real voffset: parent.height * .01
+            property real voffset: parent.height * 0.01
 
             renderType: Text.NativeRendering
-            font {
-                pixelSize: parent.height * .58
-                letterSpacing: -parent.width * .08
-                family: "League Spartan"
-            }
             color: Qt.rgba(1, 1, 1, 1)
             y: parent.height / 3 - height / 2 + voffset
-            x: -parent.width * .055
-            text: if (use12H.value) {
-                      wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2).replace(/1/g," 1 ") }
-                  else
-                      wallClock.time.toLocaleString(Qt.locale(), "HH").replace(/1/g," 1 ")
+            x: -parent.width * 0.055
+            text: {
+                if (use12H.value) {
+                    wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2).replace(/1/g, " 1 ");
+                } else {
+                    wallClock.time.toLocaleString(Qt.locale(), "HH").replace(/1/g, " 1 ");
+                }
+            }
 
+            font {
+                pixelSize: parent.height * 0.58
+                letterSpacing: -parent.width * 0.08
+                family: "League Spartan"
+            }
 
         }
 
         Text {
-            property real voffset: parent.height * .075
+            property real voffset: parent.height * 0.075
 
             renderType: Text.NativeRendering
-            font {
-                pixelSize: parent.height * .58
-                letterSpacing: -parent.width * .06
-                family: "League Spartan"
-            }
             color: Qt.rgba(1, 1, 1, 1)
             y: parent.height / 1.3 - height / 2 + voffset
-            x: parent.width*.25
-            text: wallClock.time.toLocaleString(Qt.locale(), "<b>mm</b>").replace(/1/g,"&nbsp;1")
+            x: parent.width * 0.25
+            text: wallClock.time.toLocaleString(Qt.locale(), "<b>mm</b>").replace(/1/g, "&nbsp;1")
+
+            font {
+                pixelSize: parent.height * 0.58
+                letterSpacing: -parent.width * 0.06
+                family: "League Spartan"
+            }
+
         }
 
         Text {
             renderType: Text.NativeRendering
-            anchors {
-                bottom: parent.verticalCenter
-                bottomMargin: -parent.height * .05
-                left: parent.horizontalCenter
-                leftMargin: parent.height * .19
-            }
-            font {
-                pixelSize: parent.height * .24
-                letterSpacing: -parent.width * .025
-                family: "League Spartan"
-            }
             color: Qt.rgba(1, 1, 1, 1)
             visible: !displayAmbient
-            text: wallClock.time.toLocaleString(Qt.locale(), "<b>ss</b>").replace(/1/g,"&nbsp;1")
+            text: wallClock.time.toLocaleString(Qt.locale(), "<b>ss</b>").replace(/1/g, "&nbsp;1")
+
+            anchors {
+                bottom: parent.verticalCenter
+                bottomMargin: -parent.height * 0.05
+                left: parent.horizontalCenter
+                leftMargin: parent.height * 0.19
+            }
+
+            font {
+                pixelSize: parent.height * 0.24
+                letterSpacing: -parent.width * 0.025
+                family: "League Spartan"
+            }
+
         }
 
         Text {
             renderType: Text.NativeRendering
-            anchors {
-                bottom: parent.verticalCenter
-                bottomMargin: parent.height * .25
-                left: parent.horizontalCenter
-                leftMargin: parent.height * .222
-            }
-            font {
-                pixelSize: parent.height * .1
-                letterSpacing: -parent.width * .01
-                family: "League Spartan"
-            }
             visible: use12H.value
-            lineHeight: .9
+            lineHeight: 0.9
             color: Qt.rgba(1, 1, 1, 1)
             horizontalAlignment: Text.AlignRight
             text: wallClock.time.toLocaleString(Qt.locale("en_EN"), "ap").toLowerCase()
+
+            anchors {
+                bottom: parent.verticalCenter
+                bottomMargin: parent.height * 0.25
+                left: parent.horizontalCenter
+                leftMargin: parent.height * 0.222
+            }
+
+            font {
+                pixelSize: parent.height * 0.1
+                letterSpacing: -parent.width * 0.01
+                family: "League Spartan"
+            }
+
         }
 
         Text {
             renderType: Text.NativeRendering
-            anchors {
-                top: parent.verticalCenter
-                topMargin: parent.height * .02
-                right: parent.horizontalCenter
-                rightMargin: parent.height * .24
-            }
-            font{
-                pixelSize: parent.height * .24
-                letterSpacing: -parent.width * .025
-                family: "League Spartan"
-            }
-            lineHeight: .7
+            lineHeight: 0.7
             color: Qt.rgba(1, 1, 1, 1)
             horizontalAlignment: Text.AlignRight
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b>").toLowerCase()
+
+            anchors {
+                top: parent.verticalCenter
+                topMargin: parent.height * 0.02
+                right: parent.horizontalCenter
+                rightMargin: parent.height * 0.24
+            }
+
+            font {
+                pixelSize: parent.height * 0.24
+                letterSpacing: -parent.width * 0.025
+                family: "League Spartan"
+            }
+
         }
 
         Text {
             renderType: Text.NativeRendering
-            anchors {
-                top: parent.verticalCenter
-                topMargin: parent.height * .235
-                right: parent.horizontalCenter
-                rightMargin: parent.height * .23
-            }
-            font {
-                pixelSize: parent.height*.1
-                letterSpacing: -parent.width * .01
-                family: "League Spartan"
-            }
-            lineHeight: .7
+            lineHeight: 0.7
             color: Qt.rgba(1, 1, 1, 1)
             horizontalAlignment: Text.AlignRight
             text: wallClock.time.toLocaleString(Qt.locale(), "MMM").toLowerCase()
+
+            anchors {
+                top: parent.verticalCenter
+                topMargin: parent.height * 0.235
+                right: parent.horizontalCenter
+                rightMargin: parent.height * 0.23
+            }
+
+            font {
+                pixelSize: parent.height * 0.1
+                letterSpacing: -parent.width * 0.01
+                family: "League Spartan"
+            }
+
         }
 
-        layer.samplerName: "maskSource"
         layer.effect: ShaderEffect {
             property variant source: layer2mask
             property bool keepInner: false
+
             fragmentShader: "qrc:/shaders/masked-spartan.frag.qsb"
         }
+
     }
 
     Item {
         anchors.centerIn: parent
-
         height: Math.min(parent.width, parent.height)
         width: height
 
@@ -182,10 +198,10 @@ Item {
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
                 // radius of arc is scalefactor * height or width
-                property real arcStrokeWidth: .022
-                property real scalefactor: .45 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.022
+                property real scalefactor: 0.45 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: parent
 
@@ -196,7 +212,7 @@ Item {
                     capStyle: ShapePath.FlatCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -207,12 +223,17 @@ Item {
                         sweepAngle: chargeArc.angle
                         moveToStart: false
                     }
+
                 }
+
             }
+
         }
 
         MceBatteryLevel {
             id: batteryChargePercentage
         }
+
     }
+
 }


### PR DESCRIPTION
Qt6 refactor of the 016-masked-spartan watchface. Five commits covering SPDX header, Qt6 ShaderEffect fix with build-time shader compilation, nightstand arc correctness and conventions, non-square screen geometry fix, and a qmlformat pass. This is the most complex watchface in the stock set from a Qt6 migration perspective, requiring porting of an inline GLSL shader to the Qt6 shader pipeline.

> **Note:** This PR depends on the `shaders/` folder PR which establishes `src/shaders/` and its CMake install target. Please merge that PR first.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Eight authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 ShaderEffect crash and add build-time shader compilation** — Qt6 no longer accepts inline GLSL strings in `ShaderEffect.fragmentShader`. The inline GLSL 100 shader was rewritten in GLSL 440 and added as `src/shaders/masked-spartan.frag`. Added to the existing `qt_add_shaders` block in `src/CMakeLists.txt` without a `PREFIX` so the existing `circlemaskshader.frag` resource path is not disturbed. The shader is compiled into the resource bundle at build time and referenced as `qrc:/shaders/masked-spartan.frag.qsb` in the QML. The shader logic: in normal mode (`keepInner: false`) letter shapes are cut out of the dark rectangle revealing the wallpaper behind; in AoD `layer.enabled: !displayAmbient` bypasses the shader entirely, allowing Text items to render directly on the dark background at reduced opacity. `keepInner` is a constant `false` since AoD no longer routes through the shader.

3. **Qt6 nightstand arc correctness and conventions** — removes the `layer` block from `nightstandMode`. Removes dead `batteryPercentChanged` property. Adds `| 0` bitwise cast to `chargecolor` and changes `property var` to `property int`. Removes `smooth: true` and `antialiasing: true` from `chargeArc` Shape. Normalises `colorArray` bracket spacing and `startY` parenthesis spacing. Sorts imports alphabetically. Removes `org.asteroid.controls` which has no references in the file. Retains `org.asteroid.utils` for `DeviceSpecs.hasRoundScreen` used in the `layer2mask` radius binding. Replaces root square sizing ternary with `Math.min`.

4. **Fix non-square screen geometry** — adds `id: faceRoot` to the screen-filling outer Item. Moves `layer2mask` and `_mask` from the inner square Item to become direct children of `faceRoot`, anchored to `parent` which correctly resolves to the full screen surface. On rectangular screens the dark background rectangle now fills the full panel instead of being clipped to the square inner Item. The inner square Item is retained and now contains only `nightstandMode` and `MceBatteryLevel`. Sets `layer.enabled: !displayAmbient` on `_mask` to bypass the shader in AoD. Sets `opacity: displayAmbient ? 0.75 : 1` on `_mask` for correct AoD glyph visibility. `layer2mask` color is now a static `Qt.rgba(0, 0, 0, 0.75)` with no `displayAmbient` switching needed. Removes dead `imgPath` property which had no references in the file.

5. **qmlformat pass** — full `qmlformat -i` normalisation pass over the file.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: letter cutout effect renders correctly — wallpaper visible through glyph shapes, dark rectangle fills the screen.
- Hour and minute glyphs, seconds, am/pm, date, and month all render at correct positions.
- 12h/24h toggle: hour glyph and am/pm visibility respond correctly.
- AoD: shader bypassed via `layer.enabled: !displayAmbient`; glyphs render directly as white text at reduced opacity on the dark background. No shader artefacts.
- Nightstand mode: battery arc renders correctly. No multisample renderbuffer journal warning.
- No regressions found across all five commits.

### Notes

- The outer screen-filling `Item` (`faceRoot`) is the system-injected root surface and intentionally fills the full panel. `layer2mask` and `_mask` fill `faceRoot` so the dark background covers the full screen including non-square panels. The inner square `Item` constrains only the nightstand arc geometry.
- `masked-spartan.frag` is the GLSL 440 shader source residing in `src/shaders/`. It is compiled into the resource bundle at build time via `qt_add_shaders`. In Qt6, `ShaderEffect.fragmentShader` requires a `qrc:` resource URL pointing to a compiled `.qsb`; inline GLSL strings are no longer supported.
- The `src/shaders/` folder established in the prerequisite PR is the designated location for shader source files. Once that PR merges, the `.gitkeep` placeholder can be removed as the folder will contain `masked-spartan.frag`.
- This shader compilation workflow via `qt_add_shaders` is the established pattern for any future Qt6 shader work in asteroid-launcher, including the planned FragCoord live wallpaper component.