### PR TITLE
fix(cmake): actually link to the imported ngf-qt6 target

### DIFF
--- a/lipstick/CMakeLists.txt
+++ b/lipstick/CMakeLists.txt
@@ -80,7 +80,7 @@ target_link_libraries(lipstick PUBLIC
 	PkgConfig::keepalive
 	PkgConfig::dbus-1
 	PkgConfig::dbus-glib-1
-	${ngf-qt6_LIBRARIES}
+	PkgConfig::ngf-qt6
 	PkgConfig::libsystemd
 	PkgConfig::dsme_dbus_if
 	PkgConfig::thermalmanager_dbus_if


### PR DESCRIPTION
This was done differently because it seems AsteroidOS installs the ngf-qt6 headers in a different place than it's .pc file says. That is really a packaging bug and should be fixed in the ngf-qt6 packaging, not worked around here. Without this change it fails to build on platforms where the ngf-qt6 packaging is correct like postmarketOS.

Follow-up to #266