### PR TITLE
Add shaders/ system folder for compiled Qt6 shader binaries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,10 @@ install(
 	DESTINATION ${CMAKE_INSTALL_DATADIR}/asteroid-launcher
 )
 install(
+	DIRECTORY shaders
+	DESTINATION ${CMAKE_INSTALL_DATADIR}/asteroid-launcher
+)
+install(
 	DIRECTORY applauncher
 	DESTINATION ${CMAKE_INSTALL_DATADIR}/asteroid-launcher
 )


### PR DESCRIPTION
Establishes src/shaders/ as the designated folder for compiled .qsb shader binaries in asteroid-launcher and adds the corresponding CMake install target.

### Motivation

The Qt6 migration requires watchfaces and other QML components that use ShaderEffect to ship pre-compiled .qsb binaries produced by the Qt Shader Tools qsb tool. Qt6 no longer accepts inline GLSL strings in ShaderEffect.fragmentShader; the property now expects a URL pointing to a .qsb file.

The existing watchfaces-img folder is reserved for image assets. A dedicated shaders/ folder keeps binary shader assets cleanly separated and provides a clear, use-case-neutral home for all compiled shaders regardless of whether they originate from a watchface, wallpaper, or other component.

### Changes

Adds `src/shaders/` to the repository via a `.gitkeep` placeholder file. Git does not track empty directories; the `.gitkeep` convention is used to establish the folder in the repository until its first real resident arrives in the 016-masked-spartan PR. The placeholder can be removed at that point or left in place. Adds an `install(DIRECTORY shaders ...)` target to `src/CMakeLists.txt` below the `watchfaces-preview` install block, keeping the three `watchfaces-`prefix folders together as a logical group.

### Intended scope

- **System-installed shaders** (`/usr/share/asteroid-launcher/shaders/`): stock watchface ShaderEffect binaries, future FragCoord stock wallpaper shaders, and any other runtime shader assets shipped with the package.
- **User-supplied shaders**: FragCoord exports and game shaders will reside in the XDG user data directory (`~/.local/share/asteroid-launcher/shaders/`) at runtime and are outside the scope of this system folder.

### Notes

`src/CMakeLists.txt` already uses `qt_add_shaders` for the compositor `circlemaskshader.frag`. Future stock shaders added at build time could use the same mechanism rather than shipping pre-compiled `.qsb` files. Pre-compiled `.qsb` files are appropriate for assets that need to be deployable independently of a full rebuild, such as watchface shaders installed via opkg.

The first consumer of this folder is the 016-masked-spartan watchface Qt6 refactor PR which ships `masked-spartan.frag.qsb` as the initial resident and removes the `.gitkeep`.