### PR TITLE
Match settings' default for the nightstand AoD key

### DIFF
--- a/src/qml/MainScreen.qml
+++ b/src/qml/MainScreen.qml
@@ -297,7 +297,7 @@ Item {
     ConfigurationValue {
         id: nightstandAlwaysOnDisplay
         key: "/desktop/asteroid/nightstand/always-on-display"
-        defaultValue: false
+        defaultValue: true
     }
 
     ConfigurationValue {


### PR DESCRIPTION
## The defect

Two projects declare different `defaultValue`s for the **same** dconf key:

| file | `defaultValue` |
|---|---|
| `asteroid-settings` `src/qml/NightstandPage.qml:59` | **`true`** |
| `asteroid-launcher` `src/qml/MainScreen.qml:300` | **`false`** |

The key `/desktop/asteroid/nightstand/always-on-display` is **unset** until a user touches it, so on a fresh flash each project falls back to its own default and they disagree.

## What that does

```
key unset on a fresh flash
  → asteroid-settings default true    →  user is shown the AoD toggle ON
  → asteroid-launcher default false   →  writes lowPowerModeEnabled = false
  → MCE "Use low power mode" = disabled
  → MCE pushes setAmbientEnabled(FALSE) to org.nemomobile.compositor
  → lipstick discards every ambient update tick
  → black screen in LPM, with no error reported anywhere
```

Compositor trace from the broken state (instrumented build, behind the existing `LIPSTICK_COMPOSITOR_DEBUG` gate):

```
AOD setAmbientEnabled( false ) supported= true current= false
AOD setAmbientUpdatesEnabled( true ) displayState= 0 ambientEnabled= false
AOD update DISCARDED: ambient mode is not enabled
```

## Confirmation on hardware

Same watch (sturgeon), same fresh flash, same docked boot, **only this line changed**:

```
before:  nightstandAodKey = false  →  NSD enter: will write lowPowerModeEnabled = false
after:   nightstandAodKey = true   →  NSD enter: will write lowPowerModeEnabled = true
```

MCE then reads `Use low power mode: enabled` 25 s into a fresh docked boot — a value that was `disabled` on every previous fresh flash — and the watchface renders in LPM right after firstrun, with nothing touched.

## Why it looked unreproducible

Every known "fix" was really some *other* path writing the main AoD key, whose default is `true` in both projects: disabling nightstand, unplugging the charger, or the quickpanel AoD toggle. And it is intermittent across identical reboots, because `mceChargerType` resolves asynchronously — whether it settles before or after component completion decides whether the bad value is written at all.

## Reproduction

1. Flash a recent image, complete firstrun, leave the watch **on the charger**.
2. Let it blank → black in LPM, while both AoD toggles read on.
3. `mcetool | grep 'Use low power mode'` → `disabled`.
4. Disable nightstand, unplug, or hit the quickpanel AoD toggle → renders.

## Related

There is a second, independent defect in `asteroid-settings` `DisplayPage.qml:127`: with nightstand enabled **and** the watch charging, toggling AoD there updates dconf but never reaches MCE, so the toggle silently does nothing. Worth its own patch; it is not fixed here.

---

*Diagnosed on an AsteroidOS watch rig across ~12 build/flash cycles. This investigation was performed with an LLM (Claude Opus) under my direction; every figure above is from live hardware and reproducible with the steps given. Please push back on anything that doesn't match your reading of the code.*

## Ruled out along the way, with the evidence

Recorded so none of this needs investigating again:

| theory | killed by |
|---|---|
| framebuffer / display-driver handoff | `ambientSupported()` returns **true** over D-Bus on a broken watch |
| the Qt6 migration | the bug is present in 2.0 and 2.1 |
| the quickpanel rework (#180) | it writes both values unconditionally — a *workaround*, and it predates 2.0 |
| cradle / USB / power state | a VBUS cycle and a usb-moded mode switch neither break nor fix it |
| a missing boot-time apply | a service applying the setting at boot was built and flashed; a **control image without it rendered too**, so it was not the fix |
| nightstand's uninitialised `onReadyChanged` | real — a watch booting already on the charger never fires it — but **not sufficient**: patched, flashed, still black |

The last two were our own hypotheses. Both were built, flashed, and disproved by controls.
