### PR TITLE
NotificationPreview: hide by default

### DIFF
--- a/src/qml/notifications/NotificationPreview.qml
+++ b/src/qml/notifications/NotificationPreview.qml
@@ -116,6 +116,7 @@ Item {
             }
         }
 
+        state: "hide"
         states: [
             State {
                 name: "show"


### PR DESCRIPTION
NotificationPreview currently has a default 'shown' state, which remains from launcher startup until a notification shows up and is dismissed. This results in the screen being dimmed.
