### PR TITLE
Fix live reload reverting a just-activated face

### DIFF
--- a/src/qml/MainScreen.qml
+++ b/src/qml/MainScreen.qml
@@ -48,6 +48,10 @@ Item {
     visible: Lipstick.compositor.homeActive || aboutToOpen || aboutToClose || aboutToMinimize
     enabled: visible
 
+    // Requests the active watchface Loader to reload from disk. A signal, so
+    // the handler can live in the Loader's own scope.
+    signal watchfaceReloadRequested()
+
     AppLauncherBackground { id: alb }
 
     property var defaultCenterColor: alb.centerColor("/usr/share/asteroid-launcher/default-colors.desktop")
@@ -365,9 +369,7 @@ Item {
         // dropped the component cache, so re-trigger the loader to re-read the
         // directory and pick the new face up live.
         function onReloadNeeded() {
-            var watchFaceSourceBackup = watchFaceSource.value
-            watchFaceSource.value = ""
-            watchFaceSource.value = watchFaceSourceBackup
+            desktop.watchfaceReloadRequested()
         }
     }
 
@@ -393,6 +395,18 @@ Item {
                 Behavior on opacity { NumberAnimation { duration: 200; easing.type: Easing.InCirc} }
                 anchors.fill: parent
                 source: watchFaceSource.value
+
+                // Reinstantiate to re-read the source from disk. Toggling the
+                // Loader instead of rewriting the dconf-backed watchFaceSource
+                // avoids a cross-process write that can clobber a concurrent
+                // activation.
+                Connections {
+                    target: desktop
+                    function onWatchfaceReloadRequested() {
+                        watchfaceLoader.active = false
+                        watchfaceLoader.active = true
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
f8e47ba reloads the homescreen face after a store install by bouncing the dconf-backed watchFaceSource (save it, clear it, write it back). 
But because that key is dconf-backed, the write-back races the settings app, which writes the same key to activate the just-installed face in another process. When the ~/.fonts install event reaches the launcher before the activation write does, onReloadNeeded writes the previous face back over the activation: the selection reverts and the compositor never loads the new one. Faces that bundle a font are affected, and whether an install sticks is pure timing.

This routes a signal from the desktop root into the watchface Loader and reinstantiates it to re-read the cache-cleared source, so the live reload keeps working without ever writing watchFaceSource, and a concurrent activation is never clobbered.

Review ask: If the comments feel too elaborate or not timeless enough, i am happy to rework.

Tested on beluga and catfish: community faces that intermittently reverted during development/testing of the incoming preview-auto-generator PR (e.g. navigator, halloween, duppy-vintage) now stay activated, and selection is noticeably snappier.