### PR TITLE
QuickPanel: control vibrations with dconf rather than profiled

### DIFF
--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -137,7 +137,11 @@ Item {
     }
 
     NonGraphicalFeedback { id: feedback; event: "press" }
-    ProfileControl { id: profileControl }
+    ConfigurationValue {
+        id: vibrationEnabled
+        key: "/desktop/asteroid/vibration"
+        defaultValue: true
+    }
     DisplaySettings { id: displaySettings }
 
     SoundEffect {
@@ -585,13 +589,13 @@ Item {
         QuickPanelToggle {
             icon: "ios-watch-vibrating"
             checkable: true
-            checked: profileControl.profile == "general"
+            checked: vibrationEnabled.value
 
             onClicked: {
                 if(checked) {
-                    profileControl.profile = "silent"
+                    vibrationEnabled.value = false
                 } else {
-                    profileControl.profile = "general";
+                    vibrationEnabled.value = true;
                     feedbackDelayTimer.start();
                 }
             }


### PR DESCRIPTION
To simplify our tech stack, we replaced ngfd's profile module to simply read whether vibrations are enabled from dconf rather than from a more sophisticated profiled.