### PR TITLE
quickpanel: Stop battery pulse animation when panel is off-screen

### DIFF
--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -501,8 +501,11 @@ Item {
         visible: isCharging
         opacity: 1.0
 
+        // Only pulse while the panel is on screen. The panels grid toggles
+        // rootitem.visible per panel, so this stops the infinite animation
+        // from waking the CPU every 1.5s while charging on another panel.
         SequentialAnimation on opacity {
-            running: isCharging && options.value.batteryAnimation
+            running: rootitem.visible && isCharging && options.value.batteryAnimation
             loops: Animation.Infinite
             NumberAnimation { to: 0.7; duration: 1500; easing.type: Easing.InOutQuad }
             NumberAnimation { to: 1.0; duration: 1500; easing.type: Easing.InOutQuad }


### PR DESCRIPTION
First increment of the QuickPanel cleanup tracked in #278.

The charging pulse on flashIcon runs an infinite animation gated only on
charging state. It keeps waking the CPU every 1.5 seconds even when the
QuickPanel is not the visible panel. A running animation keeps consuming even
when the item is not rendered, so while charging this runs in the background
and can slow charging down, which matches the behavior noted in the #215
review.

This gates the animation on rootitem.visible, which the panels grid already
toggles per panel, so the pulse only runs while the panel is on screen. One
line of logic plus a comment.
