### PR TITLE
Play UI sounds through ngf instead of QtMultimedia SoundEffect

### DIFF
--- a/src/qml/notifications/NotificationView.qml
+++ b/src/qml/notifications/NotificationView.qml
@@ -39,17 +39,8 @@ MouseArea {
     property bool forbidTop: column.y < 0
     property real prevY: 0
 
-    // Play the notification sound through ngf instead of a QtMultimedia
-    // SoundEffect, which misbehaves twice on Qt6: its playback chops the
-    // sample into fragments with audible gaps, and it opens a PulseAudio
-    // stream on construction that it holds for the object's whole lifetime,
-    // keeping the audio sink (and its power rail) from ever suspending -- a
-    // constant standby battery drain. ngfd plays the sound gaplessly through a
-    // short-lived GStreamer pipeline that tears down when playback ends, so
-    // the sink suspends again at idle. It also routes through the profile
-    // plugin, so the sound now honours silent mode.
     NonGraphicalFeedback {
-        id: notifFeedback
+        id: notifSound
         event: "notification"
     }
 
@@ -58,7 +49,7 @@ MouseArea {
             appName.text = notification.appName
             summary.text = notification.summary
             body.text = notification.body
-            notifFeedback.play()
+            notifSound.play()
             updateTimestamp()
         }
     }

--- a/src/qml/notifications/NotificationView.qml
+++ b/src/qml/notifications/NotificationView.qml
@@ -29,7 +29,7 @@
 
 import QtQuick
 import org.asteroid.controls
-import QtMultimedia
+import Nemo.Ngf
 
 MouseArea {
     id: view
@@ -39,9 +39,18 @@ MouseArea {
     property bool forbidTop: column.y < 0
     property real prevY: 0
 
-    SoundEffect {
-        id: notifSound
-        source: "file:///usr/share/sounds/notification.wav"
+    // Play the notification sound through ngf instead of a QtMultimedia
+    // SoundEffect, which misbehaves twice on Qt6: its playback chops the
+    // sample into fragments with audible gaps, and it opens a PulseAudio
+    // stream on construction that it holds for the object's whole lifetime,
+    // keeping the audio sink (and its power rail) from ever suspending -- a
+    // constant standby battery drain. ngfd plays the sound gaplessly through a
+    // short-lived GStreamer pipeline that tears down when playback ends, so
+    // the sink suspends again at idle. It also routes through the profile
+    // plugin, so the sound now honours silent mode.
+    NonGraphicalFeedback {
+        id: notifFeedback
+        event: "notification"
     }
 
     onNotificationChanged: {
@@ -49,7 +58,7 @@ MouseArea {
             appName.text = notification.appName
             summary.text = notification.summary
             body.text = notification.body
-            notifSound.play()
+            notifFeedback.play()
             updateTimestamp()
         }
     }

--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -31,7 +31,6 @@
 
 import QtQuick
 import Qt5Compat.GraphicalEffects
-import QtMultimedia
 import org.asteroid.controls
 import org.asteroid.utils
 import org.asteroid.launcher
@@ -144,10 +143,15 @@ Item {
     }
     DisplaySettings { id: displaySettings }
 
-    SoundEffect {
-        id: unmuteSound
-        source: "file:///usr/share/sounds/notification.wav"
-        volume: 0.8
+    // Play the un-mute confirmation through ngf rather than a QtMultimedia
+    // SoundEffect: on Qt6 a SoundEffect plays chopped and holds a PulseAudio
+    // stream open for its whole lifetime, preventing the audio sink from
+    // suspending (constant battery drain). ngfd plays gaplessly via a
+    // short-lived GStreamer pipeline so the sink can suspend again at idle.
+    // Reuses the "notification" ngf event.
+    NonGraphicalFeedback {
+        id: unmuteFeedback
+        event: "notification"
     }
 
     NetworkTechnology {
@@ -704,7 +708,7 @@ Item {
                 id: soundDelayTimer
                 interval: 150
                 repeat: false
-                onTriggered: unmuteSound.play()
+                onTriggered: unmuteFeedback.play()
             }
 
             Connections {

--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -143,14 +143,8 @@ Item {
     }
     DisplaySettings { id: displaySettings }
 
-    // Play the un-mute confirmation through ngf rather than a QtMultimedia
-    // SoundEffect: on Qt6 a SoundEffect plays chopped and holds a PulseAudio
-    // stream open for its whole lifetime, preventing the audio sink from
-    // suspending (constant battery drain). ngfd plays gaplessly via a
-    // short-lived GStreamer pipeline so the sink can suspend again at idle.
-    // Reuses the "notification" ngf event.
     NonGraphicalFeedback {
-        id: unmuteFeedback
+        id: unmuteSound
         event: "notification"
     }
 
@@ -708,7 +702,7 @@ Item {
                 id: soundDelayTimer
                 interval: 150
                 repeat: false
-                onTriggered: unmuteFeedback.play()
+                onTriggered: unmuteSound.play()
             }
 
             Connections {


### PR DESCRIPTION
Hi folks, first PR to AsteroidOS repos, so pointers are very welcome!

Came across this when improving battery lifetime for the `eos` variant of the upcoming `aurora` port. 

The notification and un-mute sounds are played with a QtMultimedia SoundEffect. That object opens a PulseAudio stream when it is created and keeps it open for the launcher's whole lifetime. Because these SoundEffect objects
live for the entire session, their streams never close, the audio sink never suspends

This depends on [AsteroidOS/meta-asteroid#279](https://github.com/AsteroidOS/meta-asteroid/pull/279), which adds the sound-only "notification" ngf event this calls. Without that event the launcher would be silent, so that one should land first.