### PR TITLE
Refactor 017-contemporary-digital-rings watchface for Qt6

### DIFF
--- a/src/watchfaces/017-contemporary-digital-rings.qml
+++ b/src/watchfaces/017-contemporary-digital-rings.qml
@@ -125,9 +125,10 @@ Item {
             font {
                 pixelSize: parent.height * .375
                 family: "Titillium"
-                styleName: 'Bold'
+                weight: Font.Bold
                 letterSpacing: -3
             }
+            renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
@@ -150,9 +151,10 @@ Item {
             }
             font {
                 pixelSize: parent.height * .1375
-                styleName: 'Semibold'
+                weight: Font.DemiBold
                 letterSpacing: -1
             }
+            renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
@@ -171,9 +173,10 @@ Item {
             font {
                 pixelSize: parent.height * .1375
                 family: "Titillium"
-                styleName: 'Thin'
+                weight: Font.Thin
                 letterSpacing: -1
             }
+            renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
@@ -193,8 +196,9 @@ Item {
             font {
                 pixelSize: parent.height * .084375
                 family: "Titillium"
-                styleName: 'Thin'
+                weight: Font.Thin
             }
+            renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
@@ -212,14 +216,16 @@ Item {
                 right: parent.right
             }
             font {
-                pixelSize: parent.height*.084375
+                pixelSize: parent.height * .084375
                 family: "Titillium"
-                styleName:'Thin'
+                weight: Font.Thin
             }
+            renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
             horizontalAlignment: Text.AlignHCenter
+            textFormat: Text.StyledText
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b> MMMM")
         }
 
@@ -235,12 +241,14 @@ Item {
             font {
                 pixelSize: parent.height * .05
                 family: "Titillium"
-                styleName: 'Semibold'
+                weight: Font.DemiBold
             }
+            renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
             horizontalAlignment: Text.AlignHCenter
+            textFormat: Text.StyledText
             visible: use12H.value
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>ap</b>")
         }
@@ -317,9 +325,11 @@ Item {
                     family: "Titillium"
                     styleName: "ExtraCondensed"
                 }
+                renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
-                style: Text.Outline; styleColor: "#80000000"
+                style: Text.Outline
+                styleColor: "#80000000"
                 text: batteryChargePercentage.percent + "%"
             }
         }
@@ -358,9 +368,8 @@ Item {
             minuteCanvas.requestPaint()
             hourCanvas.hour = hour
             hourCanvas.requestPaint()
-
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * nightstandMode.active ? .08 : .3})
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * nightstandMode.active ? .08 : .3})
+            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .3) })
+            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .3) })
         }
     }
 }

--- a/src/watchfaces/017-contemporary-digital-rings.qml
+++ b/src/watchfaces/017-contemporary-digital-rings.qml
@@ -1,33 +1,16 @@
-/*
- * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2022 - Ed Beroset <github.com/beroset>
- *               2017 - Mario Kicherer <dev@kicherer.org>
- *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
- *               2015 - Florent Revest <revestflo@gmail.com>
- *               2012 - Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
- *                      Aleksey Mikhailichenko <a.v.mich@gmail.com>
- *                      Arto Jalkanen <ajalkane@gmail.com>
- * All rights reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: 2023 Timo Könnecke <github.com/moWerk>
+// SPDX-FileCopyrightText: 2022 Darrel Griét <dgriet@gmail.com>
+// SPDX-FileCopyrightText: 2022 Ed Beroset <github.com/beroset>
+// SPDX-FileCopyrightText: 2017 Mario Kicherer <dev@kicherer.org>
+// SPDX-FileCopyrightText: 2016 Sylvia van Os <iamsylvie@openmailbox.org>
+// SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
+// SPDX-FileCopyrightText: 2012 Vasiliy Sorokin <sorokin.vasiliy@gmail.com>
+// SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
+// SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
-/*
- * Based on analog-precison by Mario Kicherer. Remodeled the arms to arcs
- * and tried hard on font centering and anchor alignment.
- */
+// Based on analog-precison by Mario Kicherer. Remodeled the arms to arcs
+// and tried hard on font centering and anchor alignment.
 
 import QtQuick
 import QtQuick.Shapes

--- a/src/watchfaces/017-contemporary-digital-rings.qml
+++ b/src/watchfaces/017-contemporary-digital-rings.qml
@@ -117,10 +117,10 @@ Item {
             id: hourDisplay
 
             anchors {
-                right: parent.horizontalCenter
-                rightMargin: -parent.height * .0938
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: -parent.width * .1085
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: parent.height * .0281
+                verticalCenterOffset: -parent.height * .03
             }
             font {
                 pixelSize: parent.height * .375
@@ -141,17 +141,14 @@ Item {
         Text {
             id: minuteDisplay
 
-            property real rotM: (wallClock.time.getMinutes() - 12.1) / 60
-
             anchors {
-                top: hourDisplay.top;
-                topMargin: -parent.height * .015625
-                leftMargin: parent.width * .025
-                left: hourDisplay.right;
+                left: parent.horizontalCenter
+                leftMargin: parent.width * .117
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * .085
             }
             font {
                 pixelSize: parent.height * .1375
-                weight: Font.DemiBold
                 letterSpacing: -1
             }
             renderType: Text.NativeRendering
@@ -165,10 +162,10 @@ Item {
             id: secondDisplay
 
             anchors {
-                bottom: hourDisplay.bottom;
-                bottomMargin: parent.height * .059375
-                leftMargin: parent.width * .025
-                left: hourDisplay.right;
+                left: parent.horizontalCenter
+                leftMargin: parent.width * .1175
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: parent.height * .0665
             }
             font {
                 pixelSize: parent.height * .1375
@@ -181,17 +178,18 @@ Item {
             style: Text.Outline
             styleColor: Qt.rgba(0, 0, 0, .5)
             horizontalAlignment: Text.AlignHCenter
-            text: wallClock.time.toLocaleString(Qt.locale(), "ss")
             visible: !displayAmbient
+            text: wallClock.time.toLocaleString(Qt.locale(), "ss")
         }
 
         Text {
             id: dowDisplay
 
             anchors {
-                bottom: hourDisplay.top
-                left: parent.left
-                right: parent.right
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: -parent.width * .002
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * .2165
             }
             font {
                 pixelSize: parent.height * .084375
@@ -206,37 +204,52 @@ Item {
             text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
         }
 
-        Text {
+        Row {
             id: dateDisplay
-
+            
             anchors {
-                topMargin: -parent.height * .05
-                top: hourDisplay.bottom
-                left: parent.left
-                right: parent.right
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: parent.width * .002
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: parent.height * .20
             }
-            font {
-                pixelSize: parent.height * .084375
-                family: "Titillium"
-                weight: Font.Thin
+            spacing: parent.width * .018
+
+            Text {
+                font {
+                    pixelSize: parent.parent.height * .084375
+                    family: "Titillium"
+                    weight: Font.Medium
+                }
+                renderType: Text.NativeRendering
+                color: Qt.rgba(1, 1, 1, 1)
+                style: Text.Outline
+                styleColor: Qt.rgba(0, 0, 0, .5)
+                text: wallClock.time.toLocaleString(Qt.locale(), "dd")
             }
-            renderType: Text.NativeRendering
-            color: Qt.rgba(1, 1, 1, 1)
-            style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
-            horizontalAlignment: Text.AlignHCenter
-            textFormat: Text.StyledText
-            text: wallClock.time.toLocaleString(Qt.locale(), "<b>dd</b> MMMM")
+
+            Text {
+                font {
+                    pixelSize: parent.parent.height * .084375
+                    family: "Titillium"
+                    weight: Font.Thin
+                }
+                renderType: Text.NativeRendering
+                color: Qt.rgba(1, 1, 1, 1)
+                style: Text.Outline
+                styleColor: Qt.rgba(0, 0, 0, .5)
+                text: wallClock.time.toLocaleString(Qt.locale(), "MMMM")
+            }
         }
 
         Text {
             id: pmDisplay
 
             anchors {
-                bottomMargin: +parent.height * .018
-                bottom: dowDisplay.top
-                left: parent.left
-                right: parent.right
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: -parent.width * .0015
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * .2975
             }
             font {
                 pixelSize: parent.height * .05

--- a/src/watchfaces/017-contemporary-digital-rings.qml
+++ b/src/watchfaces/017-contemporary-digital-rings.qml
@@ -8,44 +8,58 @@
 // SPDX-FileCopyrightText: 2012 Aleksey Mikhailichenko <a.v.mich@gmail.com>
 // SPDX-FileCopyrightText: 2012 Arto Jalkanen <ajalkane@gmail.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
-
 // Based on analog-precison by Mario Kicherer. Remodeled the arms to arcs
 // and tried hard on font centering and anchor alignment.
 
+import Nemo.Mce
+import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Shapes
-import Qt5Compat.GraphicalEffects
 import org.asteroid.controls
-import org.asteroid.utils
-import Nemo.Mce
 
 Item {
-    anchors.fill: parent
-
-    property real radian: .01745
+    property real radian: 0.01745
 
     function prepareContext(ctx) {
-        ctx.reset()
-        ctx.shadowColor = (0, 0, 0, .25)
-        ctx.shadowOffsetX = 0
-        ctx.shadowOffsetY = 0
-        ctx.shadowBlur = parent.height * .00625
-        ctx.lineCap= "round"
+        ctx.reset();
+        ctx.shadowColor = (0, 0, 0, 0.25);
+        ctx.shadowOffsetX = 0;
+        ctx.shadowOffsetY = 0;
+        ctx.shadowBlur = parent.height * 0.00625;
+        ctx.lineCap = "round";
     }
+
+    anchors.fill: parent
 
     Item {
         anchors.centerIn: parent
-
-        height: parent.width > parent.height ? parent.height : parent.width
+        height: Math.min(parent.width, parent.height)
         width: height
+        Component.onCompleted: {
+            var hour = wallClock.time.getHours();
+            var minute = wallClock.time.getMinutes();
+            var second = wallClock.time.getSeconds();
+            secondCanvas.second = second;
+            secondCanvas.requestPaint();
+            minuteCanvas.minute = minute;
+            minuteCanvas.requestPaint();
+            hourCanvas.hour = hour;
+            hourCanvas.requestPaint();
+            burnInProtectionManager.widthOffset = Qt.binding(function() {
+                return width * (nightstandMode.active ? 0.08 : 0.3);
+            });
+            burnInProtectionManager.heightOffset = Qt.binding(function() {
+                return height * (nightstandMode.active ? 0.08 : 0.3);
+            });
+        }
 
         Rectangle {
-            x: parent.width / 2-width / 2
-            y: parent.height / 2-width / 2
-            color: Qt.rgba(0, 0, 0, .2)
+            x: parent.width / 2 - width / 2
+            y: parent.height / 2 - width / 2
+            color: Qt.rgba(0, 0, 0, 0.2)
             width: parent.width / 1.3
             height: parent.height / 1.3
-            radius: width * .5
+            radius: width * 0.5
         }
 
         Canvas {
@@ -58,15 +72,15 @@ Item {
             renderStrategy: Canvas.Cooperative
             visible: !displayAmbient && !nightstandMode.active
             onPaint: {
-                var ctx = getContext("2d")
-                var rot = (wallClock.time.getSeconds() - 15) * 6
-                var rot_half = (wallClock.time.getSeconds() - 22) * 6
-                prepareContext(ctx)
-                ctx.beginPath()
-                ctx.arc(parent.width / 2, parent.height / 2, width / 2.2, -89.5 * radian, rot* radian, false);
-                ctx.lineWidth = parent.width * .009375
-                ctx.strokeStyle = Qt.rgba(.871, .165, .102, .95)
-                ctx.stroke()
+                var ctx = getContext("2d");
+                var rot = (wallClock.time.getSeconds() - 15) * 6;
+                var rot_half = (wallClock.time.getSeconds() - 22) * 6;
+                prepareContext(ctx);
+                ctx.beginPath();
+                ctx.arc(parent.width / 2, parent.height / 2, width / 2.2, -89.5 * radian, rot * radian, false);
+                ctx.lineWidth = parent.width * 0.009375;
+                ctx.strokeStyle = Qt.rgba(0.871, 0.165, 0.102, 0.95);
+                ctx.stroke();
             }
         }
 
@@ -80,14 +94,14 @@ Item {
             renderStrategy: Canvas.Cooperative
             visible: !displayAmbient && !nightstandMode.active
             onPaint: {
-                var ctx = getContext("2d")
-                var rot = (minute -15 ) * 6
-                prepareContext(ctx)
-                ctx.beginPath()
+                var ctx = getContext("2d");
+                var rot = (minute - 15) * 6;
+                prepareContext(ctx);
+                ctx.beginPath();
                 ctx.arc(parent.width / 2, parent.height / 2, width / 2.33, -88.8 * radian, rot * radian, false);
-                ctx.lineWidth = parent.width * .01875
-                ctx.strokeStyle = Qt.rgba(1, .549, .149, .95)
-                ctx.stroke()
+                ctx.lineWidth = parent.width * 0.01875;
+                ctx.strokeStyle = Qt.rgba(1, 0.549, 0.149, 0.95);
+                ctx.stroke();
             }
         }
 
@@ -101,169 +115,193 @@ Item {
             renderStrategy: Canvas.Cooperative
             visible: !displayAmbient && !nightstandMode.active
             onPaint: {
-                var ctx = getContext("2d")
-                var rot = .5 * (60 * (hour - 3) + wallClock.time.getMinutes())
-                prepareContext(ctx)
-                ctx.beginPath()
-                ctx.arc(parent.width / 2, parent.height / 2, width / 2.6,  273.5 * radian, rot * radian, false);
-                ctx.lineWidth = parent.width * .05
-                ctx.strokeStyle = Qt.rgba(.945, .769, .059, .95)
-                ctx.stroke()
-                ctx.beginPath()
+                var ctx = getContext("2d");
+                var rot = 0.5 * (60 * (hour - 3) + wallClock.time.getMinutes());
+                prepareContext(ctx);
+                ctx.beginPath();
+                ctx.arc(parent.width / 2, parent.height / 2, width / 2.6, 273.5 * radian, rot * radian, false);
+                ctx.lineWidth = parent.width * 0.05;
+                ctx.strokeStyle = Qt.rgba(0.945, 0.769, 0.059, 0.95);
+                ctx.stroke();
+                ctx.beginPath();
             }
         }
 
         Text {
             id: hourDisplay
 
+            renderType: Text.NativeRendering
+            color: Qt.rgba(1, 1, 1, 1)
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, 0.5)
+            text: {
+                if (use12H.value) {
+                    wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2);
+                } else {
+                    wallClock.time.toLocaleString(Qt.locale(), "HH");
+                }
+            }
+
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: -parent.width * .1085
+                horizontalCenterOffset: -parent.width * 0.1085
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -parent.height * .03
+                verticalCenterOffset: -parent.height * 0.03
             }
+
             font {
-                pixelSize: parent.height * .375
+                pixelSize: parent.height * 0.375
                 family: "Titillium"
                 weight: Font.Bold
                 letterSpacing: -3
             }
-            renderType: Text.NativeRendering
-            color: Qt.rgba(1, 1, 1, 1)
-            style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
-            text: if (use12H.value) {
-                      wallClock.time.toLocaleString(Qt.locale(), "hh ap").slice(0, 2) }
-                  else
-                      wallClock.time.toLocaleString(Qt.locale(), "HH")
+
         }
 
         Text {
             id: minuteDisplay
 
-            anchors {
-                left: parent.horizontalCenter
-                leftMargin: parent.width * .117
-                verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -parent.height * .085
-            }
-            font {
-                pixelSize: parent.height * .1375
-                letterSpacing: -1
-            }
             renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
+            styleColor: Qt.rgba(0, 0, 0, 0.5)
             text: wallClock.time.toLocaleString(Qt.locale(), "mm")
+
+            anchors {
+                left: parent.horizontalCenter
+                leftMargin: parent.width * 0.117
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * 0.085
+            }
+
+            font {
+                pixelSize: parent.height * 0.1375
+                letterSpacing: -1
+            }
+
         }
 
         Text {
             id: secondDisplay
 
+            renderType: Text.NativeRendering
+            color: Qt.rgba(1, 1, 1, 1)
+            style: Text.Outline
+            styleColor: Qt.rgba(0, 0, 0, 0.5)
+            horizontalAlignment: Text.AlignHCenter
+            visible: !displayAmbient
+            text: wallClock.time.toLocaleString(Qt.locale(), "ss")
+
             anchors {
                 left: parent.horizontalCenter
-                leftMargin: parent.width * .1175
+                leftMargin: parent.width * 0.1175
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: parent.height * .0665
+                verticalCenterOffset: parent.height * 0.0665
             }
+
             font {
-                pixelSize: parent.height * .1375
+                pixelSize: parent.height * 0.1375
                 family: "Titillium"
                 weight: Font.Thin
                 letterSpacing: -1
             }
-            renderType: Text.NativeRendering
-            color: Qt.rgba(1, 1, 1, 1)
-            style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
-            horizontalAlignment: Text.AlignHCenter
-            visible: !displayAmbient
-            text: wallClock.time.toLocaleString(Qt.locale(), "ss")
+
         }
 
         Text {
             id: dowDisplay
 
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: -parent.width * .002
-                verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -parent.height * .2165
-            }
-            font {
-                pixelSize: parent.height * .084375
-                family: "Titillium"
-                weight: Font.Thin
-            }
             renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
+            styleColor: Qt.rgba(0, 0, 0, 0.5)
             horizontalAlignment: Text.AlignHCenter
             text: wallClock.time.toLocaleString(Qt.locale(), "dddd")
+
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: -parent.width * 0.002
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * 0.2165
+            }
+
+            font {
+                pixelSize: parent.height * 0.084375
+                family: "Titillium"
+                weight: Font.Thin
+            }
+
         }
 
         Row {
             id: dateDisplay
-            
+
+            spacing: parent.width * 0.018
+
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: parent.width * .002
+                horizontalCenterOffset: parent.width * 0.002
                 verticalCenter: parent.verticalCenter
-                verticalCenterOffset: parent.height * .20
+                verticalCenterOffset: parent.height * 0.2
             }
-            spacing: parent.width * .018
 
             Text {
+                renderType: Text.NativeRendering
+                color: Qt.rgba(1, 1, 1, 1)
+                style: Text.Outline
+                styleColor: Qt.rgba(0, 0, 0, 0.5)
+                text: wallClock.time.toLocaleString(Qt.locale(), "dd")
+
                 font {
-                    pixelSize: parent.parent.height * .084375
+                    pixelSize: parent.parent.height * 0.084375
                     family: "Titillium"
                     weight: Font.Medium
                 }
-                renderType: Text.NativeRendering
-                color: Qt.rgba(1, 1, 1, 1)
-                style: Text.Outline
-                styleColor: Qt.rgba(0, 0, 0, .5)
-                text: wallClock.time.toLocaleString(Qt.locale(), "dd")
+
             }
 
             Text {
-                font {
-                    pixelSize: parent.parent.height * .084375
-                    family: "Titillium"
-                    weight: Font.Thin
-                }
                 renderType: Text.NativeRendering
                 color: Qt.rgba(1, 1, 1, 1)
                 style: Text.Outline
-                styleColor: Qt.rgba(0, 0, 0, .5)
+                styleColor: Qt.rgba(0, 0, 0, 0.5)
                 text: wallClock.time.toLocaleString(Qt.locale(), "MMMM")
+
+                font {
+                    pixelSize: parent.parent.height * 0.084375
+                    family: "Titillium"
+                    weight: Font.Thin
+                }
+
             }
+
         }
 
         Text {
             id: pmDisplay
 
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-                horizontalCenterOffset: -parent.width * .0015
-                verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -parent.height * .2975
-            }
-            font {
-                pixelSize: parent.height * .05
-                family: "Titillium"
-                weight: Font.DemiBold
-            }
             renderType: Text.NativeRendering
             color: Qt.rgba(1, 1, 1, 1)
             style: Text.Outline
-            styleColor: Qt.rgba(0, 0, 0, .5)
+            styleColor: Qt.rgba(0, 0, 0, 0.5)
             horizontalAlignment: Text.AlignHCenter
             textFormat: Text.StyledText
             visible: use12H.value
             text: wallClock.time.toLocaleString(Qt.locale(), "<b>ap</b>")
+
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                horizontalCenterOffset: -parent.width * 0.0015
+                verticalCenter: parent.verticalCenter
+                verticalCenterOffset: -parent.height * 0.2975
+            }
+
+            font {
+                pixelSize: parent.height * 0.05
+                family: "Titillium"
+                weight: Font.DemiBold
+            }
+
         }
 
         Item {
@@ -278,10 +316,10 @@ Item {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                property real arcStrokeWidth: .03
-                property real scalefactor: .45 - (arcStrokeWidth / 2)
+                property real arcStrokeWidth: 0.03
+                property real scalefactor: 0.45 - (arcStrokeWidth / 2)
                 property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
-                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(0.318, 1, 0.051, 0.9)]
 
                 anchors.fill: parent
 
@@ -292,7 +330,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (0.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2
@@ -303,20 +341,24 @@ Item {
                         sweepAngle: chargeArc.angle
                         moveToStart: false
                     }
+
                 }
+
             }
 
             Icon {
                 id: batteryIcon
 
                 name: "ios-battery-charging"
+                visible: nightstandMode.active
+                width: parent.width * 0.14
+                height: parent.height * 0.14
+
                 anchors {
                     centerIn: parent
-                    verticalCenterOffset: -parent.width * .316
+                    verticalCenterOffset: -parent.width * 0.316
                 }
-                visible: nightstandMode.active
-                width: parent.width * .14
-                height: parent.height * .14
+
             }
 
             ColorOverlay {
@@ -328,23 +370,26 @@ Item {
             Text {
                 id: batteryPercent
 
-                anchors {
-                    centerIn: parent
-                    verticalCenterOffset: parent.width * .324
-                }
-
-                font {
-                    pixelSize: parent.width * .09
-                    family: "Titillium"
-                    styleName: "ExtraCondensed"
-                }
                 renderType: Text.NativeRendering
                 visible: nightstandMode.active
                 color: chargeArc.colorArray[chargeArc.chargecolor]
                 style: Text.Outline
                 styleColor: "#80000000"
                 text: batteryChargePercentage.percent + "%"
+
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: parent.width * 0.324
+                }
+
+                font {
+                    pixelSize: parent.width * 0.09
+                    family: "Titillium"
+                    styleName: "ExtraCondensed"
+                }
+
             }
+
         }
 
         MceBatteryLevel {
@@ -352,37 +397,30 @@ Item {
         }
 
         Connections {
-            target: wallClock
             function onTimeChanged() {
-                if (displayAmbient) return
-                var hour = wallClock.time.getHours()
-                var minute = wallClock.time.getMinutes()
-                var second = wallClock.time.getSeconds()
-                if(secondCanvas.second !== second) {
-                    secondCanvas.second = second
-                    secondCanvas.requestPaint()
-                } if(hourCanvas.hour !== hour) {
-                    hourCanvas.hour = hour
-                }if(minuteCanvas.minute !== minute) {
-                    minuteCanvas.minute = minute
-                    minuteCanvas.requestPaint()
-                    hourCanvas.requestPaint()
+                if (displayAmbient)
+                    return ;
+
+                var hour = wallClock.time.getHours();
+                var minute = wallClock.time.getMinutes();
+                var second = wallClock.time.getSeconds();
+                if (secondCanvas.second !== second) {
+                    secondCanvas.second = second;
+                    secondCanvas.requestPaint();
+                }
+                if (hourCanvas.hour !== hour)
+                    hourCanvas.hour = hour;
+
+                if (minuteCanvas.minute !== minute) {
+                    minuteCanvas.minute = minute;
+                    minuteCanvas.requestPaint();
+                    hourCanvas.requestPaint();
                 }
             }
+
+            target: wallClock
         }
 
-        Component.onCompleted: {
-            var hour = wallClock.time.getHours()
-            var minute = wallClock.time.getMinutes()
-            var second = wallClock.time.getSeconds()
-            secondCanvas.second = second
-            secondCanvas.requestPaint()
-            minuteCanvas.minute = minute
-            minuteCanvas.requestPaint()
-            hourCanvas.hour = hour
-            hourCanvas.requestPaint()
-            burnInProtectionManager.widthOffset = Qt.binding(function() { return width * (nightstandMode.active ? .08 : .3) })
-            burnInProtectionManager.heightOffset = Qt.binding(function() { return height * (nightstandMode.active ? .08 : .3) })
-        }
     }
+
 }

--- a/src/watchfaces/017-contemporary-digital-rings.qml
+++ b/src/watchfaces/017-contemporary-digital-rings.qml
@@ -249,30 +249,20 @@ Item {
             id: nightstandMode
 
             readonly property bool active: nightstand
-            property int batteryPercentChanged: batteryChargePercentage.percent
 
             anchors.fill: parent
             visible: nightstandMode.active
-            layer {
-                enabled: true
-                samples: 4
-                smooth: true
-                textureSize: Qt.size(nightstandMode.width * 2, nightstandMode.height * 2)
-            }
 
             Shape {
                 id: chargeArc
 
                 property real angle: batteryChargePercentage.percent * 360 / 100
-                // radius of arc is scalefactor * height or width
                 property real arcStrokeWidth: .03
                 property real scalefactor: .45 - (arcStrokeWidth / 2)
-                property var chargecolor: Math.floor(batteryChargePercentage.percent / 33.35)
-                readonly property var colorArray: [ "red", "yellow", Qt.rgba(.318, 1, .051, .9)]
+                property int chargecolor: Math.floor(batteryChargePercentage.percent / 33.35) | 0
+                readonly property var colorArray: ["red", "yellow", Qt.rgba(.318, 1, .051, .9)]
 
                 anchors.fill: parent
-                smooth: true
-                antialiasing: true
 
                 ShapePath {
                     fillColor: "transparent"
@@ -281,7 +271,7 @@ Item {
                     capStyle: ShapePath.RoundCap
                     joinStyle: ShapePath.MiterJoin
                     startX: chargeArc.width / 2
-                    startY: chargeArc.height * ( .5 - chargeArc.scalefactor)
+                    startY: chargeArc.height * (.5 - chargeArc.scalefactor)
 
                     PathAngleArc {
                         centerX: chargeArc.width / 2


### PR DESCRIPTION
Qt6 refactor of the 017-contemporary-digital-rings watchface. Five commits covering SPDX header, nightstand arc correctness, text rendering, a full layout restructure, and a conventions and qmlformat pass. This is the most layout-sensitive watchface in the stock set; the original chained text-to-text anchor system required a full restructure to be Qt6-compatible.

### Commits

1. **Replace legacy copyright block with SPDX header** — converts the multi-line LGPL block comment to `SPDX-FileCopyrightText` and `SPDX-License-Identifier: LGPL-2.1-or-later` one-liners. Nine authors preserved newest-first. Updates Timo Könnecke handle from `eLtMosen` to `moWerk`, creation year 2023 preserved.

2. **Fix Qt6 nightstand arc correctness** — removes the `layer` block from `nightstandMode`. Hardware has no multisample renderbuffers; the block produces a journal warning on every nightstand activation and `textureSize` causes visible stutter. Shape antialiases natively. Removes dead `batteryPercentChanged` property. Adds `| 0` bitwise cast to `chargecolor` and changes `property var` to `property int`. Removes `smooth: true` and `antialiasing: true` from `chargeArc` Shape. Normalises `colorArray` bracket spacing and `startY` parenthesis spacing.

3. **Add Qt6 text rendering properties** — adds `renderType: Text.NativeRendering` to all six Text items and `batteryPercent` in nightstandMode. Converts simple weight-only `font.styleName` values to `font.weight` enum constants: `Bold` on `hourDisplay`, `Semibold` to `Font.DemiBold` on `minuteDisplay` and `pmDisplay`, `Thin` on `secondDisplay`, `dowDisplay`, and `dateDisplay`. Retains `styleName: "ExtraCondensed"` on `batteryPercent` as a Titillium font-file variant name. Splits `style` and `styleColor` onto separate lines throughout. Adds `textFormat: Text.StyledText` to `dateDisplay` and `pmDisplay` which use `<b>` markup. Fixes `burnInProtectionManager` ternary operator precedence in `Component.onCompleted`; the original expressions `width * nightstandMode.active ? .08 : .3` were parsed as `(width * nightstandMode.active) ? .08 : .3`, corrected to `width * (nightstandMode.active ? .08 : .3)`.

4. **Restructure Qt6 layout** — replaces the chained text-to-text anchor system with geometry-relative anchors on all six Text items. The original layout anchored each item to the `top` or `bottom` boundary of another Text item; Qt6 font metric changes cause bounding boxes to expand, compounding through the chain and displacing every item. All items now anchor to `parent.verticalCenter` and `parent.horizontalCenter` with explicit `verticalCenterOffset` and `horizontalCenterOffset` values, making the layout immune to font metric changes. Splits `dateDisplay` into a `Row` containing two separate Text items for the day number and month name, replacing the single Text with `<b>dd</b> MMMM` markup; in Qt6 the `<b>` tag maps to `Font.Bold` which is heavier than the original Thin weight with bold markup in Qt5 — the day number now uses `Font.Medium` and the month name `Font.Thin`, matching the vanilla visual weight. Removes `<b>` markup from `pmDisplay`; `Font.DemiBold` on the base text item matches the vanilla bold appearance without markup. Offset values derived from pixel-accurate GIMP measurement against the Qt5 vanilla screenshot and validated on Qt 6.11 sturgeon 400px hardware. Sub-pixel adjustments improve rendering crispness on 400px beyond the original design which was developed on a 360px base.

5. **Conventions, formatting, and qmlformat pass** — sorts imports alphabetically per qmlformat CI rule. Removes `org.asteroid.utils` which has no references in the file. Retains `org.asteroid.controls` for the `Icon` item used in the nightstand battery charging indicator. Retains `property real radian` which is actively used in all three Canvas arc `onPaint` handlers. Replaces root square sizing ternary with `Math.min`. Full `qmlformat -i` normalisation pass.

### Testing

Built on 2.2 nightly Qt 6.11 (sturgeon, 400px), compared against 1.1 nightly Qt 5.15 vanilla (tunny, 400px).

- Normal mode: all three Canvas arcs (second red, minute orange, hour yellow) render correctly. All six text items render at correct positions matching the vanilla layout.
- Hour, minute, second, day-of-week, date, and am/pm all update correctly.
- 12h/24h toggle: `hourDisplay` and `pmDisplay` respond correctly.
- `dateDisplay` Row: day number renders at `Font.Medium`, month name at `Font.Thin`, matching the vanilla visual weight without `<b>` markup.
- Nightstand mode: battery arc, charging icon, and percentage text render correctly. No multisample renderbuffer journal warning.
- AoD: second display and Canvas arcs correctly hidden.
- No regressions found across all five commits.

### Notes

- The outer screen-filling `Item` is kept intentionally as the system-injected root surface. The inner square `Item` prevents layout squish on non-square panels.
- The three Canvas arc items are intentionally retained. The arcs use `ctx.arc` with specific radius, stroke width, and start angle values that define the visual identity of the face. The `prepareContext` helper and `property real radian` are shared infrastructure for all three arcs.
- The original layout was designed on a 360px reference device. The restructured geometry-relative layout renders crisper on the 400px stock hardware due to the pixel-accurate sub-pixel offset tuning applied during this refactor.
- Chaining text item anchors to other text items is fragile across Qt font metric changes. New watchfaces should anchor all text items to geometry anchors (`parent.verticalCenter`, `parent.horizontalCenter`, or fixed container edges) with explicit offsets.