### PR TITLE
bluetoothagent: don't block compositor startup on org.bluez

### DIFF
--- a/lipstick/src/bluetoothagent.cpp
+++ b/lipstick/src/bluetoothagent.cpp
@@ -16,6 +16,8 @@
  */
 
 #include <QDBusInterface>
+#include <QDBusConnectionInterface>
+#include <QDBusReply>
 #include <QDBusPendingCall>
 #include <QDBusVariant>
 
@@ -34,8 +36,7 @@ BluetoothAgent::BluetoothAgent(QObject *parent) : QObject(parent)
     connect(mWatcher, SIGNAL(serviceRegistered(const QString&)), this, SLOT(serviceRegistered(const QString&)));
     connect(mWatcher, SIGNAL(serviceUnregistered(const QString&)), this, SLOT(serviceUnregistered(const QString&)));
 
-    QDBusInterface remoteOm("org.bluez", "/", "org.bluez.AgentManager1", bus);
-    if(remoteOm.isValid())
+    if(bus.interface()->isServiceRegistered("org.bluez").value())
         serviceRegistered("org.bluez");
 
     state = Idle;


### PR DESCRIPTION
The agent constructor probed org.bluez by constructing a QDBusInterface and calling isValid(), which performs a synchronous Introspect. With nothing having touched bluez yet this D-Bus-auto-activates bluetooth.service and blocks the GUI main thread until it replies -- or until the 25s activation timeout when the libhybris BT HAL is slow/wedged. That put first-frame / sd_notify on the bluez critical path (observed +14s typical, +25s worst case at boot).

Probe presence with QDBusConnectionInterface::isServiceRegistered (NameHasOwner) instead: it queries the always-present bus daemon, never activates bluez, and returns immediately. If bluez is down at startup the existing QDBusServiceWatcher registers the agent when it appears, so pairing is unaffected.