### PR TITLE
speed-dial: Reduce wheel spin cost

### DIFF
--- a/src/applauncher/005-speed-dial.qml
+++ b/src/applauncher/005-speed-dial.qml
@@ -97,12 +97,13 @@ Item {
                     width: parent.width
                     height: parent.height
                     radius: width/2
-                    opacity: launcherItem.pressed | fakePressed ? 0.8 : 1.0
+                    opacity: (launcherItem.pressed && !pv.moving) | fakePressed ? 0.8 : 1.0
                     color: (root.selectedLauncherItem == model.object) ? alb.centerColor(model.object.filePath) : "#f4f4f4"
                     Behavior on opacity {
                         PropertyAnimation { target: circle; duration: 70 }
                     }
                     Behavior on color {
+                        enabled: !pv.moving
                         PropertyAnimation { target: circle; property: "color"; duration: 70 }
                     }
                 }
@@ -124,10 +125,11 @@ Item {
                 anchors.centerIn: circleWrapper
                 width: circleWrapper.width * 0.70
                 height: width
-                opacity: launcherItem.pressed | fakePressed ? 1.0 : 0.9
+                opacity: (launcherItem.pressed && !pv.moving) | fakePressed ? 1.0 : 0.9
                 name: model.object.iconId === "" ? "ios-help" : model.object.iconId
                 color: (root.selectedLauncherItem == model.object) ? "#ffffff" : "#000000"
                 Behavior on color {
+                    enabled: !pv.moving
                     PropertyAnimation { target: icon; property: "color"; duration: 70 }
                 }
             }

--- a/src/applauncher/005-speed-dial.qml
+++ b/src/applauncher/005-speed-dial.qml
@@ -60,6 +60,7 @@ Item {
         model: launcherModel
         focus: true
         pathItemCount: 8
+        cacheItemCount: launcherModel.itemCount
         path: Path {
             startX: pv.width/2-pv.borderRadius/2
             startY: pv.height/2-pv.borderRadius/2 + pv.borderRadius/2 - 1

--- a/src/applauncher/005-speed-dial.qml
+++ b/src/applauncher/005-speed-dial.qml
@@ -113,7 +113,7 @@ Item {
                 horizontalOffset: 0
                 verticalOffset: 0
                 radius: 8.0
-                samples: 17
+                samples: 9
                 color: "#80000000"
                 source: circleWrapper
                 cached: true


### PR DESCRIPTION
Three independent changes to the speed dial launcher, each cutting work done per frame while the wheel is spinning.

- **Cache off-path delegates** — `cacheItemCount` keeps every delegate alive, so a spin pays the delegate creation cost (DropShadow render + icon load) only once instead of churning through it while the wheel decelerates.
- **Lower the delegate DropShadow to 9 samples** — the blur radius is small enough that 17 samples only buys a barely-perceptible softness change.
- **Snap delegate colours while the wheel is moving** — the selection sweeps the whole list as the wheel coasts, firing the circle and icon colour animations on every step. Each step re-rasterizes the delegate, repaints the Icon pixmap and invalidates the cached DropShadow. The animation now runs only at rest, where it is visible as press feedback.

Together these remove the 40-146ms frame spikes seen while coasting through the app list (measured with QSG_RENDER_TIMING on minnow)