### PR TITLE
CMakeLists.txt: Use IMPORTED_TARGET on ngf-qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,7 @@ pkg_check_modules(mce-qt6 REQUIRED IMPORTED_TARGET mce-qt6)
 pkg_check_modules(keepalive REQUIRED IMPORTED_TARGET keepalive)
 pkg_check_modules(dbus-1 REQUIRED IMPORTED_TARGET dbus-1)
 pkg_check_modules(dbus-glib-1 REQUIRED IMPORTED_TARGET dbus-glib-1)
-# No IMPORTED_TARGET: ngf-qt6.pc advertises a bogus includedir (the headers
-# actually live in the default include path) and CMake refuses to import it.
-pkg_check_modules(ngf-qt6 REQUIRED ngf-qt6)
+pkg_check_modules(ngf-qt6 REQUIRED IMPORTED_TARGET ngf-qt6)
 pkg_check_modules(libsystemd REQUIRED IMPORTED_TARGET libsystemd)
 pkg_check_modules(dsme_dbus_if REQUIRED IMPORTED_TARGET dsme_dbus_if)
 pkg_check_modules(thermalmanager_dbus_if REQUIRED IMPORTED_TARGET thermalmanager_dbus_if)


### PR DESCRIPTION
PostmarketOS folks somehow get the ngfd-qt6 headers in a different directory than us and they need that IMPORTED_TARGET to build. Depsite what the comment says, we can live with that IMPORTED_TARGET too so there's no problem putting it back.