### PR TITLE
Release the notification sound's audio stream when idle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(QML_FILES
 	qml/misc/PanelsGrid.qml
 	qml/misc/ShutdownScreen.qml
 	qml/misc/BluetoothAgent.qml
+	qml/misc/OneShotSound.qml
 	qml/misc/desktop.js
 	qml/notifications/NotificationActions.qml
 	qml/notifications/NotificationButton.qml
@@ -49,6 +50,7 @@ set_source_files_properties(qml/misc/Splash.qml                      PROPERTIES 
 set_source_files_properties(qml/misc/PanelsGrid.qml                  PROPERTIES QT_RESOURCE_ALIAS PanelsGrid.qml)
 set_source_files_properties(qml/misc/ShutdownScreen.qml              PROPERTIES QT_RESOURCE_ALIAS system/ShutdownScreen.qml)
 set_source_files_properties(qml/misc/BluetoothAgent.qml              PROPERTIES QT_RESOURCE_ALIAS connectivity/BluetoothAgent.qml)
+set_source_files_properties(qml/misc/OneShotSound.qml                PROPERTIES QT_RESOURCE_ALIAS OneShotSound.qml)
 set_source_files_properties(qml/misc/desktop.js                      PROPERTIES QT_RESOURCE_ALIAS desktop.js)
 set_source_files_properties(qml/notifications/NotificationActions.qml   PROPERTIES QT_RESOURCE_ALIAS NotificationActions.qml)
 set_source_files_properties(qml/notifications/NotificationButton.qml    PROPERTIES QT_RESOURCE_ALIAS NotificationButton.qml)

--- a/src/qml/misc/OneShotSound.qml
+++ b/src/qml/misc/OneShotSound.qml
@@ -1,0 +1,43 @@
+// Plays a sound once on a short-lived SoundEffect that is destroyed when
+// playback ends, so the audio sink can suspend at idle. Drop-in for SoundEffect.
+
+import QtQuick
+import QtMultimedia
+
+QtObject {
+    id: root
+
+    property url source
+    property real volume: 1.0
+
+    property Component effect: Component {
+        SoundEffect {
+            source: root.source
+            volume: root.volume
+
+            property bool started: false
+
+            // The sample loads asynchronously; only play once it is ready, and
+            // only once. Then tear the object down when playback finishes.
+            function playWhenReady() {
+                if (!started && status === SoundEffect.Ready) {
+                    started = true
+                    play()
+                }
+            }
+            onStatusChanged: {
+                playWhenReady()
+                // If the sample can't be loaded it will never play or finish,
+                // so destroy it here to avoid leaking an object per call.
+                if (status === SoundEffect.Error)
+                    destroy()
+            }
+            Component.onCompleted: playWhenReady()
+            onPlayingChanged: if (started && !playing) destroy()
+        }
+    }
+
+    function play() {
+        effect.createObject(root)
+    }
+}

--- a/src/qml/notifications/NotificationView.qml
+++ b/src/qml/notifications/NotificationView.qml
@@ -29,7 +29,6 @@
 
 import QtQuick
 import org.asteroid.controls
-import QtMultimedia
 
 MouseArea {
     id: view
@@ -39,7 +38,7 @@ MouseArea {
     property bool forbidTop: column.y < 0
     property real prevY: 0
 
-    SoundEffect {
+    OneShotSound {
         id: notifSound
         source: "file:///usr/share/sounds/notification.wav"
     }

--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -31,7 +31,6 @@
 
 import QtQuick
 import Qt5Compat.GraphicalEffects
-import QtMultimedia
 import org.asteroid.controls
 import org.asteroid.utils
 import org.asteroid.launcher
@@ -144,7 +143,7 @@ Item {
     }
     DisplaySettings { id: displaySettings }
 
-    SoundEffect {
+    OneShotSound {
         id: unmuteSound
         source: "file:///usr/share/sounds/notification.wav"
         volume: 0.8


### PR DESCRIPTION
Hi folks! First PR to asteroidOS, so be kind, I appreciate pointers and input if you have them 😄 

The notification and un-mute sounds are played by SoundEffect objects that live for the whole launcher session. A SoundEffect opens a PulseAudio playback stream when it is created and holds it for its entire lifetime, so these streams never close, the audio sink never suspends, module-suspend-on-idle never fires, and the audio power rail stays awake, a constant standby battery drain.

I will verify on-device (Pixel Watch 2, MACHINE=aurora) that both the notification and un-mute sounds still play and
that the audio sink suspends at idle afterwards, and report back here before this is ready to merge. Flagging now for early feedback on the approach.